### PR TITLE
fix: ensure module is loaded before encoding/decoding

### DIFF
--- a/lib/ssz.ex
+++ b/lib/ssz.ex
@@ -84,9 +84,7 @@ defmodule Ssz do
 
   # Ssz types can have special decoding rules defined in their optional encode/1 function,
   defp encode(%name{} = struct) do
-    Code.ensure_loaded!(name)
-
-    if function_exported?(name, :encode, 1) do
+    if exported?(name, :encode, 1) do
       name.encode(struct)
     else
       struct
@@ -105,9 +103,7 @@ defmodule Ssz do
 
   # Ssz types can have special decoding rules defined in their optional decode/1 function,
   defp decode(%name{} = struct) do
-    Code.ensure_loaded!(name)
-
-    if function_exported?(name, :decode, 1) do
+    if exported?(name, :decode, 1) do
       name.decode(struct)
     else
       struct
@@ -119,6 +115,11 @@ defmodule Ssz do
 
   defp decode(list) when is_list(list), do: list |> Enum.map(&decode/1)
   defp decode(non_struct), do: non_struct
+
+  defp exported?(module, function, arity) do
+    Code.ensure_loaded!(name)
+    function_exported?(name, function, arity)
+  end
 
   @spec encode_u256(non_neg_integer) :: binary
   def encode_u256(num) do

--- a/lib/ssz.ex
+++ b/lib/ssz.ex
@@ -41,6 +41,8 @@ defmodule Ssz do
 
   # Ssz types can have special decoding rules defined in their optional encode/1 function,
   defp encode(%name{} = struct) do
+    Code.ensure_loaded!(name)
+
     if function_exported?(name, :encode, 1) do
       name.encode(struct)
     else
@@ -55,6 +57,8 @@ defmodule Ssz do
 
   # Ssz types can have special decoding rules defined in their optional decode/1 function,
   defp decode(%name{} = struct) do
+    Code.ensure_loaded!(name)
+
     if function_exported?(name, :decode, 1) do
       name.decode(struct)
     else

--- a/lib/ssz.ex
+++ b/lib/ssz.ex
@@ -117,8 +117,8 @@ defmodule Ssz do
   defp decode(non_struct), do: non_struct
 
   defp exported?(module, function, arity) do
-    Code.ensure_loaded!(name)
-    function_exported?(name, function, arity)
+    Code.ensure_loaded!(module)
+    function_exported?(module, function, arity)
   end
 
   @spec encode_u256(non_neg_integer) :: binary


### PR DESCRIPTION
Closes #217

From the `Kernel.function_exported?` documentation:

> Returns true if module **is loaded** and contains a public function with the given arity, otherwise false.

Since the module wasn't loaded at first, we weren't encoding U256s properly.