### PR TITLE
chore: clean up spec-tests code and move vectors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,6 @@ jobs:
           protoc --elixir_out=./lib proto/libp2p.proto
           mix deps.get
       - name: Uncompress vectors
-        run: make tests/${{ matrix.config }}
+        run: make test/spec/vectors/tests/${{ matrix.config }}
       - name: Run tests
         run: mix test --no-start --trace --only spectest

--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,8 @@ native/libp2p_nif/go_src/main.h
 # VSCode configuration dir.
 .vscode/
 
-tests
-*.tar.gz
-
+# spec-test vectors
+test/spec/vectors
 
 libp2p_port/libp2p_port
 

--- a/Makefile
+++ b/Makefile
@@ -41,22 +41,26 @@ $(OUTPUT_DIR)/libp2p_nif.so: $(GO_ARCHIVES) $(GO_HEADERS) $(LIBP2P_DIR)/libp2p.c
 SPECTEST_VERSION = $(shell cat .spectest_version)
 SPECTEST_CONFIGS = general minimal mainnet
 
-SPECTEST_DIRS = $(patsubst %,tests/%,$(SPECTEST_CONFIGS))
-SPECTEST_TARS = $(patsubst %,%_${SPECTEST_VERSION}.tar.gz,$(SPECTEST_CONFIGS))
+SPECTEST_ROOTDIR = test/spec/vectors
+# create directory if it doesn't exist
+$(info $(shell mkdir -p $(SPECTEST_ROOTDIR)))
 
-%_${SPECTEST_VERSION}.tar.gz:
+SPECTEST_DIRS = $(patsubst %,$(SPECTEST_ROOTDIR)/tests/%,$(SPECTEST_CONFIGS))
+SPECTEST_TARS = $(patsubst %,$(SPECTEST_ROOTDIR)/%_${SPECTEST_VERSION}.tar.gz,$(SPECTEST_CONFIGS))
+
+$(SPECTEST_ROOTDIR)/%_${SPECTEST_VERSION}.tar.gz:
 	curl -L -o "$@" \
 		"https://github.com/ethereum/consensus-spec-tests/releases/download/${SPECTEST_VERSION}/$*.tar.gz"
 
-tests/%: %_${SPECTEST_VERSION}.tar.gz
+$(SPECTEST_ROOTDIR)/tests/%: $(SPECTEST_ROOTDIR)/%_${SPECTEST_VERSION}.tar.gz
 	-rm -rf $@
-	tar -xzmf  "$<"
+	tar -xzmf "$<" -C $(SPECTEST_ROOTDIR)
 
 download-vectors: $(SPECTEST_TARS)
 
 clean-vectors:
-	-rm -rf tests
-	-rm *.tar.gz
+	-rm -rf $(SPECTEST_ROOTDIR)/tests
+	-rm $(SPECTEST_ROOTDIR)/*.tar.gz
 
 
 ##### TARGETS #####

--- a/test/spec/general.ex
+++ b/test/spec/general.ex
@@ -5,9 +5,5 @@ defmodule GeneralSpecTest do
   use ExUnit.Case, async: true
   require SpecTestGenerator
 
-  setup_all do
-    Application.put_env(ChainSpec, :config, MainnetConfig)
-  end
-
   SpecTestGenerator.generate_tests("general")
 end

--- a/test/spec/mainnet.ex
+++ b/test/spec/mainnet.ex
@@ -5,10 +5,6 @@ defmodule MainnetSpecTest do
   use ExUnit.Case, async: true
   require SpecTestGenerator
 
-  setup_all do
-    Application.put_env(ChainSpec, :config, MainnetConfig)
-  end
-
   # NOTE: we only support capella for now
   SpecTestGenerator.generate_tests("mainnet", "capella")
 end

--- a/test/spec/minimal_cappela.ex
+++ b/test/spec/minimal_cappela.ex
@@ -5,10 +5,6 @@ defmodule MinimalCapellaSpecTest do
   use ExUnit.Case, async: true
   require SpecTestGenerator
 
-  setup_all do
-    Application.put_env(ChainSpec, :config, MinimalConfig)
-  end
-
   # NOTE: we only support capella for now
   SpecTestGenerator.generate_tests("minimal", "capella")
 end

--- a/test/spec/utils/generator.ex
+++ b/test/spec/utils/generator.ex
@@ -51,6 +51,12 @@ defmodule SpecTestGenerator do
         |> :erlang.md5() != unquote(paths_hash)
       end
 
+      config = SpecTestUtils.get_config(pinned_config)
+
+      setup_all do
+        Application.put_env(ChainSpec, :config, unquote(config))
+      end
+
       for testcase <- SpecTestGenerator.all_cases(),
           pinned_fork in [testcase.fork, ""],
           testcase.config == pinned_config do

--- a/test/spec/utils/testcase.ex
+++ b/test/spec/utils/testcase.ex
@@ -44,6 +44,7 @@ defmodule SpecTestCase do
         suite: suite,
         case: cse
       }) do
-    "tests/#{config}/#{fork}/#{runner}/#{handler}/#{suite}/#{cse}"
+    root = SpecTestUtils.get_vectors_dir()
+    "#{root}/#{config}/#{fork}/#{runner}/#{handler}/#{suite}/#{cse}"
   end
 end

--- a/test/spec/utils/utils.ex
+++ b/test/spec/utils/utils.ex
@@ -30,6 +30,7 @@ defmodule SpecTestUtils do
 
   def get_config("minimal"), do: MinimalConfig
   def get_config("mainnet"), do: MainnetConfig
+  def get_config("general"), do: MainnetConfig
 
   @spec read_ssz_from_file(binary, module, module) :: {:ok, any}
   def read_ssz_from_file(file_path, ssz_type, config) do

--- a/test/spec/utils/utils.ex
+++ b/test/spec/utils/utils.ex
@@ -3,6 +3,8 @@ defmodule SpecTestUtils do
   Utilities for spec tests.
   """
 
+  def get_vectors_dir, do: "test/spec/vectors/tests"
+
   def parse_yaml(map) when is_map(map) do
     map
     |> Stream.map(&parse_yaml/1)


### PR DESCRIPTION
Closes #146

This PR moves the vector download directory to `test/spec/vectors`, and moves the config setting on the spec-tests to the test generator, cleaning up some of the code.