### PR TITLE
feat: fork Tree PoC

### DIFF
--- a/lib/lambda_ethereum_consensus/application.ex
+++ b/lib/lambda_ethereum_consensus/application.ex
@@ -24,6 +24,7 @@ defmodule LambdaEthereumConsensus.Application do
       {LambdaEthereumConsensus.P2P.GossipSub, [gsub]},
       {LambdaEthereumConsensus.P2P.BlockConsumer, [host]},
       {LambdaEthereumConsensus.Libp2pPort, []},
+      {LambdaEthereumConsensus.ForkChoice.Tree, []},
       # Start the Endpoint (http/https)
       BeaconApi.Endpoint
     ]

--- a/lib/lambda_ethereum_consensus/fork_choice/tree.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/tree.ex
@@ -62,7 +62,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Tree do
   so this operation is O(1).
   """
   @spec get_head :: Node.t()
-  def get_head(), do: GenServer.call(__MODULE__, :get_head)
+  def get_head, do: GenServer.call(__MODULE__, :get_head)
 
   ##########################
   ### GenServer Callbacks

--- a/test/unit/tree.exs
+++ b/test/unit/tree.exs
@@ -1,0 +1,50 @@
+defmodule Unit.TreeTest do
+  use ExUnit.Case
+
+  alias LambdaEthereumConsensus.ForkChoice.Tree
+  alias LambdaEthereumConsensus.ForkChoice.Tree.Node
+
+  @root %Node{
+    parent_id: :root,
+    self_weight: 1,
+    subtree_weight: 1,
+    id: "root",
+    children_ids: []
+  }
+
+  @node %Node{
+    parent_id: "root",
+    self_weight: 1,
+    subtree_weight: 1,
+    id: "node1",
+    children_ids: []
+  }
+
+  setup do
+    start_supervised!(Tree)
+    :ok
+  end
+
+  test "An empty tree returns a nil head" do
+    assert Tree.get_head() == nil
+  end
+
+  test "If there's just a root, it's the head" do
+    Tree.add_block(@root)
+    assert Tree.get_head() == @root
+  end
+
+  test "If there's two nodes, the head is the child" do
+    Tree.add_block(@root)
+    Tree.add_block(@node)
+    assert Tree.get_head() == @node
+  end
+
+  test "If there's three nodes, the head is the child with the highest weight" do
+    heavy_node = @node |> Map.merge(%{self_weight: 2, id: "node 2", subtree_weight: 2})
+    Tree.add_block(@root)
+    Tree.add_block(@node)
+    Tree.add_block(heavy_node)
+    assert Tree.get_head() == heavy_node
+  end
+end

--- a/test/unit/tree.exs
+++ b/test/unit/tree.exs
@@ -47,4 +47,18 @@ defmodule Unit.TreeTest do
     Tree.add_block(heavy_node)
     assert Tree.get_head() == heavy_node
   end
+
+  test "If there's a parent is light but the subtree is heavy, it's still chosen" do
+    heavy_node = @node |> Map.merge(%{self_weight: 2, id: "node 2", subtree_weight: 2})
+
+    head_node =
+      @node
+      |> Map.merge(%{self_weight: 10, subtree_weight: 10, id: "node 3", parent_id: @node.id})
+
+    Tree.add_block(@root)
+    Tree.add_block(@node)
+    Tree.add_block(heavy_node)
+    Tree.add_block(head_node)
+    assert Tree.get_head() == head_node
+  end
 end


### PR DESCRIPTION
**Description**

This PR introduces a GenServer module that:
- Allows blocks to be added to a tree structure.
- The weights of the branch are recalculated when adding a block.
- The head is found when adding a block and cached for future requests.

Out of the scope of this PR:
- Representing slots so that one can request the block for a certain slot.

Closes #270