### PR TITLE
ci: add Rust caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,13 +52,6 @@ jobs:
       with:
         version-type: strict
         version-file: .tool-versions
-    - name: Fetch native libraries
-      id: output-cache
-      uses: actions/cache/restore@v3
-      with:
-        path: priv/native/*.so
-        key: ${{ runner.os }}-native-${{ hashFiles('native/**') }}
-        fail-on-cache-miss: true
     - name: Restore dependencies cache
       uses: actions/cache@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,6 @@ jobs:
 
   build:
     name: Build project
-    needs: compile-native
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 env:
   MIX_ENV: test
   RUST_WORKSPACES: |
-    "native/* -> target"
+    native/** -> target
     
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
 
   build:
     name: Build project
+    needs: compile-native
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
@@ -53,6 +54,13 @@ jobs:
       with:
         version-type: strict
         version-file: .tool-versions
+    - name: Fetch native libraries
+      id: output-cache
+      uses: actions/cache/restore@v3
+      with:
+        path: priv/native/*.so
+        key: ${{ runner.os }}-native-${{ hashFiles('native/**') }}
+        fail-on-cache-miss: true
     - name: Restore dependencies cache
       uses: actions/cache@v3
       with:
@@ -64,7 +72,6 @@ jobs:
     - name: Set up cargo cache
       uses: Swatinem/rust-cache@v2
       with:
-        shared-key: "rust-cache"
         workspaces: ${{ env.RUST_WORKSPACES }}
     - name: Retrieve PLT Cache
       uses: actions/cache@v1
@@ -82,7 +89,7 @@ jobs:
 
   test:
     name: Test
-    needs: [compile-native, build]
+    needs: compile-native
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
@@ -107,9 +114,7 @@ jobs:
     - name: Set up cargo cache
       uses: Swatinem/rust-cache@v2
       with:
-        shared-key: "rust-cache"
         workspaces: ${{ env.RUST_WORKSPACES }}
-        save-if: "false"
     - name: Install dependencies
       run: mix deps.get
     - name: Run tests
@@ -156,7 +161,7 @@ jobs:
 
   spectests:
     name: Run spec-tests
-    needs: [compile-native, download-spectests, build]
+    needs: [compile-native, download-spectests]
     strategy:
       matrix:
         config: ["minimal"] #[ "general", "mainnet", "minimal" ]
@@ -189,9 +194,7 @@ jobs:
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "rust-cache"
           workspaces: ${{ env.RUST_WORKSPACES }}
-          save-if: "false"
       - name: Install dependencies
         run: mix deps.get
       - name: Uncompress vectors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ on:
 env:
   MIX_ENV: test
   RUST_WORKSPACES: |
-    native/** -> target
+    native/snappy -> target
+    native/ssz_nif -> target
     
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           version-type: strict
           version-file: .tool-versions
         env:
-          ImageOS: ubuntu22
+          ImageOS: ubuntu20
       - name: Set up Go
         # NOTE: this action comes with caching by default
         uses: actions/setup-go@v4
@@ -55,7 +55,7 @@ jobs:
         version-type: strict
         version-file: .tool-versions
       env:
-        ImageOS: ubuntu22
+        ImageOS: ubuntu20
     - name: Fetch native libraries
       id: output-cache
       uses: actions/cache/restore@v3
@@ -102,7 +102,7 @@ jobs:
         version-type: strict
         version-file: .tool-versions
       env:
-        ImageOS: ubuntu22
+        ImageOS: ubuntu20
     - name: Fetch native libraries
       id: output-cache
       uses: actions/cache/restore@v3
@@ -138,7 +138,7 @@ jobs:
         version-type: strict
         version-file: .tool-versions
       env:
-        ImageOS: ubuntu22
+        ImageOS: ubuntu20
     - name: Restore dependencies cache
       uses: actions/cache@v3
       with:
@@ -183,7 +183,7 @@ jobs:
           version-type: strict
           version-file: .tool-versions
         env:
-          ImageOS: ubuntu22
+          ImageOS: ubuntu20
       - name: Fetch native libraries
         uses: actions/cache/restore@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   compile-native:
     name: Build native libraries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Set up Elixir
@@ -25,7 +25,7 @@ jobs:
           version-type: strict
           version-file: .tool-versions
         env:
-          ImageOS: ubuntu20
+          ImageOS: ubuntu22
       - name: Set up Go
         # NOTE: this action comes with caching by default
         uses: actions/setup-go@v4
@@ -45,7 +45,7 @@ jobs:
   build:
     name: Build project
     needs: compile-native
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Elixir
@@ -54,7 +54,7 @@ jobs:
         version-type: strict
         version-file: .tool-versions
       env:
-        ImageOS: ubuntu20
+        ImageOS: ubuntu22
     - name: Fetch native libraries
       id: output-cache
       uses: actions/cache/restore@v3
@@ -87,7 +87,7 @@ jobs:
   test:
     name: Test
     needs: compile-native
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Elixir
@@ -96,7 +96,7 @@ jobs:
         version-type: strict
         version-file: .tool-versions
       env:
-        ImageOS: ubuntu20
+        ImageOS: ubuntu22
     - name: Fetch native libraries
       id: output-cache
       uses: actions/cache/restore@v3
@@ -117,7 +117,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Elixir
@@ -126,7 +126,7 @@ jobs:
         version-type: strict
         version-file: .tool-versions
       env:
-        ImageOS: ubuntu20
+        ImageOS: ubuntu22
     - name: Restore dependencies cache
       uses: actions/cache@v3
       with:
@@ -142,7 +142,7 @@ jobs:
 
   download-spectests:
     name: Download spectests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Cache compressed spectests
@@ -162,7 +162,7 @@ jobs:
     strategy:
       matrix:
         config: ["minimal"] #[ "general", "mainnet", "minimal" ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Set up Elixir
@@ -171,7 +171,7 @@ jobs:
           version-type: strict
           version-file: .tool-versions
         env:
-          ImageOS: ubuntu20
+          ImageOS: ubuntu22
       - name: Fetch native libraries
         uses: actions/cache/restore@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 env:
   MIX_ENV: test
   RUST_WORKSPACES: |
-    "native/* -> native/**/target"
+    "native/* -> target"
     
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,6 @@ jobs:
         with:
           version-type: strict
           version-file: .tool-versions
-        env:
-          ImageOS: ubuntu20
       - name: Set up Go
         # NOTE: this action comes with caching by default
         uses: actions/setup-go@v4
@@ -54,8 +52,6 @@ jobs:
       with:
         version-type: strict
         version-file: .tool-versions
-      env:
-        ImageOS: ubuntu20
     - name: Fetch native libraries
       id: output-cache
       uses: actions/cache/restore@v3
@@ -101,8 +97,6 @@ jobs:
       with:
         version-type: strict
         version-file: .tool-versions
-      env:
-        ImageOS: ubuntu20
     - name: Fetch native libraries
       id: output-cache
       uses: actions/cache/restore@v3
@@ -137,8 +131,6 @@ jobs:
       with:
         version-type: strict
         version-file: .tool-versions
-      env:
-        ImageOS: ubuntu20
     - name: Restore dependencies cache
       uses: actions/cache@v3
       with:
@@ -182,8 +174,6 @@ jobs:
         with:
           version-type: strict
           version-file: .tool-versions
-        env:
-          ImageOS: ubuntu20
       - name: Fetch native libraries
         uses: actions/cache/restore@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 
 env:
   MIX_ENV: test
+  RUST_WORKSPACES: |
+    "native/* -> native/**/target"
     
 permissions:
   contents: read
@@ -69,6 +71,11 @@ jobs:
         restore-keys: ${{ runner.os }}-mix-
     - name: Install dependencies
       run: mix deps.get
+    - name: Set up cargo cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: "rust-cache"
+        workspaces: ${{ env.RUST_WORKSPACES }}
     - name: Retrieve PLT Cache
       uses: actions/cache@v1
       id: plt-cache
@@ -85,7 +92,7 @@ jobs:
 
   test:
     name: Test
-    needs: compile-native
+    needs: [compile-native, build]
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
@@ -109,6 +116,12 @@ jobs:
         path: deps
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
         restore-keys: ${{ runner.os }}-mix-
+    - name: Set up cargo cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: "rust-cache"
+        workspaces: ${{ env.RUST_WORKSPACES }}
+        save-if: "false"
     - name: Install dependencies
       run: mix deps.get
     - name: Run tests
@@ -157,7 +170,7 @@ jobs:
 
   spectests:
     name: Run spec-tests
-    needs: [compile-native, download-spectests]
+    needs: [compile-native, download-spectests, build]
     strategy:
       matrix:
         config: ["minimal"] #[ "general", "mainnet", "minimal" ]
@@ -189,6 +202,12 @@ jobs:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-
+      - name: Set up cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-cache"
+          workspaces: ${{ env.RUST_WORKSPACES }}
+          save-if: "false"
       - name: Install dependencies
         run: mix deps.get
       - name: Uncompress vectors


### PR DESCRIPTION
Adds Rust caches to corresponding jobs, cleans up some unneeded env vars passed to actions, and pins the ubuntu version to latest.