### PR TITLE
feat: add `on_block` handler

### DIFF
--- a/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
@@ -41,13 +41,6 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
     finalized_slot =
       Misc.compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
 
-    finalized_checkpoint_block =
-      Store.get_checkpoint_block(
-        store,
-        block.parent_root,
-        store.finalized_checkpoint.epoch
-      )
-
     cond do
       # Parent block must be known
       not Map.has_key?(store.block_states, block.parent_root) ->
@@ -64,7 +57,12 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
         {:error, "block is prior to last finalized epoch"}
 
       # Check block is a descendant of the finalized block at the checkpoint finalized slot
-      store.finalized_checkpoint.root != finalized_checkpoint_block ->
+      store.finalized_checkpoint.root !=
+          Store.get_checkpoint_block(
+            store,
+            block.parent_root,
+            store.finalized_checkpoint.epoch
+          ) ->
         {:error, "block isn't descendant of latest finalized block"}
 
       true ->

--- a/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
@@ -34,7 +34,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
   A block that is asserted as invalid due to unavailable PoW block may be valid at a later time,
   consider scheduling it for later processing in such case.
   """
-  @spec on_tick(Store.t(), SignedBeaconBlock.t()) :: {:ok, Store.t()} | {:error, String.t()}
+  @spec on_block(Store.t(), SignedBeaconBlock.t()) :: {:ok, Store.t()} | {:error, String.t()}
   def on_block(%Store{} = store, %SignedBeaconBlock{message: block} = signed_block) do
     finalized_slot =
       Misc.compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)

--- a/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
@@ -3,7 +3,8 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
   Handlers that update the fork choice store.
   """
 
-  alias SszTypes.Store
+  alias LambdaEthereumConsensus.StateTransition.{EpochProcessing, Misc}
+  alias SszTypes.{Checkpoint, SignedBeaconBlock, Store}
 
   ### Public API ###
 
@@ -26,10 +27,83 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
   end
 
   @doc """
-  Called whenever a signed block is received.
+  Run ``on_block`` upon receiving a new block.
+
+  A block that is asserted as invalid due to unavailable PoW block may be valid at a later time,
+  consider scheduling it for later processing in such case.
   """
-  def on_block(store, _block) do
-    {:ok, store}
+  def on_block(%Store{} = store, %SignedBeaconBlock{message: block} = signed_block) do
+    finalized_slot =
+      Misc.compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
+
+    finalized_checkpoint_block =
+      Store.get_checkpoint_block(
+        store,
+        block.parent_root,
+        store.finalized_checkpoint.epoch
+      )
+
+    cond do
+      # Parent block must be known
+      not Map.has_key?(store.block_states, block.parent_root) ->
+        {:error, "parent state not found in store"}
+
+      # Blocks cannot be in the future. If they are, their
+      # consideration must be delayed until they are in the past.
+      Store.get_current_slot(store) < block.slot ->
+        # TODO: handle this error somehow
+        {:error, "block is from the future"}
+
+      # Check that block is later than the finalized epoch slot (optimization to reduce calls to get_ancestor)
+      block.slot <= finalized_slot ->
+        {:error, "block is prior to last finalized epoch"}
+
+      # Check block is a descendant of the finalized block at the checkpoint finalized slot
+      store.finalized_checkpoint.root != finalized_checkpoint_block ->
+        {:error, "block isn't descendant of latest finalized block"}
+
+      true ->
+        compute_post_state(store, signed_block)
+    end
+  end
+
+  # Check the block is valid and compute the post-state.
+  defp compute_post_state(
+         %Store{block_states: states} = store,
+         %SignedBeaconBlock{message: block} = signed_block
+       ) do
+    state = states[block.parent_root]
+    block_root = Ssz.hash_tree_root(block)
+
+    # TODO: add stub for this
+    state = StateTransition.state_transition(state, signed_block, true)
+
+    # Add new block to the store
+    blocks = Map.put(store.blocks, block_root, block)
+    # Add new state for this block to the store
+    states = Map.put(store.block_states, block_root, state)
+
+    store = %Store{store | blocks: blocks, block_states: states}
+
+    seconds_per_slot = ChainSpec.get("SECONDS_PER_SLOT")
+    intervals_per_slot = ChainSpec.get("INTERVALS_PER_SLOT")
+    # Add proposer score boost if the block is timely
+    time_into_slot = rem(store.time - store.genesis_time, seconds_per_slot)
+    is_before_attesting_interval = time_into_slot < div(seconds_per_slot, intervals_per_slot)
+
+    store =
+      if is_before_attesting_interval and Store.get_current_slot(store) == block.slot do
+        %Store{store | proposer_boost_root: block_root}
+      else
+        store
+      end
+
+    # Update checkpoints in store if necessary
+    store =
+      update_checkpoints(store, state.current_justified_checkpoint, state.finalized_checkpoint)
+
+    # Eagerly compute unrealized justification and finality
+    compute_pulled_up_tip(store, block_root)
   end
 
   ### Private functions ###
@@ -70,6 +144,54 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
         )
       end)
     end)
+  end
+
+  defp compute_pulled_up_tip(%Store{block_states: states} = store, block_root) do
+    state = states[block_root]
+    # Pull up the post-state of the block to the next epoch boundary
+    # TODO: implement stub
+    state = EpochProcessing.process_justification_and_finalization(state)
+
+    unrealized_justifications =
+      Map.put(store.unrealized_justifications, block_root, state.current_justified_checkpoint)
+
+    store = %Store{store | unrealized_justifications: unrealized_justifications}
+
+    store =
+      update_unrealized_checkpoints(
+        store,
+        state.current_justified_checkpoint,
+        state.finalized_checkpoint
+      )
+
+    # If the block is from a prior epoch, apply the realized values
+    block_epoch = Misc.compute_epoch_at_slot(store.blocks[block_root].slot)
+    current_epoch = Misc.compute_epoch_at_slot(Store.get_current_slot(store))
+
+    if block_epoch < current_epoch do
+      update_checkpoints(store, state.current_justified_checkpoint, state.finalized_checkpoint)
+    else
+      store
+    end
+  end
+
+  # Update unrealized checkpoints in store if necessary
+  defp update_unrealized_checkpoints(
+         %Store{} = store,
+         %Checkpoint{} = unrealized_justified_checkpoint,
+         %Checkpoint{} = unrealized_finalized_checkpoint
+       ) do
+    store
+    |> if_then_update(
+      unrealized_justified_checkpoint.epoch > store.unrealized_justified_checkpoint.epoch,
+      # Update unrealized justified checkpoint
+      &%Store{&1 | unrealized_justified_checkpoint: unrealized_justified_checkpoint}
+    )
+    |> if_then_update(
+      unrealized_finalized_checkpoint.epoch > store.unrealized_finalized_checkpoint.epoch,
+      # Update unrealized finalized checkpoint
+      &%Store{&1 | unrealized_finalized_checkpoint: unrealized_finalized_checkpoint}
+    )
   end
 
   defp compute_slots_since_epoch_start(slot) do

--- a/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
@@ -3,6 +3,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
   Handlers that update the fork choice store.
   """
 
+  alias LambdaEthereumConsensus.StateTransition
   alias LambdaEthereumConsensus.StateTransition.{EpochProcessing, Misc}
   alias SszTypes.{Checkpoint, SignedBeaconBlock, Store}
 
@@ -75,7 +76,6 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
     state = states[block.parent_root]
     block_root = Ssz.hash_tree_root(block)
 
-    # TODO: add stub for this
     state = StateTransition.state_transition(state, signed_block, true)
 
     # Add new block to the store
@@ -149,7 +149,6 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
   defp compute_pulled_up_tip(%Store{block_states: states} = store, block_root) do
     state = states[block_root]
     # Pull up the post-state of the block to the next epoch boundary
-    # TODO: implement stub
     state = EpochProcessing.process_justification_and_finalization(state)
 
     unrealized_justifications =

--- a/lib/lambda_ethereum_consensus/fork_choice/store.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/store.ex
@@ -55,6 +55,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Store do
     result =
       case Helpers.get_forkchoice_store(anchor_state, signed_anchor_block.message) do
         {:ok, store = %Store{}} ->
+          store = on_tick_now(store)
           Logger.info("[Fork choice] Initialized store.")
           {:ok, store}
 
@@ -93,8 +94,8 @@ defmodule LambdaEthereumConsensus.ForkChoice.Store do
 
   @impl GenServer
   def handle_info(:on_tick, store) do
-    time = :os.system_time(:second)
-    new_store = Handlers.on_tick(store, time)
+    new_store = on_tick_now(store)
+
     schedule_next_tick()
     {:noreply, new_store}
   end
@@ -107,6 +108,8 @@ defmodule LambdaEthereumConsensus.ForkChoice.Store do
   defp get_store_attrs(attrs) do
     GenServer.call(__MODULE__, {:get_store_attrs, attrs})
   end
+
+  defp on_tick_now(store), do: Handlers.on_tick(store, :os.system_time(:second))
 
   defp schedule_next_tick do
     # For millisecond precision

--- a/lib/lambda_ethereum_consensus/p2p/gossip_handler.ex
+++ b/lib/lambda_ethereum_consensus/p2p/gossip_handler.ex
@@ -12,13 +12,16 @@ defmodule LambdaEthereumConsensus.P2P.GossipHandler do
   @spec handle_message(String.t(), struct) :: :ok
   def handle_message(topic_name, payload)
 
-  def handle_message("/eth2/bba4da96/beacon_block/ssz_snappy", %SignedBeaconBlock{message: block}) do
+  def handle_message(
+        "/eth2/bba4da96/beacon_block/ssz_snappy",
+        %SignedBeaconBlock{message: block} = signed_block
+      ) do
     current_slot = Store.get_current_slot()
 
     if block.slot > current_slot - ChainSpec.get("SLOTS_PER_EPOCH") do
       Logger.info("[Gossip] Block decoded for slot #{block.slot}")
 
-      PendingBlocks.add_block(block)
+      PendingBlocks.add_block(signed_block)
     end
 
     :ok

--- a/lib/lambda_ethereum_consensus/state_transition/epoch_processing.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/epoch_processing.ex
@@ -325,4 +325,10 @@ defmodule LambdaEthereumConsensus.StateTransition.EpochProcessing do
       {:ok, state}
     end
   end
+
+  @spec process_justification_and_finalization(BeaconState.t()) :: {:ok, BeaconState.t()}
+  def process_justification_and_finalization(state) do
+    # TODO: implement this
+    state
+  end
 end

--- a/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
@@ -1,0 +1,16 @@
+defmodule LambdaEthereumConsensus.StateTransition do
+  @moduledoc """
+  State transition logic.
+  """
+
+  alias SszTypes.{SignedBeaconBlock, BeaconState}
+
+  def state_transition(
+        %BeaconState{} = state,
+        %SignedBeaconBlock{message: _block} = _signed_block,
+        _validate_result
+      ) do
+    # TODO: implement
+    state
+  end
+end

--- a/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
@@ -3,7 +3,7 @@ defmodule LambdaEthereumConsensus.StateTransition do
   State transition logic.
   """
 
-  alias SszTypes.{SignedBeaconBlock, BeaconState}
+  alias SszTypes.{BeaconState, SignedBeaconBlock}
 
   def state_transition(
         %BeaconState{} = state,

--- a/test/fixtures/block.ex
+++ b/test/fixtures/block.ex
@@ -5,6 +5,14 @@ defmodule Fixtures.Block do
 
   alias Fixtures.Random
 
+  @spec signed_beacon_block :: SszTypes.SignedBeaconBlock.t()
+  def signed_beacon_block do
+    %SszTypes.SignedBeaconBlock{
+      message: beacon_block(),
+      signature: Random.bls_signature()
+    }
+  end
+
   @spec beacon_block :: SszTypes.BeaconBlock.t()
   def beacon_block do
     %SszTypes.BeaconBlock{

--- a/test/unit/pending_blocks_test.exs
+++ b/test/unit/pending_blocks_test.exs
@@ -4,22 +4,26 @@ defmodule Unit.PendingBlocks do
 
   alias LambdaEthereumConsensus.Beacon.PendingBlocks
   alias LambdaEthereumConsensus.ForkChoice.Store
+  alias LambdaEthereumConsensus.Store.BlockStore
 
   setup do
     # Lets trigger the process_blocks manually
     patch(PendingBlocks, :schedule_blocks_processing, fn -> :ok end)
 
-    start_supervised!({PendingBlocks, ["host"]})
+    start_supervised!({PendingBlocks, []})
     :ok
   end
 
   test "Adds a pending block to fork choice if the parent is there" do
-    block = Fixtures.Block.beacon_block()
-    {:ok, block_root} = Ssz.hash_tree_root(block)
+    signed_block = Fixtures.Block.signed_beacon_block()
+    {:ok, block_root} = Ssz.hash_tree_root(signed_block.message)
 
-    patch(Store, :has_block?, fn root -> root == block.parent_root end)
+    patch(Store, :has_block?, fn root -> root == signed_block.message.parent_root end)
 
-    PendingBlocks.add_block(block)
+    # Don't store the block in the DB, to avoid having to set it up
+    patch(BlockStore, :store_block, fn _block -> :ok end)
+
+    PendingBlocks.add_block(signed_block)
 
     assert PendingBlocks.is_pending_block(block_root)
     send(PendingBlocks, :process_blocks)


### PR DESCRIPTION
~Depends on #381~
Closes #377

This PR implements the `on_block` handler and calls it from `ForkChoice.Store`. To do this, I had to change the `BeaconBlock`s stored in `PendingBlocks` to `SignedBeaconBlock`s.

NOTE: the implementations of `state_transition` and `process_justification_and_finalization` are missing and are left for later PRs.