### PR TITLE
fix: allow not passing `--execution-jwt` flag

### DIFF
--- a/lib/lambda_ethereum_consensus/cli.ex
+++ b/lib/lambda_ethereum_consensus/cli.ex
@@ -24,7 +24,7 @@ defmodule LambdaEthereumConsensus.Cli do
   end
 
   defp init_engine_api_config(_endpoint, nil) do
-    Logger.error(
+    Logger.warning(
       "No jwt file provided. Please specify the path to fetch it from via the --execution-jwt flag."
     )
   end

--- a/lib/lambda_ethereum_consensus/cli.ex
+++ b/lib/lambda_ethereum_consensus/cli.ex
@@ -23,10 +23,14 @@ defmodule LambdaEthereumConsensus.Cli do
     args
   end
 
-  defp init_engine_api_config(_endpoint, nil) do
+  defp init_engine_api_config(endpoint, nil) do
     Logger.warning(
       "No jwt file provided. Please specify the path to fetch it from via the --execution-jwt flag."
     )
+
+    Application.fetch_env!(:lambda_ethereum_consensus, EngineApi)
+    |> then(&if endpoint, do: Keyword.put(&1, :endpoint, endpoint), else: &1)
+    |> then(&Application.put_env(:lambda_ethereum_consensus, EngineApi, &1))
   end
 
   defp init_engine_api_config(endpoint, jwt_path) do

--- a/lib/lambda_ethereum_consensus/cli.ex
+++ b/lib/lambda_ethereum_consensus/cli.ex
@@ -27,8 +27,6 @@ defmodule LambdaEthereumConsensus.Cli do
     Logger.error(
       "No jwt file provided. Please specify the path to fetch it from via the --execution-jwt flag."
     )
-
-    System.stop(1)
   end
 
   defp init_engine_api_config(endpoint, jwt_path) do


### PR DESCRIPTION
Currently, the Engine API isn't integrated into the rest of the node. This PR removes the `System.exit` call when `--execution-jwt` isn't specified. This is intended as a quick patch, and should ideally be solved in another way, like disabling the whole Engine API module when either the endpoint or JWT flags are unspecified (or when some special flag IS specified).