### PR TITLE
fix: eternal `make lint` runs

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,7 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs:
+    (["{mix,.formatter}.exs", "{config,lib}/**/*.{ex,exs}"] ++
+       (Path.wildcard("test/*") -- ["test/generated"]))
+    |> Enum.map(&(&1 <> "/**/*.{ex,exs}"))
 ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,7 +1,6 @@
 # Used by "mix format"
 [
   inputs:
-    (["{mix,.formatter}.exs", "{config,lib}/**/*.{ex,exs}"] ++
-       (Path.wildcard("test/*") -- ["test/generated"]))
-    |> Enum.map(&(&1 <> "/**/*.{ex,exs}"))
+    ["{mix,.formatter}.exs", "{config,lib}/**/*.{ex,exs}"] ++
+      ((Path.wildcard("test/*") -- ["test/generated"]) |> Enum.map(&(&1 <> "/**/*.{ex,exs}")))
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -49,8 +49,8 @@ test/spec/vectors
 native/libp2p_port/libp2p_port
 
 # Proto generated code.
-lib/proto
-native/libp2p_port/internal/proto
+*.pb.ex
+*.pb.go
 
 # local db.
 level_db

--- a/Makefile
+++ b/Makefile
@@ -41,14 +41,14 @@ $(OUTPUT_DIR)/libp2p_nif.so: $(GO_ARCHIVES) $(GO_HEADERS) $(LIBP2P_DIR)/libp2p.c
 
 ### PORT
 
-PROTOBUF_EX_FILES := lib/proto/libp2p.pb.ex
+PROTOBUF_EX_FILES := proto/libp2p.pb.ex
 PROTOBUF_GO_FILES := native/libp2p_port/internal/proto/libp2p.pb.go
 
 $(PROTOBUF_GO_FILES): proto/libp2p.proto
 	protoc --go_out=./native/libp2p_port $<
 
 $(PROTOBUF_EX_FILES): proto/libp2p.proto
-	protoc --elixir_out=./lib $<
+	protoc --elixir_out=. $<
 
 PORT_SOURCES := $(shell find native/libp2p_port -type f)
 

--- a/mix.exs
+++ b/mix.exs
@@ -63,5 +63,5 @@ defmodule LambdaEthereumConsensus.MixProject do
   end
 
   defp compiler_paths(:test), do: ["test/spec", "test/fixtures"] ++ compiler_paths(:prod)
-  defp compiler_paths(_), do: ["lib"]
+  defp compiler_paths(_), do: ["lib", "proto"]
 end


### PR DESCRIPTION
This PR fixes the issue with `make lint` taking forever to run. This was because the formatter included generated test files. The solution was doing a partial expansion of the test folder, and excluding the `test/generated` folder from the matched paths.

Also, I moved the protobuf generated files to the `proto` directory, so the formatter and linter don't include them.