### PR TITLE
ci: check format and run credo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
         if: steps.output-cache.outputs.cache-hit != 'true'
         run: make compile-native
 
-  build:
-    name: Build
+  dialyzer:
+    name: Dialyzer
     needs: compile-native
     runs-on: ubuntu-latest
     steps:
@@ -111,6 +111,39 @@ jobs:
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
         restore-keys: ${{ runner.os }}-mix-
     - name: Install dependencies
-      run: mix deps.get 
+      run: mix deps.get
     - name: Run tests
       run: mix test
+
+  lint:
+    name: Format & Credo
+    needs: compile-native
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Elixir
+      uses: erlef/setup-beam@v1
+      with:
+        version-type: strict
+        version-file: .tool-versions
+      env:
+        ImageOS: ubuntu20
+    - name: Fetch native libraries
+      id: output-cache
+      uses: actions/cache/restore@v3
+      with:
+        path: priv/native/*.so
+        key: ${{ runner.os }}-native-${{ hashFiles('native/**') }}
+        fail-on-cache-miss: true
+    - name: Restore dependencies cache
+      uses: actions/cache@v3
+      with:
+        path: deps
+        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-mix-
+    - name: Install dependencies
+      run: mix deps.get
+    - name: Check format
+      run: mix format --check-formatted
+    - name: Run credo
+      run: mix credo --strict

--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,7 @@ deps:
 # Run tests
 test: compile-native
 	mix test
+
+lint: compile-native
+	mix format --check-formatted
+	mix credo --strict

--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,7 @@ defmodule LambdaEthereumConsensus.MixProject do
       dialyzer: dialyzer(),
       preferred_cli_env: [
         dialyzer: :test
-      ],
+      ]
     ]
   end
 
@@ -27,6 +27,7 @@ defmodule LambdaEthereumConsensus.MixProject do
   defp deps do
     [
       {:dialyxir, "~> 1.1", only: [:dev, :test], runtime: false},
+      {:credo, "~> 1.7", only: [:dev, :test], runtime: false}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,8 @@
 %{
+  "bunt": {:hex, :bunt, "0.2.1", "e2d4792f7bc0ced7583ab54922808919518d0e57ee162901a16a1b6664ef3b14", [:mix], [], "hexpm", "a330bfb4245239787b15005e66ae6845c9cd524a288f0d141c148b02603777a5"},
+  "credo": {:hex, :credo, "1.7.0", "6119bee47272e85995598ee04f2ebbed3e947678dee048d10b5feca139435f75", [:mix], [{:bunt, "~> 0.2.1", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2.8", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "6839fcf63d1f0d1c0f450abc8564a57c43d644077ab96f2934563e68b8a769d7"},
   "dialyxir": {:hex, :dialyxir, "1.3.0", "fd1672f0922b7648ff9ce7b1b26fcf0ef56dda964a459892ad15f6b4410b5284", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "00b2a4bcd6aa8db9dcb0b38c1225b7277dca9bc370b6438715667071a304696f"},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
+  "file_system": {:hex, :file_system, "0.2.10", "fb082005a9cd1711c05b5248710f8826b02d7d1784e7c3451f9c1231d4fc162d", [:mix], [], "hexpm", "41195edbfb562a593726eda3b3e8b103a309b733ad25f3d642ba49696bf715dc"},
+  "jason": {:hex, :jason, "1.4.1", "af1504e35f629ddcdd6addb3513c3853991f694921b1b9368b0bd32beb9f1b63", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "fbb01ecdfd565b56261302f7e1fcc27c4fb8f32d56eab74db621fc154604a7a1"},
 }

--- a/test/libp2p_test.exs
+++ b/test/libp2p_test.exs
@@ -111,7 +111,7 @@ defmodule Libp2pTest do
     :ok = Libp2p.host_close(host)
   end
 
-  def try_read_stream(host, iterator, protocol_id) do
+  defp connect_to_peers(host, iterator, protocol_id) do
     {:ok, peerstore} = Libp2p.host_peerstore(host)
 
     true = Libp2p.iterator_next(iterator)
@@ -124,19 +124,21 @@ defmodule Libp2pTest do
 
       :ok = Libp2p.peerstore_add_addrs(peerstore, id, addrs, Libp2p.ttl_permanent_addr())
 
-      case Libp2p.host_new_stream(host, id, protocol_id) do
-        {:ok, stream} ->
-          case Libp2p.stream_read(stream) do
-            {:ok, msg} -> IO.puts(["\"#{Base.encode16(msg)}\""])
-            _ -> :ok
-          end
-
-        _ ->
-          :ok
-      end
+      read_stream(Libp2p.host_new_stream(host, id, protocol_id))
     end
 
-    try_read_stream(host, iterator, protocol_id)
+    connect_to_peers(host, iterator, protocol_id)
+  end
+
+  defp read_stream({:ok, stream}) do
+    case Libp2p.stream_read(stream) do
+      {:ok, msg} -> IO.puts(["\"#{Base.encode16(msg)}\""])
+      _ -> :ok
+    end
+  end
+
+  defp read_stream(_) do
+    :ok
   end
 
   @tag :skip
@@ -154,7 +156,7 @@ defmodule Libp2pTest do
 
     {:ok, iterator} = Libp2p.listener_random_nodes(listener)
 
-    try_read_stream(host, iterator, protocol_id)
+    connect_to_peers(host, iterator, protocol_id)
 
     :ok = Libp2p.host_close(host)
   end


### PR DESCRIPTION
Closes #9 #11

This PR adds credo to the Makefile and CI (+ a `mix format` check), and fixes a warning.