### PR TITLE
refactor: clean up spec tests a bit

### DIFF
--- a/test/spec/runners/epoch_processing.ex
+++ b/test/spec/runners/epoch_processing.ex
@@ -38,27 +38,27 @@ defmodule EpochProcessingTestRunner do
   def run_test_case(%SpecTestCase{} = testcase) do
     case_dir = SpecTestCase.dir(testcase)
 
-    _pre =
+    pre =
       SpecTestUtils.read_ssz_from_file!(
         case_dir <> "/pre.ssz_snappy",
         SszTypes.BeaconState
       )
 
-    {:ok, _post} =
-      SpecTestUtils.read_ssz_from_file(
+    post =
+      SpecTestUtils.read_ssz_from_optional_file!(
         case_dir <> "/post.ssz_snappy",
         SszTypes.BeaconState
       )
 
-    # handle_case(testcase.handler, pre, post)
+    handle_case(testcase.handler, pre, post)
   end
 
-  def handle_case("eth1_data_reset", pre_state, post_state) do
+  defp handle_case("eth1_data_reset", pre_state, post_state) do
     result = EpochProcessing.process_eth1_data_reset(pre_state)
     assert {:ok, post_state} == result
   end
 
-  def handle_case("randao_mixes_reset", pre_state, post_state) do
+  defp handle_case("randao_mixes_reset", pre_state, post_state) do
     result = EpochProcessing.process_randao_mixes_reset(pre_state)
     assert {:ok, post_state} == result
   end

--- a/test/spec/runners/operations.ex
+++ b/test/spec/runners/operations.ex
@@ -74,7 +74,7 @@ defmodule OperationsTestRunner do
       )
 
     post =
-      SpecTestUtils.read_ssz_from_file(
+      SpecTestUtils.read_ssz_from_optional_file!(
         case_dir <> "/post.ssz_snappy",
         SszTypes.BeaconState
       )
@@ -82,7 +82,7 @@ defmodule OperationsTestRunner do
     handle_case(testcase.handler, pre, operation, post, case_dir)
   end
 
-  def handle_case("execution_payload", _pre, _operation, _post, case_dir) do
+  defp handle_case("execution_payload", _pre, _operation, _post, case_dir) do
     %{execution_valid: _execution_valid} =
       YamlElixir.read_from_file!(case_dir <> "/execution.yaml")
       |> SpecTestUtils.parse_yaml()

--- a/test/spec/utils/compile_time.ex
+++ b/test/spec/utils/compile_time.ex
@@ -1,0 +1,11 @@
+defmodule SpecTestCompileUtils do
+  @moduledoc """
+  Compile time utilities for spec tests.
+  """
+
+  def get_vectors_dir, do: "test/spec/vectors/tests"
+
+  def get_config("minimal"), do: MinimalConfig
+  def get_config("mainnet"), do: MainnetConfig
+  def get_config("general"), do: MainnetConfig
+end

--- a/test/spec/utils/generator.ex
+++ b/test/spec/utils/generator.ex
@@ -11,15 +11,15 @@ defmodule SpecTestGenerator do
 
   @vectors_dir SpecTestCompileUtils.get_vectors_dir()
 
-  def all_cases do
-    [@vectors_dir]
-    |> Stream.concat(["*"] |> Stream.cycle() |> Stream.take(6))
-    |> Enum.join("/")
-    |> Path.wildcard()
-    |> Stream.map(&Path.relative_to(&1, @vectors_dir))
-    |> Stream.map(&Path.split/1)
-    |> Enum.map(&SpecTestCase.new/1)
-  end
+  @all_cases [@vectors_dir]
+             |> Stream.concat(["*"] |> Stream.cycle() |> Stream.take(6))
+             |> Enum.join("/")
+             |> Path.wildcard()
+             |> Stream.map(&Path.relative_to(&1, @vectors_dir))
+             |> Stream.map(&Path.split/1)
+             |> Enum.map(&SpecTestCase.new/1)
+
+  def all_cases, do: @all_cases
 
   def runner_map, do: @runner_map
 

--- a/test/spec/utils/generator.ex
+++ b/test/spec/utils/generator.ex
@@ -9,7 +9,7 @@ defmodule SpecTestGenerator do
     "epoch_processing" => EpochProcessingTestRunner
   }
 
-  @vectors_dir SpecTestUtils.get_vectors_dir()
+  @vectors_dir SpecTestCompileUtils.get_vectors_dir()
 
   def all_cases do
     [@vectors_dir]
@@ -57,7 +57,7 @@ defmodule SpecTestGenerator do
         |> :erlang.md5() != unquote(paths_hash)
       end
 
-      config = SpecTestUtils.get_config(pinned_config)
+      config = SpecTestCompileUtils.get_config(pinned_config)
 
       setup_all do
         Application.put_env(:lambda_ethereum_consensus, ChainSpec, config: unquote(config))

--- a/test/spec/utils/testcase.ex
+++ b/test/spec/utils/testcase.ex
@@ -44,7 +44,7 @@ defmodule SpecTestCase do
         suite: suite,
         case: cse
       }) do
-    root = SpecTestUtils.get_vectors_dir()
+    root = SpecTestCompileUtils.get_vectors_dir()
     "#{root}/#{config}/#{fork}/#{runner}/#{handler}/#{suite}/#{cse}"
   end
 end

--- a/test/spec/utils/utils.ex
+++ b/test/spec/utils/utils.ex
@@ -3,8 +3,6 @@ defmodule SpecTestUtils do
   Utilities for spec tests.
   """
 
-  def get_vectors_dir, do: "test/spec/vectors/tests"
-
   def parse_yaml(map) when is_map(map) do
     map
     |> Stream.map(&parse_yaml/1)
@@ -30,27 +28,23 @@ defmodule SpecTestUtils do
   defp parse_as_string(x) when is_integer(x), do: :binary.encode_unsigned(x, :little)
   defp parse_as_string("0x" <> hash), do: Base.decode16!(hash, [{:case, :lower}])
 
-  def get_config("minimal"), do: MinimalConfig
-  def get_config("mainnet"), do: MainnetConfig
-  def get_config("general"), do: MainnetConfig
-
-  @spec read_ssz_from_file(binary, module) :: {:ok, any}
-  def read_ssz_from_file(file_path, ssz_type) do
+  @spec read_ssz_from_optional_file!(binary, module) :: any() | nil
+  def read_ssz_from_optional_file!(file_path, ssz_type) do
     if File.exists?(file_path) do
       compressed = File.read!(file_path)
       {:ok, decompressed} = :snappyer.decompress(compressed)
       {:ok, ssz_object} = Ssz.from_ssz(decompressed, ssz_type)
-      {:ok, ssz_object}
+      ssz_object
     else
-      {:ok, nil}
+      nil
     end
   end
 
-  @spec read_ssz_from_file!(binary, module) :: any
+  @spec read_ssz_from_file!(binary, module) :: any()
   def read_ssz_from_file!(file_path, ssz_type) do
-    case read_ssz_from_file(file_path, ssz_type) do
-      {:ok, nil} -> raise "File not found: #{file_path}"
-      {:ok, ssz_object} -> ssz_object
+    case read_ssz_from_optional_file!(file_path, ssz_type) do
+      nil -> raise "File not found: #{file_path}"
+      ssz_object -> ssz_object
     end
   end
 


### PR DESCRIPTION
This PR renames `read_ssz_from_file` to `read_ssz_from_optional_file!`, to better convey its intended usage. It also changes it to return the value or `nil`, instead of wrapping it in an `:ok` tuple.
Along with that, it also enables `epoch_processing` spec-tests and changes the `handle_case` functions to _private_ visibility (so that non-usage gives a warning).
Finally, it splits the utils module into compile-time and runtime utilities, and caches some used values to reduce the amount of recompiling needed.