### PR TITLE
chore: generate all mainnet test cases

### DIFF
--- a/test/spec/mainnet.ex
+++ b/test/spec/mainnet.ex
@@ -5,5 +5,5 @@ defmodule MainnetSpecTest do
   require SpecTestGenerator
 
   # NOTE: we only support capella for now
-  SpecTestGenerator.generate_tests("mainnet", "capella")
+  SpecTestGenerator.generate_tests("mainnet")
 end

--- a/test/spec/runners/epoch_processing.ex
+++ b/test/spec/runners/epoch_processing.ex
@@ -30,8 +30,8 @@ defmodule EpochProcessingTestRunner do
   ]
 
   @impl TestRunner
-  def skip?(%SpecTestCase{} = testcase) do
-    Enum.member?(@disabled_handlers ++ @deprecated_handlers, testcase.handler)
+  def skip?(%SpecTestCase{fork: fork, handler: handler}) do
+    fork != "capella" or Enum.member?(@disabled_handlers ++ @deprecated_handlers, handler)
   end
 
   @impl TestRunner

--- a/test/spec/runners/operations.ex
+++ b/test/spec/runners/operations.ex
@@ -52,8 +52,8 @@ defmodule OperationsTestRunner do
   ]
 
   @impl TestRunner
-  def skip?(%SpecTestCase{} = testcase) do
-    Enum.member?(@disabled_handlers, testcase.handler)
+  def skip?(%SpecTestCase{fork: fork, handler: handler}) do
+    fork != "capella" or Enum.member?(@disabled_handlers, handler)
   end
 
   @impl TestRunner

--- a/test/spec/runners/ssz_static.ex
+++ b/test/spec/runners/ssz_static.ex
@@ -22,8 +22,8 @@ defmodule SSZStaticTestRunner do
   ]
 
   @impl TestRunner
-  def skip?(%SpecTestCase{handler: handler}) do
-    Enum.member?(@disabled, handler)
+  def skip?(%SpecTestCase{fork: fork, handler: handler}) do
+    fork != "capella" or Enum.member?(@disabled, handler)
   end
 
   @impl TestRunner


### PR DESCRIPTION
This PR enables generation of non-capella mainnet spec-tests. That way, we can run them on cases like #313 that have vectors only on phase0.