### PR TITLE
fix: error "no with clause matching: nil"

### DIFF
--- a/lib/lambda_ethereum_consensus/store/block_store.ex
+++ b/lib/lambda_ethereum_consensus/store/block_store.ex
@@ -77,7 +77,7 @@ defmodule LambdaEthereumConsensus.Store.BlockStore do
     with {:ok, it} <- Db.iterate_keys(),
          {:ok, key} <- Exleveldb.iterator_move(it, initial_key),
          {:ok, _} <-
-           if(key == initial_key, do: Exleveldb.iterator_move(it, :prev)) do
+           if(key == initial_key, do: Exleveldb.iterator_move(it, :prev), else: {:ok, nil}) do
       it
     else
       # DB is empty


### PR DESCRIPTION
The error happened when running the node without checkpoint sync. The match fails because an `if` without `else` returns `nil` when the condition is `false`, but in that case, we'd like it to silently pass.