### PR TITLE
perf: ease the load to the fork choice GenServer.

### DIFF
--- a/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
+++ b/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
@@ -98,7 +98,14 @@ defmodule LambdaEthereumConsensus.Beacon.PendingBlocks do
 
         # If all the other conditions are false, add block to fork choice
         true ->
-          send_block_to_forkchoice(state, signed_block, block_root)
+          new_state = send_block_to_forkchoice(state, signed_block, block_root)
+
+          # When on checkpoint sync, we might accumulate a couple of hundred blocks in the pending blocks queue.
+          # This can cause the ForkChoie to timeout on other call requests since it has to process all the
+          # pending blocks first. TODO: find a better way to handle this
+          Process.sleep(100)
+
+          new_state
       end
     end)
     |> then(fn state ->
@@ -109,8 +116,11 @@ defmodule LambdaEthereumConsensus.Beacon.PendingBlocks do
 
   @impl true
   def handle_info(:download_blocks, state) do
+    blocks_in_store = state.blocks_to_download |> MapSet.filter(&Store.has_block?/1)
+
     downloaded_blocks =
       state.blocks_to_download
+      |> MapSet.difference(blocks_in_store)
       |> Enum.to_list()
       # max 20 blocks per request
       |> Enum.take(20)
@@ -120,7 +130,7 @@ defmodule LambdaEthereumConsensus.Beacon.PendingBlocks do
           signed_blocks
 
         {:error, reason} ->
-          Logger.warning("Block download failed: '#{reason}'")
+          Logger.debug("Block download failed: '#{reason}'")
           []
       end
 
@@ -129,7 +139,10 @@ defmodule LambdaEthereumConsensus.Beacon.PendingBlocks do
     end
 
     roots_to_remove =
-      downloaded_blocks |> Enum.map(&Ssz.hash_tree_root!(&1.message)) |> MapSet.new()
+      downloaded_blocks
+      |> Enum.map(&Ssz.hash_tree_root!(&1.message))
+      |> MapSet.new()
+      |> MapSet.union(blocks_in_store)
 
     schedule_blocks_download()
     {:noreply, Map.update!(state, :blocks_to_download, &MapSet.difference(&1, roots_to_remove))}

--- a/lib/lambda_ethereum_consensus/beacon/sync_blocks.ex
+++ b/lib/lambda_ethereum_consensus/beacon/sync_blocks.ex
@@ -85,7 +85,7 @@ defmodule LambdaEthereumConsensus.Beacon.SyncBlocks do
 
       {:error, error} ->
         if not String.contains?(inspect(error), "failed to dial") do
-          Logger.warning(
+          Logger.debug(
             "Blocks download failed for slot #{from} count #{count} Error: #{inspect(error)}"
           )
         end

--- a/lib/lambda_ethereum_consensus/fork_choice/store.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/store.ex
@@ -137,11 +137,11 @@ defmodule LambdaEthereumConsensus.ForkChoice.Store do
     id = attestation.signature |> Base.encode16() |> String.slice(0, 8)
     Logger.debug("[Fork choice] Adding attestation #{id} to the store.")
 
-    # state =
-    case Handlers.on_attestation(state, attestation, false) do
-      {:ok, new_state} -> new_state
-      _ -> state
-    end
+    state =
+      case Handlers.on_attestation(state, attestation, false) do
+        {:ok, new_state} -> new_state
+        _ -> state
+      end
 
     {:noreply, state}
   end

--- a/lib/lambda_ethereum_consensus/p2p/gossip_handler.ex
+++ b/lib/lambda_ethereum_consensus/p2p/gossip_handler.ex
@@ -35,9 +35,10 @@ defmodule LambdaEthereumConsensus.P2P.GossipHandler do
     slot = aggregate.data.slot
     root = aggregate.data.beacon_block_root |> Base.encode16()
 
-    Store.on_attestation(aggregate)
+    # We are getting ~500 attestations in half a second. This is overwheling the store GenServer at the moment.
+    # Store.on_attestation(aggregate)
 
-    Logger.debug(
+    Logger.info(
       "[Gossip] Aggregate decoded for slot #{slot}. Root: #{root}. Total attestations: #{votes}"
     )
   end

--- a/lib/lambda_ethereum_consensus/p2p/gossip_handler.ex
+++ b/lib/lambda_ethereum_consensus/p2p/gossip_handler.ex
@@ -38,7 +38,7 @@ defmodule LambdaEthereumConsensus.P2P.GossipHandler do
     # We are getting ~500 attestations in half a second. This is overwheling the store GenServer at the moment.
     # Store.on_attestation(aggregate)
 
-    Logger.info(
+    Logger.debug(
       "[Gossip] Aggregate decoded for slot #{slot}. Root: #{root}. Total attestations: #{votes}"
     )
   end

--- a/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
@@ -114,7 +114,7 @@ defmodule LambdaEthereumConsensus.StateTransition do
   end
 
   # TODO: uncomment when implemented
-  defp process_block(state, block) do
+  def process_block(state, block) do
     {:ok, state}
     # |> map(&Operations.process_block_header(&1, block))
     |> map(&Operations.process_withdrawals(&1, block.body.execution_payload))


### PR DESCRIPTION
**Motivation**
We're seeing that when there is a big load of messages to the `ForkChoice.Store` GenServer (typically a combination of ~500 attestations and ~100 blocks that are being synced) then some other call to the same server (for example, to get the current slot) ends up in 5000ms timeout.

**Description**
We need to think about how to we deal with this holistically. But in the meantime, I added a couple of hacks to ease the load.

Some questions:
- Do we really need to process 500 aggregated attestations per slot? (In one example for a single slot it meant 141416 attestations. That numbers times 32 is 4M, much more than the 0.8M of active validators on mainnet, if my math is right). 
- Should we create different GenServers to process attestations for example?
