### PR TITLE
feat: request missing blocks only

### DIFF
--- a/lib/lambda_ethereum_consensus/p2p/block_downloader.ex
+++ b/lib/lambda_ethereum_consensus/p2p/block_downloader.ex
@@ -23,6 +23,9 @@ defmodule LambdaEthereumConsensus.P2P.BlockDownloader do
     blocks = request_blocks(host, demand)
     remaining = demand - length(blocks)
 
+    # Since request_blocks always returns the demanded amount,
+    # this can only happen if database is empty, or we don't
+    # have any blocks to request
     if remaining > 0 do
       Process.send_after(self(), :retry, 1000)
     end

--- a/lib/lambda_ethereum_consensus/p2p/block_downloader.ex
+++ b/lib/lambda_ethereum_consensus/p2p/block_downloader.ex
@@ -3,6 +3,7 @@ defmodule LambdaEthereumConsensus.P2P.BlockDownloader do
   This module requests blocks from peers.
   """
   alias LambdaEthereumConsensus.P2P
+  alias LambdaEthereumConsensus.Store.BlockStore
   use GenStage
   require Logger
 
@@ -13,29 +14,43 @@ defmodule LambdaEthereumConsensus.P2P.BlockDownloader do
 
   @impl true
   def init([host]) do
-    {:producer, host}
+    {:producer, {host, 0}}
   end
 
   @impl true
-  def handle_demand(incoming_demand, host) do
-    blocks =
-      for _ <- 0..incoming_demand do
-        request_block(host) |> wrap_message()
-      end
+  def handle_demand(incoming_demand, {host, remaining_demand}) do
+    demand = incoming_demand + remaining_demand
+    blocks = request_blocks(host, demand)
+    remaining = demand - length(blocks)
 
-    {:noreply, blocks, host}
+    if remaining > 0 do
+      Process.send_after(self(), :retry, 1000)
+    end
+
+    {:noreply, blocks, {host, remaining}}
   end
 
-  defp request_block(host) do
-    # TODO: get missing slots from DB
-    start_slot = 7_270_097 + :rand.uniform(100_000)
+  @impl true
+  def handle_info(:retry, {host, 0}), do: {:noreply, [], {host, 0}}
 
+  @impl true
+  def handle_info(:retry, {host, demand}), do: handle_demand(0, {host, demand})
+
+  defp request_blocks(host, demand) do
+    BlockStore.stream_missing_blocks_desc()
+    |> Stream.take(demand)
+    |> Stream.map(&request_block(host, &1))
+    |> Stream.map(&wrap_message/1)
+    |> Enum.to_list()
+  end
+
+  defp request_block(host, slot) do
     # TODO: handle no-peers asynchronously?
     peer_id = get_some_peer()
 
     payload =
       %SszTypes.BeaconBlocksByRangeRequest{
-        start_slot: start_slot,
+        start_slot: slot,
         # TODO: we need to refactor the Snappy library to return
         # the remaining buffer when decompressing
         count: 1
@@ -62,7 +77,7 @@ defmodule LambdaEthereumConsensus.P2P.BlockDownloader do
       # we just ignore the error and continue
       {:error, reason} ->
         Logger.debug("error requesting block: #{reason}")
-        request_block(host)
+        request_block(host, slot)
     end
   end
 

--- a/lib/lambda_ethereum_consensus/store/block_store.ex
+++ b/lib/lambda_ethereum_consensus/store/block_store.ex
@@ -6,7 +6,7 @@ defmodule LambdaEthereumConsensus.Store.BlockStore do
   alias LambdaEthereumConsensus.Store.Utils
 
   @block_prefix "block"
-  @slot_prefix "slot"
+  @blockslot_prefix @block_prefix <> "slot"
 
   @spec store_block(SszTypes.BeaconBlock.t()) :: :ok
   def store_block(%SszTypes.BeaconBlock{} = block) do
@@ -50,22 +50,41 @@ defmodule LambdaEthereumConsensus.Store.BlockStore do
 
   def stream_missing_blocks_desc do
     Stream.resource(&init_cursor/0, &prev_slot/1, &close_cursor/1)
+    # TODO: we should remove this when we have a genesis block
+    |> Stream.concat([-1])
+    |> Stream.transform(nil, &get_missing/2)
   end
 
   defp init_cursor do
-    max_key = Utils.get_key(@block_prefix, 0xFFFFFFFFFFFFFFFF)
-    {:ok, it} = Db.iterate_keys()
-    {:ok, _} = Exleveldb.iterator_move(it, max_key)
-    it
+    max_key = block_root_by_slot_key(0xFFFFFFFFFFFFFFFF)
+
+    with {:ok, it} <- Db.iterate_keys(),
+         {:ok, _} <- Exleveldb.iterator_move(it, max_key) do
+      it
+    else
+      # We'll just try again later
+      {:error, :invalid_iterator} -> nil
+    end
   end
+
+  defp prev_slot(nil), do: {:halt, nil}
 
   defp prev_slot(it) do
-    {:ok, prev_key} = Exleveldb.iterator_move(it, :prev)
-    {[prev_key], it}
+    {:ok, prev_key} =
+      Exleveldb.iterator_move(it, :prev)
+
+    case prev_key do
+      @blockslot_prefix <> <<key::64>> -> {[key], it}
+      _ -> {:halt, it}
+    end
   end
 
+  defp close_cursor(nil), do: :ok
   defp close_cursor(it), do: :ok = Exleveldb.iterator_close(it)
 
+  def get_missing(slot, nil), do: {[], slot}
+  def get_missing(slot, prev), do: {(prev - 1)..(slot + 1)//-1, slot}
+
   defp block_key(root), do: Utils.get_key(@block_prefix, root)
-  defp block_root_by_slot_key(slot), do: Utils.get_key(@block_prefix <> @slot_prefix, slot)
+  defp block_root_by_slot_key(slot), do: Utils.get_key(@blockslot_prefix, slot)
 end

--- a/lib/lambda_ethereum_consensus/store/db.ex
+++ b/lib/lambda_ethereum_consensus/store/db.ex
@@ -14,13 +14,14 @@ defmodule LambdaEthereumConsensus.Store.Db do
 
   @spec put(binary, binary) :: :ok
   def put(key, value) do
-    GenServer.call(@registered_name, {:put, {key, value}})
-    :ok
+    ref = GenServer.call(@registered_name, :get_ref)
+    Exleveldb.put(ref, key, value)
   end
 
-  @spec get(binary) :: :not_found | {:error, binary} | {:ok, binary}
+  @spec get(binary) :: {:ok, binary} | :not_found
   def get(key) do
-    GenServer.call(@registered_name, {:get, key})
+    ref = GenServer.call(@registered_name, :get_ref)
+    Exleveldb.get(ref, key)
   end
 
   @impl true
@@ -35,19 +36,5 @@ defmodule LambdaEthereumConsensus.Store.Db do
   end
 
   @impl true
-  def handle_call({:put, {key, value}}, _from, %{ref: ref} = state) do
-    :ok = Exleveldb.put(ref, key, value)
-    {:reply, :ok, state}
-  end
-
-  @impl true
-  def handle_call({:get, key}, _from, %{ref: ref} = state) do
-    case Exleveldb.get(ref, key) do
-      {:ok, value} ->
-        {:reply, {:ok, value}, state}
-
-      :not_found ->
-        {:reply, :not_found, state}
-    end
-  end
+  def handle_call(:get_ref, _from, %{ref: ref} = state), do: {:reply, ref, state}
 end

--- a/lib/lambda_ethereum_consensus/store/db.ex
+++ b/lib/lambda_ethereum_consensus/store/db.ex
@@ -24,13 +24,7 @@ defmodule LambdaEthereumConsensus.Store.Db do
     Exleveldb.get(ref, key)
   end
 
-  @spec get(binary) :: {:ok, binary} | :not_found
-  def get(key) do
-    ref = GenServer.call(@registered_name, :get_ref)
-    Exleveldb.get(ref, key)
-  end
-
-  @spec get_keys_cursor() :: {:ok, :eleveldb.itr_ref()} | {:error, any()}
+  @spec iterate_keys() :: {:ok, :eleveldb.itr_ref()} | {:error, any()}
   def iterate_keys do
     ref = GenServer.call(@registered_name, :get_ref)
     # TODO: wrap cursor to make it DB-agnostic

--- a/lib/lambda_ethereum_consensus/store/utils.ex
+++ b/lib/lambda_ethereum_consensus/store/utils.ex
@@ -4,7 +4,8 @@ defmodule LambdaEthereumConsensus.Store.Utils do
   """
   @spec get_key(binary, non_neg_integer | binary) :: binary
   def get_key(prefix, suffix) when is_integer(suffix) do
-    prefix <> :binary.encode_unsigned(suffix)
+    # NOTE: this uses the last 64 bits of the suffix only
+    prefix <> <<suffix::64>>
   end
 
   def get_key(prefix, suffix) when is_binary(suffix) do


### PR DESCRIPTION
Depends on #211 #225

This PR adds missing block detection to our DB, and uses that to request blocks from peers. It also refactors the module to only serve the DB handle and allowing concurrent access to it, since _levelDB_ is already thread-safe.