### PR TITLE
perf: optimize `Misc.compute_committee` a bit

### DIFF
--- a/lib/lambda_ethereum_consensus/state_transition/misc.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/misc.ex
@@ -194,7 +194,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Misc do
       committee_start..committee_end//1
       |> Stream.map(&compute_shuffled_index(&1, index_count, seed))
       |> Stream.with_index()
-      |> Enum.reduce_while([], fn
+      |> Enum.reduce_while({:ok, []}, fn
         {{:ok, shuffled_index}, i}, {:ok, acc} ->
           {:cont, {:ok, [{shuffled_index, i} | acc]}}
 


### PR DESCRIPTION
This reduces the time of `process_attestation` by ~0.5s (~30%)