### PR TITLE
feat: add optimistic block sync from checkpoint.

### DIFF
--- a/lib/lambda_ethereum_consensus/application.ex
+++ b/lib/lambda_ethereum_consensus/application.ex
@@ -31,6 +31,7 @@ defmodule LambdaEthereumConsensus.Application do
       {LambdaEthereumConsensus.P2P.IncomingRequests, []},
       {LambdaEthereumConsensus.ForkChoice, [Keyword.get(args, :checkpoint_sync)]},
       {LambdaEthereumConsensus.Beacon.PendingBlocks, []},
+      {LambdaEthereumConsensus.Beacon.SyncBlocks, []},
       {LambdaEthereumConsensus.P2P.GossipSub, []},
       # Start the Endpoint (http/https)
       {BeaconApi.Endpoint, []}

--- a/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
+++ b/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
@@ -82,15 +82,7 @@ defmodule LambdaEthereumConsensus.Beacon.PendingBlocks do
             nil
 
           true ->
-            case BlockDownloader.request_block_by_root(block.parent_root) do
-              {:ok, signed_block} ->
-                Logger.info("Block downloaded: #{signed_block.message.slot}")
-                add_block(signed_block)
-
-              {:error, reason} ->
-                Logger.debug("Block download failed: '#{reason}'")
-            end
-
+            download_block(block.parent_root)
             nil
         end
       end)
@@ -102,6 +94,17 @@ defmodule LambdaEthereumConsensus.Beacon.PendingBlocks do
   ##########################
   ### Private Functions
   ##########################
+
+  defp download_block(block_root) do
+    case BlockDownloader.request_block_by_root(block_root) do
+      {:ok, signed_block} ->
+        Logger.info("Block downloaded: #{signed_block.message.slot}")
+        add_block(signed_block)
+
+      {:error, reason} ->
+        Logger.debug("Block download failed: '#{reason}'")
+    end
+  end
 
   defp schedule_blocks_processing do
     Process.send_after(self(), :process_blocks, 1000)

--- a/lib/lambda_ethereum_consensus/beacon/sync_blocks.ex
+++ b/lib/lambda_ethereum_consensus/beacon/sync_blocks.ex
@@ -21,9 +21,6 @@ defmodule LambdaEthereumConsensus.Beacon.SyncBlocks do
   end
 
   def run(_opts) do
-    # TODO: this is a hack to make sure the on_tick has been called at least once
-    Process.sleep(2000)
-
     {:ok, checkpoint} = Store.get_finalized_checkpoint()
 
     initial_slot = Misc.compute_start_slot_at_epoch(checkpoint.epoch)

--- a/lib/lambda_ethereum_consensus/beacon/sync_blocks.ex
+++ b/lib/lambda_ethereum_consensus/beacon/sync_blocks.ex
@@ -1,0 +1,121 @@
+defmodule LambdaEthereumConsensus.Beacon.SyncBlocks do
+  @moduledoc false
+
+  use GenServer
+
+  require Logger
+
+  alias LambdaEthereumConsensus.Beacon.PendingBlocks
+  alias LambdaEthereumConsensus.ForkChoice.Store
+  alias LambdaEthereumConsensus.P2P.BlockDownloader
+  alias LambdaEthereumConsensus.StateTransition.Misc
+
+  @blocks_per_chunk 20
+
+  @type state :: %{
+          chunks: [%{from: integer(), count: integer()}]
+        }
+
+  ##########################
+  ### Public API
+  ##########################
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  ##########################
+  ### GenServer Callbacks
+  ##########################
+
+  @impl GenServer
+  @spec init(any) :: {:ok, state()}
+  def init(_opts) do
+    schedule_sync()
+
+    # TODO: this is a hack to make sure the on_tick has been called at least once
+    Process.sleep(2000)
+
+    {:ok, checkpoint} = Store.get_finalized_checkpoint()
+
+    initial_slot = Misc.compute_start_slot_at_epoch(checkpoint.epoch)
+    last_slot = Store.get_current_slot()
+
+    Logger.info(
+      "Syncing from slot #{initial_slot} to #{last_slot}, count: #{last_slot - initial_slot + 1}"
+    )
+
+    chunks =
+      Enum.chunk_every(initial_slot..last_slot, @blocks_per_chunk)
+      |> Enum.map(fn chunk ->
+        first_slot = List.first(chunk)
+        last_slot = List.last(chunk)
+        count = last_slot - first_slot + 1
+        %{from: first_slot, count: count}
+      end)
+
+    {:ok, %{chunks: chunks}}
+  end
+
+  @impl GenServer
+  @spec handle_info(:sync, state()) :: {:noreply, state()}
+  def handle_info(:sync, %{chunks: chunks}) do
+    Logger.info("Syncing. Blocks remaining: #{Enum.count(chunks) * @blocks_per_chunk}")
+
+    results =
+      chunks
+      |> Task.async_stream(
+        fn chunk -> fetch_blocks_by_slot(chunk.from, chunk.count) end,
+        max_concurrency: 20,
+        timeout: 20_000,
+        on_timeout: :kill_task
+      )
+      |> Enum.map(fn
+        {:ok, result} -> result
+        {:error, error} -> {:error, error}
+        {:exit, :timeout} -> {:error, "timeout"}
+      end)
+
+    results
+    |> Enum.filter(fn result -> match?({:ok, _}, result) end)
+    |> Enum.map(fn {:ok, blocks} -> blocks end)
+    |> List.flatten()
+    |> Enum.each(&PendingBlocks.add_block/1)
+
+    remaining_chunks =
+      Enum.zip(chunks, results)
+      |> Enum.filter(fn {_chunk, result} -> match?({:error, _}, result) end)
+      |> Enum.map(fn {chunk, _} -> chunk end)
+
+    if not Enum.empty?(remaining_chunks) do
+      schedule_sync()
+    end
+
+    {:noreply,
+     %{
+       chunks: remaining_chunks
+     }}
+  end
+
+  @spec fetch_blocks_by_slot(non_neg_integer(), integer()) ::
+          {:ok, [SszTypes.SignedBeaconBlock]} | {:error, any()}
+  def fetch_blocks_by_slot(from, count) do
+    case BlockDownloader.request_blocks_by_slot(from, count, 0) do
+      {:ok, blocks} ->
+        {:ok, blocks}
+
+      {:error, error} ->
+        if not String.contains?(inspect(error), "failed to dial") do
+          Logger.warning(
+            "Blocks download failed for slot #{from} count #{count} Error: #{inspect(error)}"
+          )
+        end
+
+        {:error, error}
+    end
+  end
+
+  defp schedule_sync do
+    Process.send_after(self(), :sync, 1_000)
+  end
+end

--- a/lib/lambda_ethereum_consensus/beacon/sync_blocks.ex
+++ b/lib/lambda_ethereum_consensus/beacon/sync_blocks.ex
@@ -41,10 +41,6 @@ defmodule LambdaEthereumConsensus.Beacon.SyncBlocks do
     initial_slot = Misc.compute_start_slot_at_epoch(checkpoint.epoch)
     last_slot = Store.get_current_slot()
 
-    Logger.info(
-      "Syncing from slot #{initial_slot} to #{last_slot}, count: #{last_slot - initial_slot + 1}"
-    )
-
     chunks =
       Enum.chunk_every(initial_slot..last_slot, @blocks_per_chunk)
       |> Enum.map(fn chunk ->
@@ -60,7 +56,7 @@ defmodule LambdaEthereumConsensus.Beacon.SyncBlocks do
   @impl GenServer
   @spec handle_info(:sync, state()) :: {:noreply, state()}
   def handle_info(:sync, %{chunks: chunks}) do
-    Logger.info("Syncing. Blocks remaining: #{Enum.count(chunks) * @blocks_per_chunk}")
+    Logger.info("[Optimistic Sync] Blocks remaining: #{Enum.count(chunks) * @blocks_per_chunk}")
 
     results =
       chunks
@@ -98,7 +94,7 @@ defmodule LambdaEthereumConsensus.Beacon.SyncBlocks do
   end
 
   @spec fetch_blocks_by_slot(non_neg_integer(), integer()) ::
-          {:ok, [SszTypes.SignedBeaconBlock]} | {:error, any()}
+          {:ok, [SszTypes.SignedBeaconBlock]} | {:error, binary()}
   def fetch_blocks_by_slot(from, count) do
     case BlockDownloader.request_blocks_by_slot(from, count, 0) do
       {:ok, blocks} ->

--- a/lib/lambda_ethereum_consensus/beacon/sync_blocks.ex
+++ b/lib/lambda_ethereum_consensus/beacon/sync_blocks.ex
@@ -78,8 +78,8 @@ defmodule LambdaEthereumConsensus.Beacon.SyncBlocks do
     end
   end
 
-  @spec fetch_blocks_by_slot(non_neg_integer(), integer()) ::
-          {:ok, [SszTypes.SignedBeaconBlock]} | {:error, binary()}
+  @spec fetch_blocks_by_slot(SszTypes.slot(), non_neg_integer()) ::
+          {:ok, [SszTypes.SignedBeaconBlock.t()]} | {:error, String.t()}
   def fetch_blocks_by_slot(from, count) do
     case BlockDownloader.request_blocks_by_slot(from, count, 0) do
       {:ok, blocks} ->

--- a/lib/lambda_ethereum_consensus/fork_choice/store.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/store.ex
@@ -78,7 +78,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Store do
 
   @impl GenServer
   def handle_cast({:on_block, block_root, signed_block}, state) do
-    Logger.info("[Fork choice] Adding block #{block_root} to the store.")
+    Logger.info("[Fork choice] Adding block #{signed_block.message.slot} to the store.")
 
     state =
       case Handlers.on_block(state, signed_block) do
@@ -86,6 +86,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Store do
           Map.put(state, :blocks, Map.put(state.blocks, block_root, signed_block.message))
 
         _ ->
+          Logger.error("Failed to add block #{signed_block.message.slot} to the store.")
           state
       end
 

--- a/lib/lambda_ethereum_consensus/p2p/block_downloader.ex
+++ b/lib/lambda_ethereum_consensus/p2p/block_downloader.ex
@@ -136,12 +136,8 @@ defmodule LambdaEthereumConsensus.P2P.BlockDownloader do
         {:error, "unexpected EOF"}
 
       <<0, ^fork_context::binary-size(4)>> <> rest ->
-        result = rest |> :binary.split(<<0, fork_context::binary-size(4)>>, [:global])
-
-        case result do
-          chunks when length(chunks) == count -> {:ok, chunks}
-          _ -> {:error, "expected #{count} chunks, got #{length(result)}"}
-        end
+        chunks = rest |> :binary.split(<<0, fork_context::binary-size(4)>>, [:global])
+        {:ok, chunks}
 
       <<0, wrong_context::binary-size(4)>> <> _ ->
         {:error, "wrong context: #{Base.encode16(wrong_context)}"}


### PR DESCRIPTION
**Motivation**
When syncing from checkpoint, we are a couple of hundred blocks behind. Instead of relying on Pending Blocks to download parents one by one, let's optimistically download blocks from the checkpoint sync slot.

**Description**
Added `SyncBlocks` module a task that is triggered on application start that downloads all blocks from the last checkpoint sync to the current slot.

