### PR TITLE
fix: number of remaining blocks is rounded up

### DIFF
--- a/lib/lambda_ethereum_consensus/beacon/sync_blocks.ex
+++ b/lib/lambda_ethereum_consensus/beacon/sync_blocks.ex
@@ -40,7 +40,8 @@ defmodule LambdaEthereumConsensus.Beacon.SyncBlocks do
 
   @spec perform_sync([chunk()]) :: :ok
   def perform_sync(chunks) do
-    Logger.info("[Optimistic Sync] Blocks remaining: #{Enum.count(chunks) * @blocks_per_chunk}")
+    remaining = chunks |> Stream.map(fn %{count: c} -> c end) |> Enum.sum()
+    Logger.info("[Optimistic Sync] Blocks remaining: #{remaining}")
 
     results =
       chunks

--- a/lib/lambda_ethereum_consensus/fork_choice/store.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/store.ex
@@ -117,7 +117,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Store do
   @impl GenServer
   def handle_cast({:on_attestation, %Attestation{} = attestation}, %SszTypes.Store{} = state) do
     id = attestation.signature |> Base.encode16() |> String.slice(0, 8)
-    Logger.info("[Fork choice] Adding attestation #{id} to the store.")
+    Logger.debug("[Fork choice] Adding attestation #{id} to the store.")
 
     state =
       case Handlers.on_attestation(state, attestation, false) do


### PR DESCRIPTION
This PR fixes the "Remaining blocks: ..." message by counting the number of blocks remaining instead of approximating it. It also lowers the log level of attestation notifications to debug, since it's too spammy.