### PR TITLE
fix: `process_execution_payload` hash tree root calculation

### DIFF
--- a/lib/lambda_ethereum_consensus/state_transition/operations.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/operations.ex
@@ -7,7 +7,6 @@ defmodule LambdaEthereumConsensus.StateTransition.Operations do
   alias LambdaEthereumConsensus.StateTransition.{Accessors, Misc, Mutators, Predicates}
   alias LambdaEthereumConsensus.Utils.BitVector
   alias SszTypes.BeaconBlockBody
-  alias LambdaEthereumConsensus.SszEx
 
   alias SszTypes.{
     Attestation,

--- a/lib/lambda_ethereum_consensus/state_transition/operations.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/operations.ex
@@ -7,6 +7,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Operations do
   alias LambdaEthereumConsensus.StateTransition.{Accessors, Misc, Mutators, Predicates}
   alias LambdaEthereumConsensus.Utils.BitVector
   alias SszTypes.BeaconBlockBody
+  alias LambdaEthereumConsensus.SszEx
 
   alias SszTypes.{
     Attestation,
@@ -277,9 +278,10 @@ defmodule LambdaEthereumConsensus.StateTransition.Operations do
                  SszTypes.Transaction
                ),
              {:ok, withdrawals_root} <-
-               Ssz.hash_list_tree_root(
+               Ssz.hash_list_tree_root_typed(
                  payload.withdrawals,
-                 ChainSpec.get("MAX_WITHDRAWALS_PER_PAYLOAD")
+                 ChainSpec.get("MAX_WITHDRAWALS_PER_PAYLOAD"),
+                 SszTypes.Withdrawal
                ) do
           {:ok,
            %BeaconState{

--- a/lib/lambda_ethereum_consensus/state_transition/operations.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/operations.ex
@@ -278,10 +278,9 @@ defmodule LambdaEthereumConsensus.StateTransition.Operations do
                  SszTypes.Transaction
                ),
              {:ok, withdrawals_root} <-
-               Ssz.hash_list_tree_root_typed(
+               Ssz.hash_list_tree_root(
                  payload.withdrawals,
-                 ChainSpec.get("MAX_WITHDRAWALS_PER_PAYLOAD"),
-                 SszTypes.Withdrawal
+                 ChainSpec.get("MAX_WITHDRAWALS_PER_PAYLOAD")
                ) do
           {:ok,
            %BeaconState{

--- a/lib/spec/runners/operations.ex
+++ b/lib/spec/runners/operations.ex
@@ -43,19 +43,28 @@ defmodule OperationsTestRunner do
   @disabled_handlers [
     # "attester_slashing",
     # "attestation",
-    # "deposit",
     # "block_header",
+    # "deposit",
     # "proposer_slashing",
     # "voluntary_exit",
     # "sync_aggregate",
-    "execution_payload"
+    # "execution_payload"
     # "withdrawals",
     # "bls_to_execution_change"
   ]
 
+  @disabled_cases [
+    "bad_parent_hash_first_payload"
+  ]
+
   @impl TestRunner
-  def skip?(%SpecTestCase{fork: fork, handler: handler}) do
-    fork != "capella" or Enum.member?(@disabled_handlers, handler)
+  def skip?(%SpecTestCase{fork: "capella", handler: handler, case: testcase}) do
+    Enum.member?(@disabled_handlers, handler) or Enum.member?(@disabled_cases, testcase)
+  end
+
+  @impl TestRunner
+  def skip?(_testcase) do
+    true
   end
 
   @impl TestRunner
@@ -89,14 +98,17 @@ defmodule OperationsTestRunner do
       YamlElixir.read_from_file!(case_dir <> "/execution.yaml")
       |> SpecTestUtils.sanitize_yaml()
 
-    new_state = Operations.process_execution_payload(pre, operation, execution_valid)
+    # dbg(pre.latest_execution_payload_header)
+    # dbg(operation)
+    # dbg(post.latest_execution_payload_header)
+    result = Operations.process_execution_payload(pre, operation, execution_valid)
 
-    case post do
-      nil ->
-        assert match?({:error, _message}, new_state)
+    case result do
+      {:ok, state} ->
+        assert Diff.diff(state, post) == :unchanged
 
-      _ ->
-        assert new_state == {:ok, post}
+      {:error, error} ->
+        assert post == nil, "Execution payload failed, error: #{error}"
     end
   end
 

--- a/lib/spec/runners/operations.ex
+++ b/lib/spec/runners/operations.ex
@@ -98,9 +98,6 @@ defmodule OperationsTestRunner do
       YamlElixir.read_from_file!(case_dir <> "/execution.yaml")
       |> SpecTestUtils.sanitize_yaml()
 
-    # dbg(pre.latest_execution_payload_header)
-    # dbg(operation)
-    # dbg(post.latest_execution_payload_header)
     result = Operations.process_execution_payload(pre, operation, execution_valid)
 
     case result do


### PR DESCRIPTION
**Description**
Hash tree root calculation has been fixed on https://github.com/lambdaclass/lambda_ethereum_consensus/pull/469, lets adapt the `process_execution_payload` function to use it.
