### PR TITLE
refactor: move special encoding/decoding rules to the types themselves.

### DIFF
--- a/lib/ssz.ex
+++ b/lib/ssz.ex
@@ -31,15 +31,13 @@ defmodule Ssz do
 
   # Ssz types can have special decoding rules defined in their optional encode/1 function,
   defp encode(%name{} = struct) do
-    case function_exported?(name, :encode, 1) do
-      true ->
-        name.encode(struct)
-
-      false ->
-        struct
-        |> Map.from_struct()
-        |> Enum.map(fn {k, v} -> {k, encode(v)} end)
-        |> then(&struct!(name, &1))
+    if function_exported?(name, :encode, 1) do
+      name.encode(struct)
+    else
+      struct
+      |> Map.from_struct()
+      |> Enum.map(fn {k, v} -> {k, encode(v)} end)
+      |> then(&struct!(name, &1))
     end
   end
 
@@ -47,15 +45,13 @@ defmodule Ssz do
 
   # Ssz types can have special decoding rules defined in their optional decode/1 function,
   defp decode(%name{} = struct) do
-    case function_exported?(name, :decode, 1) do
-      true ->
-        name.decode(struct)
-
-      false ->
-        struct
-        |> Map.from_struct()
-        |> Enum.map(fn {k, v} -> {k, decode(v)} end)
-        |> then(&struct!(name, &1))
+    if function_exported?(name, :decode, 1) do
+      name.decode(struct)
+    else
+      struct
+      |> Map.from_struct()
+      |> Enum.map(fn {k, v} -> {k, decode(v)} end)
+      |> then(&struct!(name, &1))
     end
   end
 

--- a/lib/ssz.ex
+++ b/lib/ssz.ex
@@ -29,10 +29,7 @@ defmodule Ssz do
   ##### Utils
   defp error, do: :erlang.nif_error(:nif_not_loaded)
 
-  @doc """
-    For Ssz types that have special encoding rules defined in their optional encode/1 function,
-    call it recursively.
-  """
+  # Ssz types can have special decoding rules defined in their optional encode/1 function,
   defp encode(%name{} = struct) do
     case function_exported?(name, :encode, 1) do
       true ->
@@ -48,10 +45,7 @@ defmodule Ssz do
 
   defp encode(non_struct), do: non_struct
 
-  @doc """
-    For Ssz types that have special decoding rules defined in their optional decode/1 function,
-    call it recursively.
-  """
+  # Ssz types can have special decoding rules defined in their optional decode/1 function,
   defp decode(%name{} = struct) do
     case function_exported?(name, :decode, 1) do
       true ->

--- a/lib/ssz_types/execution_payload.ex
+++ b/lib/ssz_types/execution_payload.ex
@@ -42,4 +42,12 @@ defmodule SszTypes.ExecutionPayload do
           transactions: list(SszTypes.transaction()),
           withdrawals: list(SszTypes.Withdrawal.t())
         }
+
+  def decode(%__MODULE__{} = map) do
+    Map.update!(map, :base_fee_per_gas, &Ssz.decode_u256/1)
+  end
+
+  def encode(%__MODULE__{} = map) do
+    Map.update!(map, :base_fee_per_gas, &Ssz.encode_u256/1)
+  end
 end

--- a/lib/ssz_types/execution_payload_header.ex
+++ b/lib/ssz_types/execution_payload_header.ex
@@ -42,4 +42,12 @@ defmodule SszTypes.ExecutionPayloadHeader do
           transactions_root: SszTypes.root(),
           withdrawals_root: SszTypes.root()
         }
+
+  def encode(%__MODULE__{} = map) do
+    Map.update!(map, :base_fee_per_gas, &Ssz.encode_u256/1)
+  end
+
+  def decode(%__MODULE__{} = map) do
+    Map.update!(map, :base_fee_per_gas, &Ssz.decode_u256/1)
+  end
 end

--- a/test/spec/utils/generator.ex
+++ b/test/spec/utils/generator.ex
@@ -52,8 +52,11 @@ defmodule SpecTestGenerator do
         test_runner = Map.get(SpecTestGenerator.runner_map(), testcase.runner)
 
         @tag :spectest
-        @tag config: testcase.config, fork: testcase.fork
-        @tag runner: testcase.runner, suite: testcase.suite
+        @tag config: testcase.config,
+             fork: testcase.fork,
+             runner: testcase.runner,
+             handler: testcase.handler,
+             suite: testcase.suite
         if test_runner == nil do
           @tag :skip
           test test_name


### PR DESCRIPTION
**Motivation**
We want the custom rules to be as closer to the type definition so that we don't bloat the Ssz module. Addionally, if we have a type A with special encoding/decoding rules that is contained inside type B, we shouldn't have to define the rule for type B, it should work out of the box
