### PR TITLE
refactor: simplify "epoch_processing" handlers

### DIFF
--- a/lib/spec/runners/epoch_processing.ex
+++ b/lib/spec/runners/epoch_processing.ex
@@ -3,6 +3,7 @@ defmodule EpochProcessingTestRunner do
   Runner for Epoch Processing test cases. See: https://github.com/ethereum/consensus-specs/tree/dev/tests/formats/epoch_processing
   """
   alias LambdaEthereumConsensus.StateTransition.EpochProcessing
+  alias LambdaEthereumConsensus.Utils.Diff
 
   use ExUnit.CaseTemplate
   use TestRunner
@@ -52,50 +53,17 @@ defmodule EpochProcessingTestRunner do
     handle_case(testcase.handler, pre, post)
   end
 
-  defp handle_case("effective_balance_updates", pre, post) do
-    result = EpochProcessing.process_effective_balance_updates(pre)
-    assert result == {:ok, post}
-  end
-
-  defp handle_case("eth1_data_reset", pre, post) do
-    result = EpochProcessing.process_eth1_data_reset(pre)
-    assert result == {:ok, post}
-  end
-
-  defp handle_case("inactivity_updates", pre, post) do
-    result = EpochProcessing.process_inactivity_updates(pre)
-    assert result == {:ok, post}
-  end
-
-  defp handle_case("randao_mixes_reset", pre, post) do
-    result = EpochProcessing.process_randao_mixes_reset(pre)
-    assert result == {:ok, post}
-  end
-
-  defp handle_case("registry_updates", pre, post) do
-    result = EpochProcessing.process_registry_updates(pre)
+  defp handle_case(name, pre, post) do
+    fun = "process_#{name}" |> String.to_existing_atom()
+    result = apply(EpochProcessing, fun, [pre])
 
     case post do
       nil ->
         assert {:error, _error_msg} = result
 
       post ->
-        assert result == {:ok, post}
+        assert {:ok, state} = result
+        assert Diff.diff(state, post) == :unchanged
     end
-  end
-
-  defp handle_case("participation_flag_updates", pre, post) do
-    result = EpochProcessing.process_participation_flag_updates(pre)
-    assert result == {:ok, post}
-  end
-
-  defp handle_case("slashings_reset", pre, post) do
-    result = EpochProcessing.process_slashings_reset(pre)
-    assert result == {:ok, post}
-  end
-
-  defp handle_case("historical_summaries_update", pre, post) do
-    result = EpochProcessing.process_historical_summaries_update(pre)
-    assert result == {:ok, post}
   end
 end


### PR DESCRIPTION
This PR removes duplicated code in `epoch_processing` handlers, and changes assertions to use the new `Diff.diff/2` function