### PR TITLE
fix: allow some block downloads to fail

### DIFF
--- a/lib/lambda_ethereum_consensus/p2p/block_downloader.ex
+++ b/lib/lambda_ethereum_consensus/p2p/block_downloader.ex
@@ -168,7 +168,7 @@ defmodule LambdaEthereumConsensus.P2P.BlockDownloader do
       |> Enum.map(&decode_chunk/1)
       |> Enum.map(fn
         {:ok, block} -> block
-        {:error, reason} -> nil
+        {:error, _reason} -> nil
       end)
       |> Enum.filter(&(&1 != nil))
 

--- a/lib/lambda_ethereum_consensus/p2p/block_downloader.ex
+++ b/lib/lambda_ethereum_consensus/p2p/block_downloader.ex
@@ -163,17 +163,22 @@ defmodule LambdaEthereumConsensus.P2P.BlockDownloader do
 
   @spec decode_chunks([binary()]) :: {:ok, [SszTypes.SignedBeaconBlock.t()]} | {:error, binary()}
   defp decode_chunks(chunks) do
-    results =
+    blocks =
       chunks
       |> Enum.map(&decode_chunk/1)
+      |> Enum.map(fn
+        {:ok, block} -> block
+        {:error, reason} -> nil
+      end)
+      |> Enum.filter(&(&1 != nil))
 
-    if Enum.all?(results, fn
-         {:ok, _} -> true
-         _ -> false
-       end) do
-      {:ok, results |> Enum.map(fn {:ok, block} -> block end)}
-    else
-      {:error, "some decoding of chunks failed"}
+    case blocks do
+      [] ->
+        Logger.error("All blocks decoding failed")
+        {:error, "all blocks decoding failed"}
+
+      blocks ->
+        {:ok, blocks}
     end
   end
 


### PR DESCRIPTION
**Motivation**
Before, if you were requesting several blocks and there was one failure, all the request would be considered failed. Instead of that, just return the blocks that have been succesfull


