### PR TITLE
chore: add `make fmt` target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,9 @@ jobs:
     - name: Install dependencies
       run: mix deps.get
     - name: Check format
-      run: mix format --check-formatted
+      run: |
+        make fmt
+        git diff --exit-code
     - name: Run credo
       run: mix credo --strict
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: iex deps test clean compile-native format \
+.PHONY: iex deps test clean compile-native fmt \
 		clean-vectors download-vectors uncompress-vectors
 
 # Delete current file when command fails

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,6 @@ lint:
 
 fmt:
 	mix format
-	cd native/libp2p_nif; go fmt
+	cd native/libp2p_nif; gofmt -l -w .
 	cd native/snappy_nif; cargo fmt
 	cd native/ssz_nif; cargo fmt

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ lint:
 	mix format --check-formatted
 	mix credo --strict
 
-format:
+fmt:
 	mix format
 	cd native/libp2p_nif; go fmt
 	cd native/snappy_nif; cargo fmt

--- a/Makefile
+++ b/Makefile
@@ -89,3 +89,6 @@ lint:
 
 format:
 	mix format
+	cd native/libp2p_nif; go fmt
+	cd native/snappy_nif; cargo fmt
+	cd native/ssz_nif; cargo fmt

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: iex deps test clean compile-native \
+.PHONY: iex deps test clean compile-native format \
 		clean-vectors download-vectors uncompress-vectors
 
 # Delete current file when command fails
@@ -86,3 +86,6 @@ spec-test: compile-native tests/minimal #$(SPECTEST_DIRS)
 lint:
 	mix format --check-formatted
 	mix credo --strict
+
+format:
+	mix format

--- a/native/ssz_nif/src/types/beacon_chain.rs
+++ b/native/ssz_nif/src/types/beacon_chain.rs
@@ -135,6 +135,6 @@ gen_struct!(
     /// Corresponds to [`lighthouse_types::Deposit`]
     pub(crate) struct Deposit<'a> {
         proof: Vec<Binary<'a>>,
-        data: DepositData<'a>
+        data: DepositData<'a>,
     }
 );

--- a/native/ssz_nif/src/types/beacon_chain.rs
+++ b/native/ssz_nif/src/types/beacon_chain.rs
@@ -135,6 +135,6 @@ gen_struct!(
     /// Corresponds to [`lighthouse_types::Deposit`]
     pub(crate) struct Deposit<'a> {
         proof: Vec<Binary<'a>>,
-        data: DepositData<'a>,
+        data: DepositData<'a>
     }
 );


### PR DESCRIPTION
Closes #93

This PR adds a target that formats the project's code and CI checks to enforce its usage.