### PR TITLE
chore: bump OTP version to 26

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
-elixir 1.15
-erlang 25.3
+erlang 26.1
+elixir 1.15.6-otp-26
 golang 1.20
 rust 1.71.1
 protoc 24.3


### PR DESCRIPTION
The latest macOS release has problems with Elixir when using OTP 25. This PR bumps the version used in `.tool-versions` to OTP 26, which doesn't have these problems.

Also flips the order of Elixir and Erlang versions listed, since:

> Even though it's possible to install Elixir first, it's recommended to install Erlang first.