### PR TITLE
fix: wrong head resolving in fork-choice spec-tests

### DIFF
--- a/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
@@ -336,7 +336,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
     message = %Checkpoint{epoch: target.epoch, root: beacon_block_root}
 
     attesting_indices
-    |> Stream.filter(&MapSet.member?(store.equivocating_indices, &1))
+    |> Stream.reject(&MapSet.member?(store.equivocating_indices, &1))
     |> Stream.filter(&(not Map.has_key?(messages, &1) or target.epoch > messages[&1].epoch))
     |> Enum.reduce(messages, &Map.put(&2, &1, message))
     |> then(&{:ok, %Store{store | latest_messages: &1}})

--- a/lib/lambda_ethereum_consensus/fork_choice/helpers.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/helpers.ex
@@ -74,18 +74,15 @@ defmodule LambdaEthereumConsensus.ForkChoice.Helpers do
   defp get_weight(%Store{} = store, root) do
     state = store.checkpoint_states[store.justified_checkpoint]
 
-    unslashed_and_active_indices =
-      Accessors.get_active_validator_indices(state, Accessors.get_current_epoch(state))
-      |> Enum.filter(fn i -> not Enum.at(state.validators, i).slashed end)
-
     attestation_score =
-      unslashed_and_active_indices
+      Accessors.get_active_validator_indices(state, Accessors.get_current_epoch(state))
+      |> Stream.reject(&Enum.at(state.validators, &1).slashed)
       |> Stream.filter(&Map.has_key?(store.latest_messages, &1))
-      |> Stream.filter(&(not MapSet.member?(store.equivocating_indices, &1)))
+      |> Stream.reject(&MapSet.member?(store.equivocating_indices, &1))
       |> Stream.filter(fn i ->
         Store.get_ancestor(store, store.latest_messages[i].root, store.blocks[root].slot) == root
       end)
-      |> Stream.map(fn i -> Enum.at(state.validators, i).effective_balance end)
+      |> Stream.map(&Enum.at(state.validators, &1).effective_balance)
       |> Enum.sum()
 
     if store.proposer_boost_root == <<0::256>> or

--- a/lib/lambda_ethereum_consensus/fork_choice/helpers.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/helpers.ex
@@ -61,7 +61,9 @@ defmodule LambdaEthereumConsensus.ForkChoice.Helpers do
       children =
         blocks
         |> Stream.filter(fn {_, block} -> block.parent_root == head end)
-        |> Enum.map(fn {root, _} -> root end)
+        |> Stream.map(fn {root, _} -> root end)
+        # Ties broken by favoring block with lexicographically higher root
+        |> Enum.sort(:desc)
 
       if Enum.empty?(children) do
         {:halt, head}

--- a/lib/lambda_ethereum_consensus/fork_choice/helpers.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/helpers.ex
@@ -65,7 +65,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Helpers do
       |> Enum.sort(:desc)
       |> then(fn
         [] -> {:halt, head}
-        c -> {:cont, Enum.max_by(c, fn root -> get_weight(store, root) end)}
+        c -> {:cont, Enum.max_by(c, &get_weight(store, &1))}
       end)
     end)
     |> then(&{:ok, &1})

--- a/lib/spec/runners/fork_choice.ex
+++ b/lib/spec/runners/fork_choice.ex
@@ -37,38 +37,38 @@ defmodule ForkChoiceTestRunner do
 
   @disabled_ex_ante_cases [
     # "ex_ante_attestations_is_greater_than_proposer_boost_with_boost",
-    "ex_ante_sandwich_with_boost_not_sufficient",
-    "ex_ante_sandwich_with_honest_attestation",
-    "ex_ante_sandwich_without_attestations"
+    # "ex_ante_sandwich_with_boost_not_sufficient",
+    # "ex_ante_sandwich_with_honest_attestation",
+    # "ex_ante_sandwich_without_attestations",
     # "ex_ante_vanilla"
   ]
 
   @disabled_get_head_cases [
     # "chain_no_attestations",
-    "discard_equivocations_on_attester_slashing",
-    "discard_equivocations_slashed_validator_censoring",
+    # "discard_equivocations_on_attester_slashing",
+    # "discard_equivocations_slashed_validator_censoring",
     # "filtered_block_tree",
     # "genesis",
-    "proposer_boost_correct_head",
-    "shorter_chain_but_heavier_weight",
-    "split_tie_breaker_no_attestations",
+    # "proposer_boost_correct_head",
+    # "shorter_chain_but_heavier_weight",
+    # "split_tie_breaker_no_attestations",
     # "voting_source_beyond_two_epoch",
-    "voting_source_within_two_epoch"
+    # "voting_source_within_two_epoch"
   ]
 
   @disabled_reorg_cases [
     # "delayed_justification_current_epoch",
     # "delayed_justification_previous_epoch",
-    "include_votes_another_empty_chain_with_enough_ffg_votes_current_epoch",
-    "include_votes_another_empty_chain_with_enough_ffg_votes_previous_epoch",
-    "include_votes_another_empty_chain_without_enough_ffg_votes_current_epoch",
-    "simple_attempted_reorg_delayed_justification_current_epoch",
-    "simple_attempted_reorg_delayed_justification_previous_epoch",
-    "simple_attempted_reorg_without_enough_ffg_votes"
+    # "include_votes_another_empty_chain_with_enough_ffg_votes_current_epoch",
+    # "include_votes_another_empty_chain_with_enough_ffg_votes_previous_epoch",
+    # "include_votes_another_empty_chain_without_enough_ffg_votes_current_epoch",
+    # "simple_attempted_reorg_delayed_justification_current_epoch",
+    # "simple_attempted_reorg_delayed_justification_previous_epoch",
+    # "simple_attempted_reorg_without_enough_ffg_votes"
   ]
 
   @disabled_withholding_cases [
-    "withholding_attack"
+    # "withholding_attack",
     # "withholding_attack_unviable_honest_chain"
   ]
 
@@ -81,9 +81,7 @@ defmodule ForkChoiceTestRunner do
       Enum.member?(@disabled_withholding_cases, testcase)
   end
 
-  def skip?(_testcase) do
-    true
-  end
+  def skip?(_testcase), do: true
 
   @impl TestRunner
   def run_test_case(testcase) do


### PR DESCRIPTION
Closes #449

This PR squashes two bugs:
- we weren't breaking ties correctly in `get_head` (5c909fcf8f2601220e25bf9ee341bf318d60652b)
- we had an inverted condition in `update_latest_messages` (32905327e42c0dff02a36e6ea809309d0430a390)

With this, all spec-tests for fork-choice run correctly 🥳 