### PR TITLE
refactor: move config to runtime.exs.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -4,14 +4,6 @@ import Config
 # Configure logging
 config :logger, level: :info, truncate: :infinity
 
-config :lambda_ethereum_consensus, ChainSpec, config: MainnetConfig
-
-config :lambda_ethereum_consensus, LambdaEthereumConsensus.Execution.EngineApi,
-  endpoint: "http://localhost:8551",
-  version: "2.0",
-  # Will be set by CLI
-  jwt_secret: nil
-
 # Configures the phoenix endpoint
 config :lambda_ethereum_consensus, BeaconApi.Endpoint,
   http: [port: 4000],
@@ -21,8 +13,7 @@ config :lambda_ethereum_consensus, BeaconApi.Endpoint,
     layout: false
   ]
 
-# Configures peer discovery
-config :lambda_ethereum_consensus, :discovery, port: 9000
+config :lambda_ethereum_consensus, LambdaEthereumConsensus.Telemetry, enable: true
 
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,0 +1,43 @@
+import Config
+
+{args, _remaining_args, _errors} =
+  OptionParser.parse(System.argv(),
+    switches: [
+      network: :string,
+      checkpoint_sync: :string,
+      execution_endpoint: :string,
+      execution_jwt: :string
+    ]
+  )
+
+network = Keyword.get(args, :network, "mainnet")
+checkpoint_sync = Keyword.get(args, :checkpoint_sync)
+execution_endpoint = Keyword.get(args, :execution_endpoint, "http://localhost:8551")
+jwt_path = Keyword.get(args, :execution_jwt)
+
+config :lambda_ethereum_consensus, LambdaEthereumConsensus.ForkChoice,
+  checkpoint_sync: checkpoint_sync
+
+configs_per_network = %{
+  "minimal" => MinimalConfig,
+  "mainnet" => MainnetConfig
+}
+
+config :lambda_ethereum_consensus, ChainSpec, config: configs_per_network |> Map.fetch!(network)
+
+bootnodes = YamlElixir.read_from_file!("config/networks/#{network}/bootnodes.yaml")
+
+# Configures peer discovery
+config :lambda_ethereum_consensus, :discovery, port: 9000, bootnodes: bootnodes
+
+jwt_secret =
+  if jwt_path do
+    File.read!(jwt_path)
+  else
+    nil
+  end
+
+config :lambda_ethereum_consensus, LambdaEthereumConsensus.Execution.EngineApi,
+  endpoint: execution_endpoint,
+  jwt_secret: jwt_secret,
+  version: "2.0"

--- a/lib/lambda_ethereum_consensus/application.ex
+++ b/lib/lambda_ethereum_consensus/application.ex
@@ -6,12 +6,12 @@ defmodule LambdaEthereumConsensus.Application do
   use Application
   require Logger
 
-  alias LambdaEthereumConsensus.Cli
-
   @impl true
   def start(_type, _args) do
-    args = Cli.parse_args()
-    checkpoint_sync = Keyword.get(args, :checkpoint_sync)
+    checkpoint_sync =
+      Application.fetch_env!(:lambda_ethereum_consensus, LambdaEthereumConsensus.ForkChoice)[
+        :checkpoint_sync
+      ]
 
     config = Application.fetch_env!(:lambda_ethereum_consensus, :discovery)
     port = Keyword.fetch!(config, :port)


### PR DESCRIPTION
**Motivation**
Config should ideally be set in the config files. Before this change, we were changing config values in application.

**Description**
- The only bad part is that we're no longer logging when there are config values that are not valid. 

