### PR TITLE
fix: reduce `SyncBlocks` max concurrency

### DIFF
--- a/lib/lambda_ethereum_consensus/beacon/sync_blocks.ex
+++ b/lib/lambda_ethereum_consensus/beacon/sync_blocks.ex
@@ -46,7 +46,7 @@ defmodule LambdaEthereumConsensus.Beacon.SyncBlocks do
       chunks
       |> Task.async_stream(
         fn chunk -> fetch_blocks_by_slot(chunk.from, chunk.count) end,
-        max_concurrency: 20,
+        max_concurrency: 4,
         timeout: 20_000,
         on_timeout: :kill_task
       )


### PR DESCRIPTION
We currently have a bottleneck on `Libp2pPort`. This PR reduces the amount of concurrent requests used when syncing, to avoid hogging the limited network resources.