### PR TITLE
docs(readme): add instructions for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,29 @@
 # lambda_ethereum_consensus
 
 ## Prerequisites
-- [asdf](https://github.com/asdf-vm/asdf), see `.tool-versions` for the required versions.
+### Direct
+Install directly through offocial mirrors
+- [elixir](https://elixir-lang.org/install.html)
+- [erlang](https://www.erlang.org/downloads)
+- [golang](https://go.dev/doc/install)
+
+### Alternative (recommended)
+Use tool version manager **asdf** to follow this repo's exact versions located in `.tool-versions`
+- [tool manager asdf](https://github.com/asdf-vm/asdf)
+
+After installing **asdf**, add the necessary plugins to handle the tools.
+```shell
+asdf plugin add elixir
+asdf plugin add erlang
+asdf plugin add golang
+```
+Finally, install the tools' version on `.tool-version`.
+```shell
+asdf install
+```
+
+
+
 ## Installing and running
 
 There are Makefile targets for these tasks.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can install the necessary components directly from official sources:
 
 ### Alternative (Recommended) Installation
 For precise control over versions, it's recommended to use the **asdf** tool version manager and follow the versions specified in `.tool-versions` in this repository.
-- [asdf tool version manager](https://github.com/asdf-vm/asdf)
+- [asdf tool version manager](https://asdf-vm.com/guide/getting-started.html)
 
 After installing **asdf**, add the required plugins for managing the tools:
 ```shell

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Lambda Ethereum Consensus
+# Lambda_Ethereum_Consensus
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,27 @@
-# lambda_ethereum_consensus
+# Lambda Ethereum Consensus
 
 ## Prerequisites
-### Direct
-Install directly through offocial mirrors
-- [elixir](https://elixir-lang.org/install.html)
-- [erlang](https://www.erlang.org/downloads)
-- [golang](https://go.dev/doc/install)
 
-### Alternative (recommended)
-Use tool version manager **asdf** to follow this repo's exact versions located in `.tool-versions`
-- [tool manager asdf](https://github.com/asdf-vm/asdf)
+### Direct Installation
+You can install the necessary components directly from official sources:
+- [Elixir](https://elixir-lang.org/install.html)
+- [Erlang](https://www.erlang.org/downloads)
+- [Go](https://go.dev/doc/install)
 
-After installing **asdf**, add the necessary plugins to handle the tools.
+### Alternative (Recommended) Installation
+For precise control over versions, it's recommended to use the **asdf** tool version manager and follow the versions specified in `.tool-versions` in this repository.
+- [asdf tool version manager](https://github.com/asdf-vm/asdf)
+
+After installing **asdf**, add the required plugins for managing the tools:
 ```shell
 asdf plugin add elixir
 asdf plugin add erlang
 asdf plugin add golang
 ```
-Finally, install the tools' version on `.tool-version`.
+Finally, install the specific versions of these tools as specified in `.tool-versions`:
 ```shell
 asdf install
 ```
-
-
 
 ## Installing and running
 


### PR DESCRIPTION
**Motivation**

This pull request addresses issue #38 

**Description**

Added instructions for installing Go, Erlang and Elixir directly from official mirrors and through the asdf tool version manager.


Closes #38 

