### PR TITLE
perf: optimize `process_rewards_and_penalties` (+fix)

### DIFF
--- a/lib/lambda_ethereum_consensus/state_transition/accessors.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/accessors.ex
@@ -383,7 +383,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Accessors do
   @spec get_block_root_at_slot(BeaconState.t(), SszTypes.slot()) ::
           {:ok, SszTypes.root()} | {:error, binary()}
   def get_block_root_at_slot(state, slot) do
-    if slot < state.slot && state.slot <= slot + ChainSpec.get("SLOTS_PER_HISTORICAL_ROOT") do
+    if slot < state.slot and state.slot <= slot + ChainSpec.get("SLOTS_PER_HISTORICAL_ROOT") do
       root = Enum.at(state.block_roots, rem(slot, ChainSpec.get("SLOTS_PER_HISTORICAL_ROOT")))
       {:ok, root}
     else

--- a/lib/lambda_ethereum_consensus/state_transition/epoch_processing.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/epoch_processing.ex
@@ -422,8 +422,6 @@ defmodule LambdaEthereumConsensus.StateTransition.EpochProcessing do
         )
 
       {:ok, new_state}
-    else
-      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/lib/lambda_ethereum_consensus/state_transition/misc.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/misc.ex
@@ -102,17 +102,11 @@ defmodule LambdaEthereumConsensus.StateTransition.Misc do
 
   @spec decrease_inactivity_score(SszTypes.uint64(), boolean, SszTypes.uint64()) ::
           SszTypes.uint64()
-  def decrease_inactivity_score(
-        inactivity_score,
-        state_is_in_inactivity_leak,
-        inactivity_score_recovery_rate
-      ) do
-    if state_is_in_inactivity_leak do
-      inactivity_score
-    else
-      inactivity_score - min(inactivity_score_recovery_rate, inactivity_score)
-    end
-  end
+  def decrease_inactivity_score(inactivity_score, true, _inactivity_score_recovery_rate),
+    do: inactivity_score
+
+  def decrease_inactivity_score(inactivity_score, false, inactivity_score_recovery_rate),
+    do: inactivity_score - min(inactivity_score_recovery_rate, inactivity_score)
 
   @spec update_inactivity_score(%{integer => SszTypes.uint64()}, integer, {SszTypes.uint64()}) ::
           SszTypes.uint64()

--- a/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
@@ -48,7 +48,7 @@ defmodule LambdaEthereumConsensus.StateTransition do
   def process_slots(%BeaconState{slot: old_slot} = state, slot) do
     slots_per_epoch = ChainSpec.get("SLOTS_PER_EPOCH")
 
-    Enum.reduce((old_slot + 1)..slot, {:ok, state}, fn next_slot, acc ->
+    Enum.reduce((old_slot + 1)..slot//1, {:ok, state}, fn next_slot, acc ->
       acc
       |> map(&process_slot/1)
       # Process epoch on the start slot of the next epoch
@@ -57,10 +57,8 @@ defmodule LambdaEthereumConsensus.StateTransition do
     end)
   end
 
-  defp maybe_process_epoch(%BeaconState{} = state, slot_in_epoch) when slot_in_epoch == 0,
-    do: {:ok, state}
-
-  defp maybe_process_epoch(%BeaconState{} = state, _slot_in_epoch), do: process_epoch(state)
+  defp maybe_process_epoch(%BeaconState{} = state, 0), do: process_epoch(state)
+  defp maybe_process_epoch(%BeaconState{} = state, _slot_in_epoch), do: {:ok, state}
 
   defp process_slot(%BeaconState{} = state) do
     # Cache state root

--- a/lib/ssz_types/beacon_chain/beacon_state.ex
+++ b/lib/ssz_types/beacon_chain/beacon_state.ex
@@ -117,14 +117,13 @@ defmodule SszTypes.BeaconState do
   @doc """
   Return the deltas for a given ``flag_index`` by scanning through the participation flags.
   """
-  @spec get_flag_index_deltas(t(), integer) :: {list(SszTypes.gwei()), list(SszTypes.gwei())}
-  def get_flag_index_deltas(state, flag_index) do
+  @spec get_flag_index_deltas(t(), integer(), integer()) ::
+          Enumerable.t({SszTypes.gwei(), SszTypes.gwei()})
+  def get_flag_index_deltas(state, weight, flag_index) do
     previous_epoch = Accessors.get_previous_epoch(state)
 
     {:ok, unslashed_participating_indices} =
       Accessors.get_unslashed_participating_indices(state, flag_index, previous_epoch)
-
-    weight = Enum.at(Constants.participation_flag_weights(), flag_index)
 
     unslashed_participating_balance =
       Accessors.get_total_balance(state, unslashed_participating_indices)
@@ -139,28 +138,33 @@ defmodule SszTypes.BeaconState do
 
     weight_denominator = Constants.weight_denominator()
 
-    penalties = rewards = List.duplicate(0, length(state.validators))
+    previous_epoch = Accessors.get_previous_epoch(state)
 
-    Accessors.get_eligible_validator_indices(state)
-    |> Enum.reduce({rewards, penalties}, fn index, {rewards, penalties} ->
-      base_reward = Accessors.get_base_reward(state, index)
-      is_unslashed = MapSet.member?(unslashed_participating_indices, index)
+    state.validators
+    |> Stream.with_index()
+    |> Stream.map(fn {validator, index} ->
+      if Predicates.is_eligible_validator(validator, previous_epoch) do
+        base_reward = Accessors.get_base_reward(state, index)
+        is_unslashed = MapSet.member?(unslashed_participating_indices, index)
 
-      cond do
-        is_unslashed and Predicates.is_in_inactivity_leak(state) ->
-          {rewards, penalties}
+        cond do
+          is_unslashed and Predicates.is_in_inactivity_leak(state) ->
+            {0, 0}
 
-        is_unslashed ->
-          reward_numerator = base_reward * weight * unslashed_participating_increments
-          reward = div(reward_numerator, active_increments * weight_denominator)
-          {List.update_at(rewards, index, &(&1 + reward)), penalties}
+          is_unslashed ->
+            reward_numerator = base_reward * weight * unslashed_participating_increments
+            reward = div(reward_numerator, active_increments * weight_denominator)
+            {reward, 0}
 
-        flag_index != Constants.timely_head_flag_index() ->
-          penalty = div(base_reward * weight, weight_denominator)
-          {rewards, List.update_at(penalties, index, &(&1 + penalty))}
+          flag_index != Constants.timely_head_flag_index() ->
+            penalty = div(base_reward * weight, weight_denominator)
+            {0, penalty}
 
-        true ->
-          {rewards, penalties}
+          true ->
+            {0, 0}
+        end
+      else
+        {0, 0}
       end
     end)
   end
@@ -171,34 +175,31 @@ defmodule SszTypes.BeaconState do
   """
   @spec get_inactivity_penalty_deltas(t()) :: {list(SszTypes.gwei()), list(SszTypes.gwei())}
   def get_inactivity_penalty_deltas(state) do
-    n_validator = length(state.validators)
-    rewards = List.duplicate(0, n_validator)
-    penalties = List.duplicate(0, n_validator)
     previous_epoch = Accessors.get_previous_epoch(state)
 
-    {:ok, unslashed_participating_indices} =
+    {:ok, matching_target_indices} =
       Accessors.get_unslashed_participating_indices(
         state,
         Constants.timely_target_flag_index(),
         previous_epoch
       )
 
-    matching_target_indices = MapSet.new(unslashed_participating_indices)
-
     penalty_denominator =
       ChainSpec.get("INACTIVITY_SCORE_BIAS") *
         ChainSpec.get("INACTIVITY_PENALTY_QUOTIENT_BELLATRIX")
 
-    state
-    |> Accessors.get_eligible_validator_indices()
-    |> Stream.filter(&(not MapSet.member?(matching_target_indices, &1)))
-    |> Enum.reduce({rewards, penalties}, fn index, {rw, pn} ->
-      penalty_numerator =
-        Enum.at(state.validators, index).effective_balance *
-          Enum.at(state.inactivity_scores, index)
-
-      penalty = div(penalty_numerator, penalty_denominator)
-      {rw, List.update_at(pn, index, &(&1 + penalty))}
+    state.validators
+    |> Stream.zip(state.inactivity_scores)
+    |> Stream.with_index()
+    |> Stream.map(fn {{validator, inactivity_score}, index} ->
+      if Predicates.is_eligible_validator(validator, previous_epoch) and
+           not MapSet.member?(matching_target_indices, index) do
+        penalty_numerator = validator.effective_balance * inactivity_score
+        penalty = div(penalty_numerator, penalty_denominator)
+        {0, penalty}
+      else
+        {0, 0}
+      end
     end)
   end
 end


### PR DESCRIPTION
This PR optimizes the `process_rewards_and_penalties` function so that it takes an acceptable amount of time to run. It also inverts the check in `maybe_process_epoch` so that `process_epoch` only runs on an epoch start, instead of on every slot that's not the start of an epoch.