### PR TITLE
feat: make checkpoint sync optional again

### DIFF
--- a/lib/lambda_ethereum_consensus/application.ex
+++ b/lib/lambda_ethereum_consensus/application.ex
@@ -12,11 +12,6 @@ defmodule LambdaEthereumConsensus.Application do
     {args, _remaining_args, _errors} =
       OptionParser.parse(System.argv(), switches: [checkpoint_sync: :string])
 
-    if not Keyword.has_key?(args, :checkpoint_sync) do
-      Logger.error("No checkpoint sync url provided.")
-      :init.stop(1)
-    end
-
     {:ok, host} = Libp2p.host_new()
     {:ok, gsub} = Libp2p.new_gossip_sub(host)
 
@@ -26,7 +21,7 @@ defmodule LambdaEthereumConsensus.Application do
       {LambdaEthereumConsensus.P2P.IncomingRequestHandler, [host]},
       {LambdaEthereumConsensus.P2P.PeerConsumer, [host]},
       {LambdaEthereumConsensus.Libp2pPort, []},
-      {LambdaEthereumConsensus.ForkChoice, {Keyword.fetch!(args, :checkpoint_sync), host}},
+      {LambdaEthereumConsensus.ForkChoice, {Keyword.get(args, :checkpoint_sync), host}},
       {LambdaEthereumConsensus.Beacon.PendingBlocks, [host]},
       {LambdaEthereumConsensus.P2P.GossipSub, [gsub]},
       # Start the Endpoint (http/https)

--- a/lib/lambda_ethereum_consensus/fork_choice/store.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/store.ex
@@ -52,18 +52,20 @@ defmodule LambdaEthereumConsensus.ForkChoice.Store do
   @impl GenServer
   @spec init({BeaconState.t(), BeaconBlock.t()}) :: {:ok, Store.t()} | {:stop, any}
   def init({anchor_state = %BeaconState{}, anchor_block = %BeaconBlock{}}) do
+    result =
+      case Utils.get_forkchoice_store(anchor_state, anchor_block) do
+        {:ok, store = %Store{}} ->
+          Logger.info("[Fork choice] Initialized store.")
+          {:ok, store}
+
+        {:error, error} ->
+          {:stop, error}
+      end
+
     # TODO: this should be done after validation
     :ok = StateStore.store_state(anchor_state)
     :ok = BlockStore.store_block(anchor_block)
-
-    case Utils.get_forkchoice_store(anchor_state, anchor_block) do
-      {:ok, store = %Store{}} ->
-        Logger.info("[Fork choice] Initialized store.")
-        {:ok, store}
-
-      {:error, error} ->
-        {:stop, error}
-    end
+    result
   end
 
   @impl GenServer

--- a/lib/lambda_ethereum_consensus/fork_choice/store.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/store.ex
@@ -7,7 +7,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Store do
   require Logger
 
   alias LambdaEthereumConsensus.ForkChoice.Utils
-  alias LambdaEthereumConsensus.Store.BlockStore
+  alias LambdaEthereumConsensus.Store.{BlockStore, StateStore}
   alias SszTypes.BeaconBlock
   alias SszTypes.BeaconState
   alias SszTypes.Store
@@ -52,6 +52,10 @@ defmodule LambdaEthereumConsensus.ForkChoice.Store do
   @impl GenServer
   @spec init({BeaconState.t(), BeaconBlock.t()}) :: {:ok, Store.t()} | {:stop, any}
   def init({anchor_state = %BeaconState{}, anchor_block = %BeaconBlock{}}) do
+    # TODO: this should be done after validation
+    :ok = StateStore.store_state(anchor_state)
+    :ok = BlockStore.store_block(anchor_block)
+
     case Utils.get_forkchoice_store(anchor_state, anchor_block) do
       {:ok, store = %Store{}} ->
         Logger.info("[Fork choice] Initialized store.")

--- a/lib/lambda_ethereum_consensus/fork_choice/supervisor.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/supervisor.ex
@@ -18,20 +18,23 @@ defmodule LambdaEthereumConsensus.ForkChoice do
         Logger.info("[Checkpoint sync] Received beacon state at slot #{anchor_state.slot}.")
 
         {:ok, anchor_block} = fetch_anchor_block(anchor_state, host)
-
-        children = [
-          {LambdaEthereumConsensus.ForkChoice.Store, {anchor_state, anchor_block}},
-          {LambdaEthereumConsensus.ForkChoice.Tree, []}
-        ]
-
-        Supervisor.init(children, strategy: :one_for_all)
+        init_children(anchor_state, anchor_block)
 
       {:error, _} ->
         :ignore
     end
   end
 
-  def fetch_anchor_block(%SszTypes.BeaconState{} = anchor_state, host) do
+  defp init_children(anchor_state, anchor_block) do
+    children = [
+      {LambdaEthereumConsensus.ForkChoice.Store, {anchor_state, anchor_block}},
+      {LambdaEthereumConsensus.ForkChoice.Tree, []}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_all)
+  end
+
+  defp fetch_anchor_block(%SszTypes.BeaconState{} = anchor_state, host) do
     {:ok, state_root} = Ssz.hash_tree_root(anchor_state)
 
     # The latest_block_header.state_root was zeroed out to avoid circular dependencies


### PR DESCRIPTION
This PR makes checkpoint sync optional after doing it once. After that, we fetch the initial state and block from the DB. With this change, the node's startup time is reduced considerably.