### PR TITLE
Remove proto generated files from credo checks

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -25,7 +25,7 @@
           "lib/",
           "test/"
         ],
-        excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
+        excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/", ~r"/lib/proto/"]
       },
       #
       # Load and configure plugins here:


### PR DESCRIPTION
**Motivation**

Proto generated files might contain linter errors like not having newlines at the end of the file, but we can't and won't change them manually, plus they are not in source control either way.

**Description**

This PR removes the generated elixir protos from the linter checks.