### PR TITLE
build: warnings on Elixir compilation should not pass the CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
       uses: Swatinem/rust-cache@v2
       with:
         workspaces: ${{ env.RUST_WORKSPACES }}
+    - name: Compile Elixir (Warnings as errors)
+      run: mix compile --warnings-as-errors
     - name: Retrieve PLT Cache
       uses: actions/cache@v1
       id: plt-cache


### PR DESCRIPTION
**Motivation**
Let's prevent warnings to slip into main

Also, `dialyzer` was performing the compilation anyway so this shouldn't take more time (also, it's better to have them separated for better debugging)

