### PR TITLE
fix: status message handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ Or by a single runner in all configs, with:
 make spec-test-runner-`runner`
 
 # Some examples
-make spec-test-config-ssz_static
-make spec-test-config-bls
-make spec-test-config-operations
+make spec-test-runner-ssz_static
+make spec-test-runner-bls
+make spec-test-runner-operations
 ```
 
 The complete list of test runners can be found [here](https://github.com/ethereum/consensus-specs/tree/dev/tests/formats).

--- a/lib/lambda_ethereum_consensus/fork_choice/store.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/store.ex
@@ -96,7 +96,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Store do
 
   @impl GenServer
   def handle_call(:get_current_status_message, _from, state) do
-    {:reply, Helpers.current_status_message(state)}
+    {:reply, Helpers.current_status_message(state), state}
   end
 
   def handle_call({:get_block, block_root}, _from, state) do


### PR DESCRIPTION
**Description**

When I ran `make iex`, I got the error below:

```bash


14:41:45.843 [error] GenServer LambdaEthereumConsensus.ForkChoice.Store terminating
** (stop) bad return value: {:reply, {:ok, %SszTypes.StatusMessage{fork_digest: <<187, 164, 218, 150>>, finalized_root: <<238, 54, 2, 127, 35, 225, 4, 13, 165, 18, 215, 171, 29, 86, 84, 169, 94, 202, 243, 112, 26, 144, 8, 70, 232, 19, 235, 127, 37, 224, 135, 54>>, finalized_epoch: 241263, head_root: <<156, 160, 140, 200, 88, 234, 118, 115, 68, 6, 5, 16, 244, 87, 86, 48, 100, 15, 96, 248, 121, 156, 85, 118, 59, 226, 65, 230, 130, 34, 161, 1>>, head_slot: 7720480}}}
Last message (from #PID<0.827.0>): :get_current_status_message

14:41:45.854 [error] Task #PID<0.827.0> started from #PID<0.440.0> terminating
** (stop) exited in: GenServer.call(LambdaEthereumConsensus.ForkChoice.Store, :get_current_status_message, 10000)
    ** (EXIT) bad return value: {:reply, {:ok, %SszTypes.StatusMessage{fork_digest: <<187, 164, 218, 150>>, finalized_root: <<238, 54, 2, 127, 35, 225, 4, 13, 165, 18, 215, 171, 29, 86, 84, 169, 94, 202, 243, 112, 26, 144, 8, 70, 232, 19, 235, 127, 37, 224, 135, 54>>, finalized_epoch: 241263, head_root: <<156, 160, 140, 200, 88, 234, 118, 115, 68, 6, 5, 16, 244, 87, 86, 48, 100, 15, 96, 248, 121, 156, 85, 118, 59, 226, 65, 230, 130, 34, 161, 1>>, head_slot: 7720480}}}
    (elixir 1.15.6) lib/gen_server.ex:1074: GenServer.call/3
    (lambda_ethereum_consensus 0.1.0) lib/lambda_ethereum_consensus/p2p/incoming_requests/handler.ex:34: LambdaEthereumConsensus.P2P.IncomingRequests.Handler.handle_req/3
    (lambda_ethereum_consensus 0.1.0) lib/lambda_ethereum_consensus/p2p/incoming_requests/handler.ex:23: LambdaEthereumConsensus.P2P.IncomingRequests.Handler.handle/3
    (elixir 1.15.6) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
    (elixir 1.15.6) lib/task/supervised.ex:36: Task.Supervised.reply/4
Function: &LambdaEthereumConsensus.P2P.IncomingRequests.Handler.handle/3
    Args: ["status/1/ssz_snappy", "16Uiu2HAky-102-595", <<84, 255, 6, 0, 0, 115, 78, 97, 80, 112, 89, 1, 88, 0, 0, 235, 176, 126, 5, 187, 164, 218, 150, 61, 157, 17, 191, 226, 59, 58, 129, 206, 159, 24, 96, 181, 147, 85, 170, 214, 26, 28, 100, 246, 53, 76, 247, ...>>]
```

The issue was that the Genserver call to `current_status_message` was not returning the state.
