### PR TITLE
fix: don't pre-calculate hashes in `weigh_justification_and_finalization`

### DIFF
--- a/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
@@ -172,7 +172,6 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
       |> update_checkpoints(state.current_justified_checkpoint, state.finalized_checkpoint)
       # Eagerly compute unrealized justification and finality
       |> compute_pulled_up_tip(block_root)
-      |> then(&{:ok, &1})
     end
   end
 
@@ -216,27 +215,29 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
     end)
   end
 
+  # Pull up the post-state of the block to the next epoch boundary
   def compute_pulled_up_tip(%Store{block_states: states} = store, block_root) do
-    # Pull up the post-state of the block to the next epoch boundary
-    # TODO: handle possible errors
-    {:ok, state} = EpochProcessing.process_justification_and_finalization(states[block_root])
+    result = EpochProcessing.process_justification_and_finalization(states[block_root])
 
-    block_epoch = Misc.compute_epoch_at_slot(store.blocks[block_root].slot)
-    current_epoch = store |> Store.get_current_slot() |> Misc.compute_epoch_at_slot()
+    with {:ok, state} <- result do
+      block_epoch = Misc.compute_epoch_at_slot(store.blocks[block_root].slot)
+      current_epoch = store |> Store.get_current_slot() |> Misc.compute_epoch_at_slot()
 
-    unrealized_justifications =
-      Map.put(store.unrealized_justifications, block_root, state.current_justified_checkpoint)
+      unrealized_justifications =
+        Map.put(store.unrealized_justifications, block_root, state.current_justified_checkpoint)
 
-    %Store{store | unrealized_justifications: unrealized_justifications}
-    |> update_unrealized_checkpoints(
-      state.current_justified_checkpoint,
-      state.finalized_checkpoint
-    )
-    |> if_then_update(
-      block_epoch < current_epoch,
-      # If the block is from a prior epoch, apply the realized values
-      &update_checkpoints(&1, state.current_justified_checkpoint, state.finalized_checkpoint)
-    )
+      %Store{store | unrealized_justifications: unrealized_justifications}
+      |> update_unrealized_checkpoints(
+        state.current_justified_checkpoint,
+        state.finalized_checkpoint
+      )
+      |> if_then_update(
+        block_epoch < current_epoch,
+        # If the block is from a prior epoch, apply the realized values
+        &update_checkpoints(&1, state.current_justified_checkpoint, state.finalized_checkpoint)
+      )
+      |> then(&{:ok, &1})
+    end
   end
 
   # Update unrealized checkpoints in store if necessary

--- a/lib/lambda_ethereum_consensus/state_transition/accessors.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/accessors.ex
@@ -120,7 +120,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Accessors do
   Return the current epoch.
   """
   @spec get_current_epoch(BeaconState.t()) :: SszTypes.epoch()
-  def get_current_epoch(%BeaconState{slot: slot} = _state) do
+  def get_current_epoch(%BeaconState{slot: slot}) do
     Misc.compute_epoch_at_slot(slot)
   end
 
@@ -373,8 +373,10 @@ defmodule LambdaEthereumConsensus.StateTransition.Accessors do
   @spec get_block_root_at_slot(BeaconState.t(), SszTypes.slot()) ::
           {:ok, SszTypes.root()} | {:error, binary()}
   def get_block_root_at_slot(state, slot) do
-    if slot < state.slot and state.slot <= slot + ChainSpec.get("SLOTS_PER_HISTORICAL_ROOT") do
-      root = Enum.at(state.block_roots, rem(slot, ChainSpec.get("SLOTS_PER_HISTORICAL_ROOT")))
+    slots_per_historical_root = ChainSpec.get("SLOTS_PER_HISTORICAL_ROOT")
+
+    if slot < state.slot and state.slot <= slot + slots_per_historical_root do
+      root = Enum.at(state.block_roots, rem(slot, slots_per_historical_root))
       {:ok, root}
     else
       {:error, "Block root not available"}

--- a/lib/spec/runners/fork_choice.ex
+++ b/lib/spec/runners/fork_choice.ex
@@ -12,27 +12,27 @@ defmodule ForkChoiceTestRunner do
 
   @disabled_on_block_cases [
     # "basic",
-    "incompatible_justification_update_end_of_epoch",
-    "incompatible_justification_update_start_of_epoch",
-    "justification_update_beginning_of_epoch",
-    "justification_update_end_of_epoch",
-    "justification_withholding",
-    "justification_withholding_reverse_order",
-    "justified_update_always_if_better",
-    "justified_update_monotonic",
-    "justified_update_not_realized_finality",
-    "new_finalized_slot_is_justified_checkpoint_ancestor",
-    "not_pull_up_current_epoch_block",
+    # "incompatible_justification_update_end_of_epoch",
+    # "incompatible_justification_update_start_of_epoch",
+    # "justification_update_beginning_of_epoch",
+    # "justification_update_end_of_epoch",
+    # "justification_withholding",
+    # "justification_withholding_reverse_order",
+    # "justified_update_always_if_better",
+    # "justified_update_monotonic",
+    # "justified_update_not_realized_finality",
+    # "new_finalized_slot_is_justified_checkpoint_ancestor",
+    # "not_pull_up_current_epoch_block",
     # "on_block_bad_parent_root",
-    "on_block_before_finalized",
-    "on_block_checkpoints",
-    "on_block_finalized_skip_slots",
-    "on_block_finalized_skip_slots_not_in_skip_chain",
+    # "on_block_before_finalized",
+    # "on_block_checkpoints",
+    # "on_block_finalized_skip_slots",
+    # "on_block_finalized_skip_slots_not_in_skip_chain",
     # "on_block_future_block",
     # "proposer_boost",
     # "proposer_boost_root_same_slot_untimely_block",
-    "pull_up_on_tick",
-    "pull_up_past_epoch_block"
+    # "pull_up_on_tick",
+    # "pull_up_past_epoch_block"
   ]
 
   @disabled_ex_ante_cases [
@@ -47,18 +47,18 @@ defmodule ForkChoiceTestRunner do
     # "chain_no_attestations",
     "discard_equivocations_on_attester_slashing",
     "discard_equivocations_slashed_validator_censoring",
-    "filtered_block_tree",
+    # "filtered_block_tree",
     # "genesis",
     "proposer_boost_correct_head",
     "shorter_chain_but_heavier_weight",
     "split_tie_breaker_no_attestations",
-    "voting_source_beyond_two_epoch",
+    # "voting_source_beyond_two_epoch",
     "voting_source_within_two_epoch"
   ]
 
   @disabled_reorg_cases [
-    "delayed_justification_current_epoch",
-    "delayed_justification_previous_epoch",
+    # "delayed_justification_current_epoch",
+    # "delayed_justification_previous_epoch",
     "include_votes_another_empty_chain_with_enough_ffg_votes_current_epoch",
     "include_votes_another_empty_chain_with_enough_ffg_votes_previous_epoch",
     "include_votes_another_empty_chain_without_enough_ffg_votes_current_epoch",
@@ -68,8 +68,8 @@ defmodule ForkChoiceTestRunner do
   ]
 
   @disabled_withholding_cases [
-    "withholding_attack",
-    "withholding_attack_unviable_honest_chain"
+    "withholding_attack"
+    # "withholding_attack_unviable_honest_chain"
   ]
 
   @impl TestRunner

--- a/lib/spec/runners/fork_choice.ex
+++ b/lib/spec/runners/fork_choice.ex
@@ -207,8 +207,4 @@ defmodule ForkChoiceTestRunner do
 
     {:ok, store}
   end
-
-  defp apply_step(_, _, _) do
-    {:error, "unknown step"}
-  end
 end

--- a/lib/spec/runners/sanity.ex
+++ b/lib/spec/runners/sanity.ex
@@ -40,22 +40,22 @@ defmodule SanityTestRunner do
     # "historical_batch",
     # "inactivity_scores_full_participation_leaking",
     # "inactivity_scores_leaking",
-    "invalid_all_zeroed_sig",
-    "invalid_duplicate_attester_slashing_same_block",
-    "invalid_duplicate_bls_changes_same_block",
+    # "invalid_all_zeroed_sig",
+    # "invalid_duplicate_attester_slashing_same_block",
+    # "invalid_duplicate_bls_changes_same_block",
     # "invalid_duplicate_deposit_same_block",
-    "invalid_duplicate_proposer_slashings_same_block",
-    "invalid_duplicate_validator_exit_same_block",
-    "invalid_incorrect_block_sig",
+    # "invalid_duplicate_proposer_slashings_same_block",
+    # "invalid_duplicate_validator_exit_same_block",
+    # "invalid_incorrect_block_sig",
     # "invalid_incorrect_proposer_index_sig_from_expected_proposer",
     # "invalid_incorrect_proposer_index_sig_from_proposer_index",
-    "invalid_incorrect_state_root",
+    # "invalid_incorrect_state_root",
     # "invalid_only_increase_deposit_count",
     # "invalid_parent_from_same_slot",
     # "invalid_prev_slot_block_transition",
     # "invalid_same_slot_block_transition",
-    "invalid_similar_proposer_slashings_same_block",
-    "invalid_two_bls_changes_of_different_addresses_same_validator_same_block",
+    # "invalid_similar_proposer_slashings_same_block",
+    # "invalid_two_bls_changes_of_different_addresses_same_validator_same_block",
     # "invalid_withdrawal_fail_second_block_payload_isnt_compatible",
     # "is_execution_enabled_false",
     # "many_partial_withdrawals_in_epoch_transition",
@@ -69,7 +69,7 @@ defmodule SanityTestRunner do
     # "proposer_slashing",
     # "skipped_slots",
     # "slash_and_exit_diff_index",
-    "slash_and_exit_same_index"
+    # "slash_and_exit_same_index"
     # "sync_committee_committee__empty",
     # "sync_committee_committee__full",
     # "sync_committee_committee__half",
@@ -87,8 +87,8 @@ defmodule SanityTestRunner do
     # "slots_1",
     # "slots_2",
     # "over_epoch_boundary",
-    "historical_accumulator",
-    "double_empty_epoch"
+    "historical_accumulator"
+    # "double_empty_epoch"
   ]
 
   @impl TestRunner

--- a/lib/spec/runners/sanity.ex
+++ b/lib/spec/runners/sanity.ex
@@ -87,6 +87,8 @@ defmodule SanityTestRunner do
     # "slots_1",
     # "slots_2",
     # "over_epoch_boundary",
+    # NOTE: this is too long to run in CI
+    # TODO: optimize
     "historical_accumulator"
     # "double_empty_epoch"
   ]

--- a/lib/spec/runners/sanity.ex
+++ b/lib/spec/runners/sanity.ex
@@ -87,7 +87,7 @@ defmodule SanityTestRunner do
     # "slots_1",
     # "slots_2",
     # "over_epoch_boundary",
-    # NOTE: this is too long to run in CI
+    # NOTE: too long to run in CI
     # TODO: optimize
     "historical_accumulator"
     # "double_empty_epoch"


### PR DESCRIPTION
We were pre-calculating block hashes with `Accessors.get_block_root` while also propagating any errors from those calls. This was a problem since those calls are done inline in the spec, and inside an `if`. If that branch wasn't taken, then our implementation would fail, differing from the spec's behavior.