### PR TITLE
fix: store signed blocks instead of regular blocks.

### DIFF
--- a/lib/beacon_api/controllers/v1/beacon_controller.ex
+++ b/lib/beacon_api/controllers/v1/beacon_controller.ex
@@ -82,7 +82,7 @@ defmodule BeaconApi.V1.BeaconController do
 
   def get_block_root(conn, %{"block_id" => "0x" <> hex_block_id}) do
     with {:ok, block_root} <- Base.decode16(hex_block_id, case: :mixed),
-         {:ok, _block} <- BlockStore.get_block(block_root) do
+         {:ok, _signed_block} <- BlockStore.get_block(block_root) do
       conn |> root_response(block_root)
     else
       :not_found -> conn |> block_not_found()

--- a/lib/lambda_ethereum_consensus/fork_choice/store.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/store.ex
@@ -8,9 +8,9 @@ defmodule LambdaEthereumConsensus.ForkChoice.Store do
 
   alias LambdaEthereumConsensus.ForkChoice.Helpers
   alias LambdaEthereumConsensus.Store.{BlockStore, StateStore}
-  alias SszTypes.BeaconBlock
   alias SszTypes.BeaconState
   alias SszTypes.Store
+  alias SszTypes.SignedBeaconBlock
 
   ##########################
   ### Public API
@@ -50,10 +50,10 @@ defmodule LambdaEthereumConsensus.ForkChoice.Store do
   ##########################
 
   @impl GenServer
-  @spec init({BeaconState.t(), BeaconBlock.t()}) :: {:ok, Store.t()} | {:stop, any}
-  def init({anchor_state = %BeaconState{}, anchor_block = %BeaconBlock{}}) do
+  @spec init({BeaconState.t(), SignedBeaconBlock.t()}) :: {:ok, Store.t()} | {:stop, any}
+  def init({anchor_state = %BeaconState{}, signed_anchor_block = %SignedBeaconBlock{}}) do
     result =
-      case Helpers.get_forkchoice_store(anchor_state, anchor_block) do
+      case Helpers.get_forkchoice_store(anchor_state, signed_anchor_block.message) do
         {:ok, store = %Store{}} ->
           Logger.info("[Fork choice] Initialized store.")
           {:ok, store}
@@ -64,7 +64,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Store do
 
     # TODO: this should be done after validation
     :ok = StateStore.store_state(anchor_state)
-    :ok = BlockStore.store_block(anchor_block)
+    :ok = BlockStore.store_block(signed_anchor_block)
     result
   end
 

--- a/lib/lambda_ethereum_consensus/fork_choice/store.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/store.ex
@@ -9,8 +9,9 @@ defmodule LambdaEthereumConsensus.ForkChoice.Store do
   alias LambdaEthereumConsensus.ForkChoice.Helpers
   alias LambdaEthereumConsensus.Store.{BlockStore, StateStore}
   alias SszTypes.BeaconState
-  alias SszTypes.Store
   alias SszTypes.SignedBeaconBlock
+  alias SszTypes.Store
+
 
   ##########################
   ### Public API

--- a/lib/lambda_ethereum_consensus/fork_choice/store.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/store.ex
@@ -12,7 +12,6 @@ defmodule LambdaEthereumConsensus.ForkChoice.Store do
   alias SszTypes.SignedBeaconBlock
   alias SszTypes.Store
 
-
   ##########################
   ### Public API
   ##########################

--- a/lib/lambda_ethereum_consensus/fork_choice/supervisor.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/supervisor.ex
@@ -78,9 +78,7 @@ defmodule LambdaEthereumConsensus.ForkChoice do
     case BlockDownloader.request_block_by_root(block_root) do
       {:ok, signed_block} ->
         Logger.info("[Sync] Initial block fetched.")
-        block = signed_block.message
-
-        {:ok, block}
+        {:ok, signed_block}
 
       {:error, message} ->
         Logger.warning("[Sync] Failed to fetch initial block: #{message}.\nRetrying...")

--- a/lib/lambda_ethereum_consensus/store/block_store.ex
+++ b/lib/lambda_ethereum_consensus/store/block_store.ex
@@ -8,13 +8,14 @@ defmodule LambdaEthereumConsensus.Store.BlockStore do
   @block_prefix "block"
   @blockslot_prefix @block_prefix <> "slot"
 
-  @spec store_block(SszTypes.BeaconBlock.t()) :: :ok
-  def store_block(%SszTypes.BeaconBlock{} = block) do
+  @spec store_block(SszTypes.SignedBeaconBlock.t()) :: :ok
+  def store_block(%SszTypes.SignedBeaconBlock{} = signed_block) do
+    block = signed_block.message
     {:ok, block_root} = Ssz.hash_tree_root(block)
-    {:ok, encoded_block} = Ssz.to_ssz(block)
+    {:ok, encoded_signed_block} = Ssz.to_ssz(signed_block)
 
     key = block_key(block_root)
-    Db.put(key, encoded_block)
+    Db.put(key, encoded_signed_block)
 
     # WARN: this overrides any previous mapping for the same slot
     # TODO: this should apply fork-choice if not applied elsewhere
@@ -23,12 +24,12 @@ defmodule LambdaEthereumConsensus.Store.BlockStore do
   end
 
   @spec get_block(SszTypes.root()) ::
-          {:ok, SszTypes.BeaconBlock.t()} | {:error, String.t()} | :not_found
+          {:ok, SszTypes.SignedBeaconBlock.t()} | {:error, String.t()} | :not_found
   def get_block(block_root) do
     key = block_key(block_root)
 
-    with {:ok, block} <- Db.get(key) do
-      Ssz.from_ssz(block, SszTypes.BeaconBlock)
+    with {:ok, signed_block} <- Db.get(key) do
+      Ssz.from_ssz(signed_block, SszTypes.SignedBeaconBlock)
     end
   end
 
@@ -40,7 +41,7 @@ defmodule LambdaEthereumConsensus.Store.BlockStore do
   end
 
   @spec get_block_by_slot(SszTypes.slot()) ::
-          {:ok, SszTypes.BeaconBlock.t()} | {:error, String.t()} | :not_found
+          {:ok, SszTypes.SignedBeaconBlock.t()} | {:error, String.t()} | :not_found
   def get_block_by_slot(slot) do
     # WARN: this will return the latest block received for the given slot
     with {:ok, root} <- get_block_root_by_slot(slot) do


### PR DESCRIPTION
**Motivation**
We need to store signed blocks since we will need to pass them to other peers on request.

