### PR TITLE
chore: remove legacy Lighthouse references from ssz implementation.

### DIFF
--- a/native/ssz_nif/Cargo.lock
+++ b/native/ssz_nif/Cargo.lock
@@ -682,7 +682,6 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 name = "ssz_nif"
 version = "0.1.0"
 dependencies = [
- "ethereum-types",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "rustler",

--- a/native/ssz_nif/Cargo.toml
+++ b/native/ssz_nif/Cargo.toml
@@ -13,5 +13,4 @@ crate-type = ["cdylib"]
 rustler = "0.29.1"
 ethereum_ssz_derive = "0.5.0"
 ethereum_ssz = "0.5.0"
-ethereum-types = "0.14.1"
 ssz_types = "0.5.4"

--- a/native/ssz_nif/README.md
+++ b/native/ssz_nif/README.md
@@ -12,7 +12,7 @@ Rust side (`native/ssz_nif`):
 2. Add the struct definition to the corresponding module under `native/ssz_nif/src/ssz_types` (e.g. `beacon_chain.rs` for containers defined in `beacon-chain.md`) with `#[derive(Encode, Decode)]`.
 3. Do the same under `native/ssz_nif/src/elx_types`, but surrounding it with the `gen_struct` macro, and adding `#[derive(NifStruct)]` and `#[module …]` attributes (you can look at `beacon_chain.rs` for examples).
 4. Translate the types used (`Epoch`, `Slot`, etc.) to ones that implement *rustler* traits (you can look at [this cheat sheet](https://rustler-web.onrender.com/docs/cheat-sheet), or at the already implemented containers).
-5. If it fails because `FromElx` or `FromLH` are not implemented for types X and Y, add those implementations in `utils/from_elx.rs` and `utils/from_lh.rs` respectively.
+5. If it fails because `FromElx` or `FromSsz` are not implemented for types X and Y, add those implementations in `utils/from_elx.rs` and `utils/from_ssz.rs` respectively.
 6. Add the type name to the list in `to_ssz` and `from_ssz`.
 7. Check that it compiles correctly.
 

--- a/native/ssz_nif/src/elx_types/mod.rs
+++ b/native/ssz_nif/src/elx_types/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! To add a new type, add the struct definition (with [`rustler`] types)
 //! in the corresponding module. You may need to add some [`FromElx`] and
-//! [`FromLH`] implementations to convert between the types.
+//! [`FromSsz`] implementations to convert between the types.
 
 mod beacon_chain;
 pub(crate) use beacon_chain::*;

--- a/native/ssz_nif/src/lib.rs
+++ b/native/ssz_nif/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! To add a new type:
 //!  - Add the type to the [`types`] module, using the [`gen_struct`] macro
-//!  - Implement the necessary traits ([`FromElx`] and [`FromLH`]) for its attributes
+//!  - Implement the necessary traits ([`FromElx`] and [`FromSsz`]) for its attributes
 //!  - Add the type to [`to_ssz`] and [`from_ssz`] "match" macros
 
 pub(crate) mod elx_types;

--- a/native/ssz_nif/src/utils/from_elx.rs
+++ b/native/ssz_nif/src/utils/from_elx.rs
@@ -1,4 +1,3 @@
-use ethereum_types::H256;
 use rustler::Binary;
 use ssz::Decode;
 use ssz_types::{typenum::Unsigned, BitList, BitVector, FixedVector};
@@ -26,12 +25,6 @@ trivial_impl!(u64);
 impl<'a, const N: usize> FromElx<Binary<'a>> for [u8; N] {
     fn from(value: Binary<'a>) -> Self {
         value.as_slice().try_into().unwrap()
-    }
-}
-
-impl<'a> FromElx<Binary<'a>> for H256 {
-    fn from(value: Binary) -> Self {
-        H256::from_slice(value.as_slice())
     }
 }
 

--- a/native/ssz_nif/src/utils/from_ssz.rs
+++ b/native/ssz_nif/src/utils/from_ssz.rs
@@ -3,13 +3,13 @@ use rustler::Binary;
 use ssz::Encode;
 use ssz_types::{typenum::Unsigned, BitList, BitVector, FixedVector};
 
-pub(crate) trait FromLH<'a, T> {
+pub(crate) trait FromSsz<'a, T> {
     fn from(value: T, env: rustler::Env<'a>) -> Self;
 }
 
 macro_rules! trivial_impl {
     ($t:ty) => {
-        impl<'a> FromLH<'a, $t> for $t {
+        impl<'a> FromSsz<'a, $t> for $t {
             fn from(value: $t, _env: rustler::Env<'a>) -> Self {
                 value
             }
@@ -23,48 +23,48 @@ trivial_impl!(u16);
 trivial_impl!(u32);
 trivial_impl!(u64);
 
-impl<'a, const N: usize> FromLH<'a, [u8; N]> for Binary<'a> {
+impl<'a, const N: usize> FromSsz<'a, [u8; N]> for Binary<'a> {
     fn from(value: [u8; N], env: rustler::Env<'a>) -> Self {
         bytes_to_binary(env, &value)
     }
 }
 
-impl<'a, N: Unsigned> FromLH<'a, FixedVector<u8, N>> for Binary<'a> {
+impl<'a, N: Unsigned> FromSsz<'a, FixedVector<u8, N>> for Binary<'a> {
     fn from(value: FixedVector<u8, N>, env: rustler::Env<'a>) -> Self {
         bytes_to_binary(env, &value)
     }
 }
 
-impl<'a, Ssz, Elx, N> FromLH<'a, FixedVector<Ssz, N>> for Vec<Elx>
+impl<'a, Ssz, Elx, N> FromSsz<'a, FixedVector<Ssz, N>> for Vec<Elx>
 where
-    Elx: FromLH<'a, Ssz>,
+    Elx: FromSsz<'a, Ssz>,
     N: Unsigned,
 {
     fn from(value: FixedVector<Ssz, N>, env: rustler::Env<'a>) -> Self {
         let as_vec: Vec<_> = value.into();
         as_vec
             .into_iter()
-            .map(|v: Ssz| FromLH::from(v, env))
+            .map(|v: Ssz| FromSsz::from(v, env))
             .collect()
     }
 }
 
-impl<'a, Ssz, Elx> FromLH<'a, Vec<Ssz>> for Vec<Elx>
+impl<'a, Ssz, Elx> FromSsz<'a, Vec<Ssz>> for Vec<Elx>
 where
-    Elx: FromLH<'a, Ssz>,
+    Elx: FromSsz<'a, Ssz>,
 {
     fn from(value: Vec<Ssz>, env: rustler::Env<'a>) -> Self {
-        value.into_iter().map(|v| FromLH::from(v, env)).collect()
+        value.into_iter().map(|v| FromSsz::from(v, env)).collect()
     }
 }
 
-impl<'a, N: Unsigned> FromLH<'a, BitVector<N>> for Binary<'a> {
+impl<'a, N: Unsigned> FromSsz<'a, BitVector<N>> for Binary<'a> {
     fn from(value: BitVector<N>, env: rustler::Env<'a>) -> Self {
         bytes_to_binary(env, &value.as_ssz_bytes())
     }
 }
 
-impl<'a, N: Unsigned> FromLH<'a, BitList<N>> for Binary<'a> {
+impl<'a, N: Unsigned> FromSsz<'a, BitList<N>> for Binary<'a> {
     fn from(value: BitList<N>, env: rustler::Env<'a>) -> Self {
         bytes_to_binary(env, &value.as_ssz_bytes())
     }

--- a/native/ssz_nif/src/utils/helpers.rs
+++ b/native/ssz_nif/src/utils/helpers.rs
@@ -1,4 +1,4 @@
-use crate::utils::from_lh::FromLH;
+use crate::utils::from_ssz::FromSsz;
 use rustler::{Binary, Decoder, Encoder, Env, NewBinary, NifResult, Term};
 use ssz::{Decode, Encode};
 use std::io::Write;
@@ -12,22 +12,22 @@ pub(crate) fn bytes_to_binary<'env>(env: Env<'env>, bytes: &[u8]) -> Binary<'env
     binary.into()
 }
 
-pub(crate) fn encode_ssz<'a, Elx, Lh>(value: Term<'a>) -> NifResult<Vec<u8>>
+pub(crate) fn encode_ssz<'a, Elx, Ssz>(value: Term<'a>) -> NifResult<Vec<u8>>
 where
     Elx: Decoder<'a>,
-    Lh: Encode + FromElx<Elx>,
+    Ssz: Encode + FromElx<Elx>,
 {
     let value_nif = <Elx as Decoder>::decode(value)?;
-    let value_ssz = Lh::from(value_nif);
+    let value_ssz = Ssz::from(value_nif);
     Ok(value_ssz.as_ssz_bytes())
 }
 
-pub(crate) fn decode_ssz<'a, Elx, Lh>(bytes: &[u8], env: Env<'a>) -> Result<Term<'a>, String>
+pub(crate) fn decode_ssz<'a, Elx, Ssz>(bytes: &[u8], env: Env<'a>) -> Result<Term<'a>, String>
 where
-    Elx: Encoder + FromLH<'a, Lh>,
-    Lh: Decode,
+    Elx: Encoder + FromSsz<'a, Ssz>,
+    Ssz: Decode,
 {
-    let recovered_value = Lh::from_ssz_bytes(bytes).map_err(|e| format!("{e:?}"))?;
+    let recovered_value = Ssz::from_ssz_bytes(bytes).map_err(|e| format!("{e:?}"))?;
     let checkpoint = Elx::from(recovered_value, env);
     Ok(checkpoint.encode(env))
 }

--- a/native/ssz_nif/src/utils/mod.rs
+++ b/native/ssz_nif/src/utils/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod from_elx;
-pub(crate) mod from_lh;
+pub(crate) mod from_ssz;
 pub(crate) mod helpers;
 
 macro_rules! match_schema_and_encode {
@@ -46,10 +46,10 @@ macro_rules! gen_struct {
                 $field_vis $field_name : $field_ty
             ),*
         }
-        impl<'a> $crate::utils::from_lh::FromLH<'a, $crate::ssz_types::$name> for $name$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? {
-            fn from(lh: $crate::ssz_types::$name, env: ::rustler::Env<'a>) -> Self {
+        impl<'a> $crate::utils::from_ssz::FromSsz<'a, $crate::ssz_types::$name> for $name$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? {
+            fn from(ssz: $crate::ssz_types::$name, env: ::rustler::Env<'a>) -> Self {
                 $(
-                    let $field_name = $crate::utils::from_lh::FromLH::from(lh.$field_name, env);
+                    let $field_name = $crate::utils::from_ssz::FromSsz::from(ssz.$field_name, env);
                 )*
                 Self {
                     $($field_name),*


### PR DESCRIPTION
**Description**

We're not using lighthouse types anymore since https://github.com/lambdaclass/lambda_ethereum_consensus/pull/97 , let's drop the LH references


