### PR TITLE
refactor: move some functions to utils

### DIFF
--- a/lib/lambda_ethereum_consensus/fork_choice/checkpoint_sync.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/checkpoint_sync.ex
@@ -1,0 +1,42 @@
+defmodule LambdaEthereumConsensus.ForkChoice.CheckpointSync do
+  @moduledoc """
+  Functions related to checkpoint-sync.
+  """
+  require Logger
+
+  use Tesla
+  plug(Tesla.Middleware.JSON)
+
+  @doc """
+  Syncs the node using an inputed checkpoint
+  """
+  @spec sync_from_checkpoint(binary) :: {:ok, SszTypes.BeaconState.t()} | {:error, any}
+  def sync_from_checkpoint(url) do
+    client =
+      Tesla.client([
+        {Tesla.Middleware.Headers, [{"Accept", "application/octet-stream"}]}
+      ])
+
+    full_url =
+      url
+      |> URI.parse()
+      |> URI.append_path("/eth/v2/debug/beacon/states/finalized")
+      |> URI.to_string()
+
+    case get(client, full_url) do
+      {:ok, response} ->
+        case Ssz.from_ssz(response.body, SszTypes.BeaconState) do
+          {:ok, struct} ->
+            {:ok, struct}
+
+          {:error, error} ->
+            Logger.error("There has been an error syncing from checkpoint.")
+            {:error, error}
+        end
+
+      error ->
+        Logger.error("Invalid checkpoint sync url.")
+        {:error, error}
+    end
+  end
+end

--- a/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
@@ -7,6 +7,8 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
   alias LambdaEthereumConsensus.StateTransition.{EpochProcessing, Misc}
   alias SszTypes.{Checkpoint, SignedBeaconBlock, Store}
 
+  import LambdaEthereumConsensus.Utils, only: [if_then_update: 3]
+
   ### Public API ###
 
   @doc """
@@ -191,7 +193,4 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
     slots_per_epoch = ChainSpec.get("SLOTS_PER_EPOCH")
     slot - div(slot, slots_per_epoch) * slots_per_epoch
   end
-
-  defp if_then_update(value, true, fun), do: fun.(value)
-  defp if_then_update(value, false, _fun), do: value
 end

--- a/lib/lambda_ethereum_consensus/fork_choice/supervisor.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/supervisor.ex
@@ -4,9 +4,9 @@ defmodule LambdaEthereumConsensus.ForkChoice do
   use Supervisor
   require Logger
 
+  alias LambdaEthereumConsensus.ForkChoice.CheckpointSync
   alias LambdaEthereumConsensus.P2P.BlockDownloader
   alias LambdaEthereumConsensus.Store.{BlockStore, StateStore}
-  alias LambdaEthereumConsensus.Utils
 
   def start_link(opts) do
     Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
@@ -31,7 +31,7 @@ defmodule LambdaEthereumConsensus.ForkChoice do
   def init([checkpoint_url]) do
     Logger.info("[Sync] Initiating checkpoint sync.")
 
-    case Utils.sync_from_checkpoint(checkpoint_url) do
+    case CheckpointSync.sync_from_checkpoint(checkpoint_url) do
       {:ok, %SszTypes.BeaconState{} = anchor_state} ->
         Logger.info("[Checkpoint sync] Received beacon state at slot #{anchor_state.slot}.")
 

--- a/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
@@ -7,6 +7,8 @@ defmodule LambdaEthereumConsensus.StateTransition do
   alias LambdaEthereumConsensus.StateTransition.EpochProcessing
   alias SszTypes.{BeaconBlockHeader, BeaconState, SignedBeaconBlock}
 
+  import LambdaEthereumConsensus.Utils, only: [if_then_update: 3, map: 2]
+
   @spec state_transition(BeaconState.t(), SignedBeaconBlock.t(), boolean()) ::
           {:ok, BeaconState.t()} | {:error, String.t()}
   def state_transition(
@@ -113,10 +115,4 @@ defmodule LambdaEthereumConsensus.StateTransition do
 
   # TODO: implement
   defp process_block(state, _block), do: state
-
-  defp if_then_update(value, true, fun), do: fun.(value)
-  defp if_then_update(value, false, _fun), do: value
-
-  defp map({:ok, value}, fun), do: fun.(value)
-  defp map({:error, _} = err, _fun), do: err
 end

--- a/lib/lambda_ethereum_consensus/utils.ex
+++ b/lib/lambda_ethereum_consensus/utils.ex
@@ -2,41 +2,4 @@ defmodule LambdaEthereumConsensus.Utils do
   @moduledoc """
   Set of utility functions used throughout the project
   """
-  require Logger
-
-  use Tesla
-  plug(Tesla.Middleware.JSON)
-
-  @doc """
-  Syncs the node using an inputed checkpoint
-  """
-  @spec sync_from_checkpoint(binary) :: {:ok, SszTypes.BeaconState.t()} | {:error, any}
-  def sync_from_checkpoint(url) do
-    client =
-      Tesla.client([
-        {Tesla.Middleware.Headers, [{"Accept", "application/octet-stream"}]}
-      ])
-
-    full_url =
-      url
-      |> URI.parse()
-      |> URI.append_path("/eth/v2/debug/beacon/states/finalized")
-      |> URI.to_string()
-
-    case get(client, full_url) do
-      {:ok, response} ->
-        case Ssz.from_ssz(response.body, SszTypes.BeaconState) do
-          {:ok, struct} ->
-            {:ok, struct}
-
-          {:error, error} ->
-            Logger.error("There has been an error syncing from checkpoint.")
-            {:error, error}
-        end
-
-      error ->
-        Logger.error("Invalid checkpoint sync url.")
-        {:error, error}
-    end
-  end
 end

--- a/lib/lambda_ethereum_consensus/utils.ex
+++ b/lib/lambda_ethereum_consensus/utils.ex
@@ -1,5 +1,21 @@
 defmodule LambdaEthereumConsensus.Utils do
   @moduledoc """
-  Set of utility functions used throughout the project
+  Set of utility functions used throughout the project.
   """
+
+  @doc """
+  If ``condition`` is true, run ``fun`` on ``value`` and return the result.
+  Else return the unmodified ``value``.
+  """
+  @spec if_then_update(any(), boolean(), (any() -> any())) :: any()
+  def if_then_update(value, true, fun), do: fun.(value)
+  def if_then_update(value, false, _fun), do: value
+
+  @doc """
+  If first arg is an ``{:ok, value}`` tuple, apply ``fun`` to ``value`` and
+  return the result. Else, if it's an ``{:error, _}`` tuple, returns it.
+  """
+  @spec map({:ok | :error, any()}, (any() -> any())) :: any() | {:error, any()}
+  def map({:ok, value}, fun), do: fun.(value)
+  def map({:error, _} = err, _fun), do: err
 end


### PR DESCRIPTION
Depends on #392

This PR [moves the checkpoint-sync functions to a new module](https://github.com/lambdaclass/lambda_ethereum_consensus/commit/d0af2b70ac27689ff19cfbdb0dcf211b5ee966ac) and [moves some functions used in state processing into the `Utils` module](https://github.com/lambdaclass/lambda_ethereum_consensus/commit/c5a59816cf3f85868e4b014cab0d9ac77f229a8c).