### PR TITLE
perf: parallelize `IncomingRequestHandler`

### DIFF
--- a/lib/lambda_ethereum_consensus/application.ex
+++ b/lib/lambda_ethereum_consensus/application.ex
@@ -28,7 +28,7 @@ defmodule LambdaEthereumConsensus.Application do
       {LambdaEthereumConsensus.Libp2pPort, libp2p_opts},
       {LambdaEthereumConsensus.Store.Db, []},
       {LambdaEthereumConsensus.P2P.Peerbook, []},
-      {LambdaEthereumConsensus.P2P.IncomingRequestHandler, []},
+      {LambdaEthereumConsensus.P2P.IncomingRequests.Supervisor, []},
       {LambdaEthereumConsensus.ForkChoice, [Keyword.get(args, :checkpoint_sync)]},
       {LambdaEthereumConsensus.Beacon.PendingBlocks, []},
       {LambdaEthereumConsensus.P2P.GossipSub, []},

--- a/lib/lambda_ethereum_consensus/application.ex
+++ b/lib/lambda_ethereum_consensus/application.ex
@@ -28,7 +28,7 @@ defmodule LambdaEthereumConsensus.Application do
       {LambdaEthereumConsensus.Libp2pPort, libp2p_opts},
       {LambdaEthereumConsensus.Store.Db, []},
       {LambdaEthereumConsensus.P2P.Peerbook, []},
-      {LambdaEthereumConsensus.P2P.IncomingRequests.Supervisor, []},
+      {LambdaEthereumConsensus.P2P.IncomingRequests, []},
       {LambdaEthereumConsensus.ForkChoice, [Keyword.get(args, :checkpoint_sync)]},
       {LambdaEthereumConsensus.Beacon.PendingBlocks, []},
       {LambdaEthereumConsensus.P2P.GossipSub, []},

--- a/lib/lambda_ethereum_consensus/p2p/incoming_requests/handler.ex
+++ b/lib/lambda_ethereum_consensus/p2p/incoming_requests/handler.ex
@@ -1,46 +1,11 @@
-defmodule LambdaEthereumConsensus.P2P.IncomingRequestHandler do
-  use GenServer
-
+defmodule LambdaEthereumConsensus.P2P.IncomingRequests.Handler do
   @moduledoc """
   This module handles Req/Resp domain requests.
   """
   require Logger
   alias LambdaEthereumConsensus.Libp2pPort
 
-  @prefix "/eth2/beacon_chain/req/"
 
-  def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts)
-  end
-
-  @impl true
-  def init(_opts) do
-    [
-      "status/1",
-      "goodbye/1",
-      "ping/1",
-      "beacon_blocks_by_range/2",
-      "metadata/2"
-    ]
-    |> Stream.map(&Enum.join([@prefix, &1, "/ssz_snappy"]))
-    |> Stream.map(&Libp2pPort.set_handler/1)
-    |> Enum.each(fn :ok -> nil end)
-
-    {:ok, nil}
-  end
-
-  @impl true
-  def handle_info({:request, {@prefix <> name, message_id, message}}, state) do
-    Logger.debug("'#{name}' request received")
-
-    case handle_req(name, message_id, message) do
-      :ok -> :ok
-      :not_implemented -> :ok
-      {:error, error} -> Logger.error("[#{name}] Request error: #{inspect(error)}")
-    end
-
-    {:noreply, state}
-  end
 
   @spec handle_req(String.t(), String.t(), binary()) ::
           :ok | :not_implemented | {:error, binary()}

--- a/lib/lambda_ethereum_consensus/p2p/incoming_requests/incoming_requests.ex
+++ b/lib/lambda_ethereum_consensus/p2p/incoming_requests/incoming_requests.ex
@@ -1,5 +1,7 @@
-defmodule LambdaEthereumConsensus.P2P.IncomingRequests.Supervisor do
+defmodule LambdaEthereumConsensus.P2P.IncomingRequests do
   use Supervisor
+
+  alias __MODULE__
 
   def start_link(opts) do
     Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
@@ -8,7 +10,8 @@ defmodule LambdaEthereumConsensus.P2P.IncomingRequests.Supervisor do
   @impl true
   def init(_opts) do
     children = [
-      {LambdaEthereumConsensus.P2P.IncomingRequests.Receiver, []}
+      {Task.Supervisor, name: IncomingRequests.Handler},
+      {IncomingRequests.Receiver, []}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/lambda_ethereum_consensus/p2p/incoming_requests/incoming_requests.ex
+++ b/lib/lambda_ethereum_consensus/p2p/incoming_requests/incoming_requests.ex
@@ -1,4 +1,7 @@
 defmodule LambdaEthereumConsensus.P2P.IncomingRequests do
+  @moduledoc """
+  This module is a ``Supervisor`` over ``Receiver`` and ``Handler``.
+  """
   use Supervisor
 
   alias __MODULE__

--- a/lib/lambda_ethereum_consensus/p2p/incoming_requests/receiver.ex
+++ b/lib/lambda_ethereum_consensus/p2p/incoming_requests/receiver.ex
@@ -1,0 +1,46 @@
+defmodule LambdaEthereumConsensus.P2P.IncomingRequests.Receiver do
+  @moduledoc """
+  This module receives Req/Resp domain requests, and dispatches them to
+  ``LambdaEthereumConsensus.P2P.IncomingRequests.Handler.handle_req/3``.
+  """
+  use GenServer
+  require Logger
+
+  alias LambdaEthereumConsensus.Libp2pPort
+  alias LambdaEthereumConsensus.P2P.IncomingRequests.Handler
+
+  @prefix "/eth2/beacon_chain/req/"
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @impl true
+  def init(_opts) do
+    [
+      "status/1",
+      "goodbye/1",
+      "ping/1",
+      "beacon_blocks_by_range/2",
+      "metadata/2"
+    ]
+    |> Stream.map(&Enum.join([@prefix, &1, "/ssz_snappy"]))
+    |> Stream.map(&Libp2pPort.set_handler/1)
+    |> Enum.each(fn :ok -> nil end)
+
+    {:ok, nil}
+  end
+
+  @impl true
+  def handle_info({:request, {@prefix <> name, message_id, message}}, state) do
+    Logger.debug("'#{name}' request received")
+
+    case Handler.handle_req(name, message_id, message) do
+      :ok -> :ok
+      :not_implemented -> :ok
+      {:error, error} -> Logger.error("[#{name}] Request error: #{inspect(error)}")
+    end
+
+    {:noreply, state}
+  end
+end

--- a/lib/lambda_ethereum_consensus/p2p/incoming_requests/supervisor.ex
+++ b/lib/lambda_ethereum_consensus/p2p/incoming_requests/supervisor.ex
@@ -1,0 +1,16 @@
+defmodule LambdaEthereumConsensus.P2P.IncomingRequests.Supervisor do
+  use Supervisor
+
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_opts) do
+    children = [
+      {LambdaEthereumConsensus.P2P.IncomingRequests.Receiver, []}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end


### PR DESCRIPTION
Closes #344

This PR:
- splits `IncomingRequestHandler` into `IncomingRequests.Handler` and `IncomingRequests.Receiver`, with a supervisor named `IncomingRequests`
- `IncomingRequests` starts both a `Task.Supervisor` with name `IncomingRequests.Handler`, and a `GenServer` `IncomingRequests.Receiver` that receives the requests
- each time `Receiver` gets a request, it starts an async task via the `Task.Supervisor`