### PR TITLE
chore: add `.proto` file dependency to `proto` make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ PORT_SOURCES := $(shell find native/libp2p_port -type f)
 $(OUTPUT_DIR)/libp2p_port: $(PORT_SOURCES)
 	cd native/libp2p_port; go build -o ../../$(OUTPUT_DIR)/libp2p_port
 
-compile-port: $(OUTPUT_DIR)/libp2p_port
+compile-port: $(OUTPUT_DIR)/libp2p_port proto
 
 # Run an interactive terminal with the main supervisor setup.
 start: compile-native compile-port
@@ -121,8 +121,8 @@ fmt:
 	cd native/ssz_nif; cargo fmt
 	cd native/bls_nif; cargo fmt
 
-# Generate protobof code
-proto:
+# Generate protobuf code
+proto: proto/libp2p.proto
 	sh scripts/make_protos.sh
 
 nix:


### PR DESCRIPTION
This makes it so you don't need to explicitly run `make proto`: `make` takes care of it for you.