### PR TITLE
build: ignore running ci when changing only markdown files.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches: [ '*' ]
+    paths-ignore:
+      - '**/*.md'
 
 env:
   MIX_ENV: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   push:
     branches: [ main ]
-    paths-ignore:
-      - '**/*.md'
   pull_request:
     branches: [ '*' ]
     paths-ignore:


### PR DESCRIPTION
**Motivation**
We don't want to waste resources and time by running the CI when only .md files change
