### PR TITLE
fix: ld warning, malformed LC_DYSYMTAB

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 erlang 26.1
 elixir 1.15.6-otp-26
-golang 1.20
+golang 1.21.3
 rust 1.71.1
 protoc 24.3


### PR DESCRIPTION
Compiling the libp2p port or NIF results in this message:

```
# libp2p_port
ld: warning: '/private/var/folders/9k/wxsp3xfd6p9_9sbctbjcp1w80000gn/T/go-link-550978199/go.o' has malformed LC_DYSYMTAB, expected 119 undefined symbols to start at index 36231, found 142 undefined symbols starting at index 95
```

Looking for a solution, I found golang/go#61229. It seems this issue was fixed in later versions of the Go toolchain, and bumping it fixes it.