### PR TITLE
feat: add error handling to `FromElx` trait

### DIFF
--- a/native/ssz_nif/src/utils/helpers.rs
+++ b/native/ssz_nif/src/utils/helpers.rs
@@ -3,7 +3,7 @@ use rustler::{Binary, Decoder, Encoder, Env, NewBinary, NifResult, Term};
 use ssz::{Decode, Encode};
 use std::io::Write;
 
-use super::from_elx::FromElx;
+use super::from_elx::{FromElx, FromElxError};
 
 pub(crate) fn bytes_to_binary<'env>(env: Env<'env>, bytes: &[u8]) -> Binary<'env> {
     let mut binary = NewBinary::new(env, bytes.len());
@@ -18,8 +18,12 @@ where
     Ssz: Encode + FromElx<Elx>,
 {
     let value_nif = <Elx as Decoder>::decode(value)?;
-    let value_ssz = Ssz::from(value_nif);
+    let value_ssz = Ssz::from(value_nif).map_err(to_nif_result)?;
     Ok(value_ssz.as_ssz_bytes())
+}
+
+fn to_nif_result(result: FromElxError) -> rustler::Error {
+    rustler::Error::Term(Box::new(result.to_string()))
 }
 
 pub(crate) fn decode_ssz<'a, Elx, Ssz>(bytes: &[u8], env: Env<'a>) -> Result<Term<'a>, String>

--- a/native/ssz_nif/src/utils/mod.rs
+++ b/native/ssz_nif/src/utils/mod.rs
@@ -58,13 +58,13 @@ macro_rules! gen_struct {
         }
 
         impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::utils::from_elx::FromElx<$name$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)?> for $crate::ssz_types::$name {
-            fn from(elx: $name) -> Self {
+            fn from(elx: $name) -> Result<Self, $crate::utils::from_elx::FromElxError> {
                 $(
-                    let $field_name = $crate::utils::from_elx::FromElx::from(elx.$field_name);
+                    let $field_name = $crate::utils::from_elx::FromElx::from(elx.$field_name)?;
                 )*
-                Self {
+                Ok(Self {
                     $($field_name),*
-                }
+                })
             }
         }
     }


### PR DESCRIPTION
Closes #101

This PR makes the `FromElx` trait return a `Result<Self, FromElxError>`. The `FromElxError` simply wraps a `String`, but should make it easier to refactor gradually in the future.