### PR TITLE
fix: errors in `compute_proposer_index`

### DIFF
--- a/lib/constants.ex
+++ b/lib/constants.ex
@@ -1,81 +1,120 @@
 defmodule Constants do
   @moduledoc """
   Constants module with 0-arity functions.
+  The following values are (non-configurable) constants used throughout the specification.
   """
 
-  @spec genesis_epoch() :: integer
+  ### Misc
+
+  @spec genesis_epoch() :: SszTypes.slot()
   def genesis_epoch, do: 0
 
-  @spec genesis_slot() :: integer
+  @spec genesis_slot() :: SszTypes.slot()
   def genesis_slot, do: 0
 
-  @spec bls_withdrawal_prefix() :: <<_::8>>
+  @far_future_epoch 2 ** 64 - 1
+
+  @spec far_future_epoch() :: non_neg_integer()
+  def far_future_epoch, do: @far_future_epoch
+
+  @spec base_rewards_per_epoch() :: non_neg_integer()
+  def base_rewards_per_epoch, do: 4
+
+  @spec deposit_contract_tree_depth() :: non_neg_integer()
+  def deposit_contract_tree_depth, do: 32
+
+  @spec justification_bits_length() :: non_neg_integer()
+  def justification_bits_length, do: 4
+
+  @spec endianness() :: atom()
+  def endianness, do: :little
+
+  @spec participation_flag_weights() :: list(non_neg_integer())
+  def participation_flag_weights,
+    do: [timely_source_weight(), timely_target_weight(), timely_head_weight()]
+
+  ### Withdrawal prefixes
+
+  @spec bls_withdrawal_prefix() :: SszTypes.bytes1()
   def bls_withdrawal_prefix, do: <<0>>
 
-  @spec eth1_address_withdrawal_prefix() :: <<_::8>>
+  @spec eth1_address_withdrawal_prefix() :: SszTypes.bytes1()
   def eth1_address_withdrawal_prefix, do: <<1>>
 
-  @spec domain_beacon_attester() :: SszTypes.domain_type()
-  def domain_beacon_attester, do: <<1, 0, 0, 0>>
+  ### Domain types
 
   @spec domain_beacon_proposer() :: SszTypes.domain_type()
   def domain_beacon_proposer, do: <<0, 0, 0, 0>>
 
-  @spec domain_deposit() :: SszTypes.domain_type()
-  def domain_deposit, do: <<3, 0, 0, 0>>
+  @spec domain_beacon_attester() :: SszTypes.domain_type()
+  def domain_beacon_attester, do: <<1, 0, 0, 0>>
 
   @spec domain_randao() :: SszTypes.domain_type()
   def domain_randao, do: <<2, 0, 0, 0>>
 
-  @spec domain_sync_committee() :: SszTypes.domain_type()
-  def domain_sync_committee, do: <<7, 0, 0, 0>>
+  @spec domain_deposit() :: SszTypes.domain_type()
+  def domain_deposit, do: <<3, 0, 0, 0>>
 
   @spec domain_voluntary_exit() :: SszTypes.domain_type()
   def domain_voluntary_exit, do: <<4, 0, 0, 0>>
 
+  @spec domain_selection_proof() :: SszTypes.domain_type()
+  def domain_selection_proof, do: <<5, 0, 0, 0>>
+
+  @spec domain_aggregate_and_proof() :: SszTypes.domain_type()
+  def domain_aggregate_and_proof, do: <<6, 0, 0, 0>>
+
+  @spec domain_application_mask() :: SszTypes.domain_type()
+  def domain_application_mask, do: <<0, 0, 0, 1>>
+
+  @spec domain_sync_committee() :: SszTypes.domain_type()
+  def domain_sync_committee, do: <<7, 0, 0, 0>>
+
+  @spec domain_sync_committee_selection_proof() :: SszTypes.domain_type()
+  def domain_sync_committee_selection_proof, do: <<8, 0, 0, 0>>
+
+  @spec domain_contribution_and_proof() :: SszTypes.domain_type()
+  def domain_contribution_and_proof, do: <<9, 0, 0, 0>>
+
   @spec domain_bls_to_execution_change() :: SszTypes.domain_type()
   def domain_bls_to_execution_change, do: <<10, 0, 0, 0>>
 
-  @spec timely_source_flag_index() :: integer
+  ### Participation flag indices
+
+  @spec timely_source_flag_index() :: non_neg_integer()
   def timely_source_flag_index, do: 0
 
-  @spec timely_target_flag_index() :: integer
+  @spec timely_target_flag_index() :: non_neg_integer()
   def timely_target_flag_index, do: 1
 
-  @spec timely_head_flag_index() :: integer
+  @spec timely_head_flag_index() :: non_neg_integer()
   def timely_head_flag_index, do: 2
 
-  @spec proposer_weight() :: integer
-  def proposer_weight, do: 8
+  ### Incentivization weights
 
-  @spec sync_reward_weight() :: integer
-  def sync_reward_weight, do: 2
-
-  @spec weight_denominator() :: integer
-  def weight_denominator, do: 64
-
-  @spec participation_flag_weights() :: list(integer)
-  def participation_flag_weights,
-    do: [timely_source_weight(), timely_target_weight(), timely_head_weight()]
-
-  @spec base_reward_factor() :: integer
-  def base_reward_factor, do: 64
-
-  @spec timely_source_weight() :: integer
+  @spec timely_source_weight() :: non_neg_integer()
   def timely_source_weight, do: 14
 
-  @spec timely_target_weight() :: integer
+  @spec timely_target_weight() :: non_neg_integer()
   def timely_target_weight, do: 26
 
-  @spec timely_head_weight() :: integer
+  @spec timely_head_weight() :: non_neg_integer()
   def timely_head_weight, do: 14
 
-  @spec far_future_epoch() :: integer
-  def far_future_epoch, do: 2 ** 64 - 1
+  @spec sync_reward_weight() :: non_neg_integer()
+  def sync_reward_weight, do: 2
 
-  @spec deposit_contract_tree_depth() :: integer
-  def deposit_contract_tree_depth, do: 32
+  @spec proposer_weight() :: non_neg_integer()
+  def proposer_weight, do: 8
 
-  @spec intervals_per_slot() :: integer
+  @spec weight_denominator() :: non_neg_integer()
+  def weight_denominator, do: 64
+
+  ## Fork choice
+
+  @spec intervals_per_slot() :: non_neg_integer()
   def intervals_per_slot, do: 3
+
+  @spec proposer_score_boost() :: non_neg_integer()
+  def proposer_score_boost, do: 3
 end

--- a/lib/lambda_ethereum_consensus/state_transition/epoch_processing.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/epoch_processing.ex
@@ -95,9 +95,9 @@ defmodule LambdaEthereumConsensus.StateTransition.EpochProcessing do
     current_epoch = Accessors.get_current_epoch(state)
     next_epoch = current_epoch + 1
     epochs_per_historical_vector = ChainSpec.get("EPOCHS_PER_HISTORICAL_VECTOR")
-    random_mix = Accessors.get_randao_mix(state, current_epoch)
+    randao_mix = Accessors.get_randao_mix(state, current_epoch)
     index = rem(next_epoch, epochs_per_historical_vector)
-    new_randao_mixes = List.replace_at(randao_mixes, index, random_mix)
+    new_randao_mixes = List.replace_at(randao_mixes, index, randao_mix)
     new_state = %BeaconState{state | randao_mixes: new_randao_mixes}
     {:ok, new_state}
   end

--- a/lib/lambda_ethereum_consensus/state_transition/misc.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/misc.ex
@@ -8,6 +8,8 @@ defmodule LambdaEthereumConsensus.StateTransition.Misc do
   alias LambdaEthereumConsensus.SszEx
   alias SszTypes.BeaconState
 
+  @max_random_byte 2 ** 8 - 1
+
   @doc """
   Returns the Unix timestamp at the start of the given slot
   """
@@ -118,7 +120,6 @@ defmodule LambdaEthereumConsensus.StateTransition.Misc do
   def compute_proposer_index(_state, [], _seed), do: {:error, "Empty indices"}
 
   def compute_proposer_index(state, indices, seed) do
-    max_random_byte = 2 ** 8 - 1
     max_effective_balance = ChainSpec.get("MAX_EFFECTIVE_BALANCE")
     total = length(indices)
 
@@ -135,7 +136,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Misc do
       {effective_balance, random_byte, candidate_index}
     end)
     |> Stream.filter(fn {effective_balance, random_byte, _} ->
-      effective_balance * max_random_byte >= max_effective_balance * random_byte
+      effective_balance * @max_random_byte >= max_effective_balance * random_byte
     end)
     |> Enum.take(1)
     |> then(fn [{_, _, candidate_index}] -> {:ok, candidate_index} end)

--- a/lib/lambda_ethereum_consensus/state_transition/misc.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/misc.ex
@@ -59,7 +59,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Misc do
       flip = rem(pivot + index_count - current_index, index_count)
       position = max(current_index, flip)
 
-      position_div_256 = position |> div(256) |> uint_to_bytes4()
+      position_div_256 = position |> div(256) |> uint_to_bytes(32)
 
       source = SszEx.hash(seed <> <<round>> <> position_div_256)
 
@@ -129,7 +129,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Misc do
       candidate_index = Enum.at(indices, index)
 
       <<_::binary-size(rem(i, 32)), random_byte, _::binary>> =
-        SszEx.hash(seed <> uint_to_bytes4(div(i, 32)))
+        SszEx.hash(seed <> uint_to_bytes(div(i, 32), 64))
 
       effective_balance = Enum.at(state.validators, candidate_index).effective_balance
 
@@ -163,10 +163,10 @@ defmodule LambdaEthereumConsensus.StateTransition.Misc do
     first_8_bytes
   end
 
-  @spec uint_to_bytes4(integer()) :: SszTypes.bytes4()
-  def uint_to_bytes4(value) do
-    # Converts an unsigned integer value to a bytes 4 value
-    <<value::unsigned-integer-little-size(32)>>
+  @spec uint_to_bytes(non_neg_integer(), 8 | 32 | 64) :: binary()
+  def uint_to_bytes(value, size) do
+    # Converts an unsigned integer value to a bytes value
+    <<value::unsigned-integer-little-size(size)>>
   end
 
   @spec uint64_to_bytes(SszTypes.uint64()) :: <<_::64>>

--- a/lib/lambda_ethereum_consensus/state_transition/misc.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/misc.ex
@@ -145,8 +145,8 @@ defmodule LambdaEthereumConsensus.StateTransition.Misc do
     max_effective_balance = ChainSpec.get("MAX_EFFECTIVE_BALANCE")
 
     total = length(indices)
-    {:ok, i} = compute_shuffled_index(rem(i, total), total, seed)
-    candidate_index = Enum.at(indices, i)
+    {:ok, index} = compute_shuffled_index(rem(i, total), total, seed)
+    candidate_index = Enum.at(indices, index)
     random_byte = SszEx.hash(seed <> uint_to_bytes4(div(i, 32)))
     <<_::binary-size(rem(i, 32)), byte, _::binary>> = random_byte
 

--- a/lib/lambda_ethereum_consensus/state_transition/operations.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/operations.ex
@@ -191,7 +191,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Operations do
     effective_balance_increment = ChainSpec.get("EFFECTIVE_BALANCE_INCREMENT")
     total_active_increments = total_active_balance |> div(effective_balance_increment)
 
-    numerator = effective_balance_increment * Constants.base_reward_factor()
+    numerator = effective_balance_increment * ChainSpec.get("BASE_REWARD_FACTOR")
     denominator = Math.integer_squareroot(total_active_balance)
     base_reward_per_increment = div(numerator, denominator)
     total_base_rewards = base_reward_per_increment * total_active_increments

--- a/lib/spec/runners/random.ex
+++ b/lib/spec/runners/random.ex
@@ -7,22 +7,22 @@ defmodule RandomTestRunner do
   use TestRunner
 
   @disabled_cases [
-    "randomized_0",
+    # "randomized_0",
     # "randomized_1",
-    "randomized_2",
-    "randomized_3",
+    # "randomized_2",
+    # "randomized_3",
     # "randomized_4",
-    "randomized_5",
-    "randomized_6",
-    "randomized_7",
+    # "randomized_5",
+    # "randomized_6",
+    # "randomized_7",
     # "randomized_8",
     # "randomized_9",
-    "randomized_10",
+    # "randomized_10",
     # "randomized_11",
-    "randomized_12",
-    "randomized_13",
-    "randomized_14",
-    "randomized_15"
+    # "randomized_12",
+    # "randomized_13",
+    # "randomized_14",
+    # "randomized_15"
   ]
 
   @impl TestRunner

--- a/lib/spec/runners/sync.ex
+++ b/lib/spec/runners/sync.ex
@@ -7,6 +7,7 @@ defmodule SyncTestRunner do
   use TestRunner
 
   @disabled_cases [
+    # TODO: we have to support https://github.com/ethereum/consensus-specs/blob/dev/tests/formats/fork_choice/README.md#on_payload_info-execution-step
     "from_syncing_to_invalid"
   ]
 

--- a/lib/ssz_types/mod.ex
+++ b/lib/ssz_types/mod.ex
@@ -10,6 +10,7 @@ defmodule SszTypes do
   @type uint256 :: 0..unquote(2 ** 256 - 1)
 
   ## Binary types
+  @type bytes1 :: <<_::8>>
   @type bytes4 :: <<_::32>>
   @type bytes20 :: <<_::160>>
   @type bytes32 :: <<_::256>>


### PR DESCRIPTION
This fixes two different bugs:
- we were overwriting `i` with the value of `compute_shuffled_index` (be1f9ca13418cb0756080dc3303217e10534b265)
- we were using `uint_to_bytes4` instead of `uint_to_bytes8` (709dc942f6932d13cf85e965fdf6d3e7f1fe0853)

Also some refactors: be1f9ca13418cb0756080dc3303217e10534b265...f20b58080795a2c1c9bf088f0fa8953494a1c6d6

This makes all tests in the `random` runner pass 🚀 