### PR TITLE
build: fix formatter taking forever.

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -2,7 +2,6 @@
 [
   inputs:
     ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
-    |> Enum.flat_map(&Path.wildcard(&1, match_dot: true))
     |> Enum.reject(&(&1 =~ "lib/proto"))
     |> Enum.reject(&(&1 =~ "test/generated"))
 ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,7 +1,4 @@
 # Used by "mix format"
 [
-  inputs:
-    ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
-    |> Enum.reject(&(&1 =~ "lib/proto"))
-    |> Enum.reject(&(&1 =~ "test/generated"))
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]


### PR DESCRIPTION
**Motivation**
In VsCode, this line is making the formatting task extremely slow (10+ seconds). Not sure what the reason is but removing it fixes the issue. Also, I don't know what the purpose of this line is.