### PR TITLE
perf: store `X_epoch_participation` and `balances` in vectors

### DIFF
--- a/lib/lambda_ethereum_consensus/fork_choice/supervisor.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/supervisor.ex
@@ -56,7 +56,7 @@ defmodule LambdaEthereumConsensus.ForkChoice do
   end
 
   defp init_children(anchor_state, anchor_block) do
-    Cache.initialize_tables()
+    Cache.initialize_cache()
 
     children = [
       {LambdaEthereumConsensus.ForkChoice.Store, {anchor_state, anchor_block}},

--- a/lib/lambda_ethereum_consensus/state_transition/accessors.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/accessors.ex
@@ -109,9 +109,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Accessors do
   def get_active_validator_indices(%BeaconState{validators: validators}, epoch) do
     validators
     |> Aja.Vector.with_index()
-    |> Aja.Vector.filter(fn {v, _} ->
-      Predicates.is_active_validator(v, epoch)
-    end)
+    |> Aja.Vector.filter(fn {v, _} -> Predicates.is_active_validator(v, epoch) end)
     |> Aja.Vector.map(fn {_, index} -> index end)
   end
 
@@ -154,14 +152,13 @@ defmodule LambdaEthereumConsensus.StateTransition.Accessors do
 
       participating_indices =
         state.validators
-        |> Stream.zip(epoch_participation)
-        |> Stream.with_index()
-        |> Stream.filter(fn {{v, _}, _} -> not v.slashed end)
-        |> Stream.filter(fn {{v, _}, _} -> Predicates.is_active_validator(v, epoch) end)
-        |> Stream.filter(fn {{_, participation}, _} ->
-          Predicates.has_flag(participation, flag_index)
+        |> Aja.Vector.zip_with(epoch_participation, fn v, participation ->
+          not v.slashed and Predicates.is_active_validator(v, epoch) and
+            Predicates.has_flag(participation, flag_index)
         end)
-        |> Stream.map(fn {{_, _}, index} -> index end)
+        |> Aja.Vector.with_index()
+        |> Aja.Vector.filter(&elem(&1, 0))
+        |> Aja.Vector.map(fn {true, index} -> index end)
         |> MapSet.new()
 
       {:ok, participating_indices}
@@ -294,21 +291,23 @@ defmodule LambdaEthereumConsensus.StateTransition.Accessors do
 
     compute_fn = fn ->
       committees_per_slot = get_committee_count_per_slot(state, epoch)
-      indices = get_active_validator_indices(state, epoch)
-      seed = get_seed(state, epoch, Constants.domain_beacon_attester())
-
-      committee_index =
-        rem(slot, ChainSpec.get("SLOTS_PER_EPOCH")) * committees_per_slot + index
-
-      committee_count = committees_per_slot * ChainSpec.get("SLOTS_PER_EPOCH")
-
-      Misc.compute_committee(indices, seed, committee_index, committee_count)
+      {committees_per_slot, get_active_validator_indices(state, epoch)}
     end
 
-    case get_epoch_root(state, epoch) do
-      {:ok, root} -> Cache.lazily_compute(:beacon_committee, {slot, index, root}, compute_fn)
-      _ -> compute_fn.()
-    end
+    {committees_per_slot, indices} =
+      case get_epoch_root(state, epoch) do
+        {:ok, root} -> Cache.lazily_compute(:beacon_committee, {epoch, root}, compute_fn)
+        _ -> compute_fn.()
+      end
+
+    seed = get_seed(state, epoch, Constants.domain_beacon_attester())
+
+    committee_index =
+      rem(slot, ChainSpec.get("SLOTS_PER_EPOCH")) * committees_per_slot + index
+
+    committee_count = committees_per_slot * ChainSpec.get("SLOTS_PER_EPOCH")
+
+    Misc.compute_committee(indices, seed, committee_index, committee_count)
   end
 
   @spec get_base_reward_per_increment(BeaconState.t()) :: Types.gwei()

--- a/lib/lambda_ethereum_consensus/state_transition/cache.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/cache.ex
@@ -7,13 +7,15 @@ defmodule LambdaEthereumConsensus.StateTransition.Cache do
     :total_active_balance,
     :beacon_proposer_index,
     :active_validator_count,
-    :beacon_committee
+    :beacon_committee,
+    :active_validator_indices
   ]
 
-  @spec initialize_tables() :: :ok
-  def initialize_tables do
-    @tables |> Enum.each(&init_table/1)
-  end
+  @spec initialize_cache() :: :ok
+  def initialize_cache, do: @tables |> Enum.each(&init_table/1)
+
+  @spec clear_cache() :: :ok
+  def clear_cache, do: @tables |> Enum.each(&:ets.delete_all_objects/1)
 
   @spec init_table(:ets.table()) :: :ok
   def init_table(table) do

--- a/lib/lambda_ethereum_consensus/state_transition/epoch_processing.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/epoch_processing.ex
@@ -194,7 +194,7 @@ defmodule LambdaEthereumConsensus.StateTransition.EpochProcessing do
     %BeaconState{current_epoch_participation: current_epoch_participation, validators: validators} =
       state
 
-    new_current_epoch_participation = for _ <- validators, do: 0
+    new_current_epoch_participation = Aja.Vector.duplicate(0, Aja.Vector.size(validators))
 
     new_state = %BeaconState{
       state

--- a/lib/lambda_ethereum_consensus/state_transition/mutators.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/mutators.ex
@@ -195,8 +195,8 @@ defmodule LambdaEthereumConsensus.StateTransition.Mutators do
         state
         | validators: &1,
           balances: state.balances ++ [amount],
-          previous_epoch_participation: state.previous_epoch_participation ++ [0],
-          current_epoch_participation: state.current_epoch_participation ++ [0],
+          previous_epoch_participation: Aja.Vector.append(state.previous_epoch_participation, 0),
+          current_epoch_participation: Aja.Vector.append(state.current_epoch_participation, 0),
           inactivity_scores: state.inactivity_scores ++ [0]
       }
     )

--- a/lib/lambda_ethereum_consensus/state_transition/mutators.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/mutators.ex
@@ -8,24 +8,6 @@ defmodule LambdaEthereumConsensus.StateTransition.Mutators do
   alias Types.Validator
 
   @doc """
-    Increase the validator balance at index ``index`` by ``delta``.
-  """
-  @spec increase_balance(BeaconState.t(), Types.validator_index(), Types.gwei()) ::
-          BeaconState.t()
-  def increase_balance(%BeaconState{balances: balances} = state, index, delta) do
-    %BeaconState{state | balances: List.update_at(balances, index, &(&1 + delta))}
-  end
-
-  @doc """
-      Decrease the validator balance at index ``index`` by ``delta``, with underflow protection.
-  """
-  @spec decrease_balance(BeaconState.t(), Types.validator_index(), Types.gwei()) ::
-          BeaconState.t()
-  def decrease_balance(%BeaconState{balances: balances} = state, index, delta) do
-    %BeaconState{state | balances: List.update_at(balances, index, &max(&1 - delta, 0))}
-  end
-
-  @doc """
   Initiate the exit of the validator with index ``index``.
   """
   @spec initiate_validator_exit(BeaconState.t(), integer()) ::
@@ -115,9 +97,12 @@ defmodule LambdaEthereumConsensus.StateTransition.Mutators do
       # Decrease slashers balance, apply proposer and whistleblower rewards
       {:ok,
        state
-       |> decrease_balance(slashed_index, slashing_penalty)
-       |> increase_balance(proposer_index, proposer_reward)
-       |> increase_balance(whistleblower_index, whistleblower_reward - proposer_reward)}
+       |> BeaconState.decrease_balance(slashed_index, slashing_penalty)
+       |> BeaconState.increase_balance(proposer_index, proposer_reward)
+       |> BeaconState.increase_balance(
+         whistleblower_index,
+         whistleblower_reward - proposer_reward
+       )}
     end
   end
 
@@ -166,7 +151,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Mutators do
   def apply_deposit(state, pubkey, withdrawal_credentials, amount, signature) do
     case Enum.find_index(state.validators, fn validator -> validator.pubkey == pubkey end) do
       index when is_number(index) ->
-        {:ok, increase_balance(state, index, amount)}
+        {:ok, BeaconState.increase_balance(state, index, amount)}
 
       _ ->
         deposit_message = %Types.DepositMessage{
@@ -194,7 +179,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Mutators do
       &%BeaconState{
         state
         | validators: &1,
-          balances: state.balances ++ [amount],
+          balances: Aja.Vector.append(state.balances, amount),
           previous_epoch_participation: Aja.Vector.append(state.previous_epoch_participation, 0),
           current_epoch_participation: Aja.Vector.append(state.current_epoch_participation, 0),
           inactivity_scores: state.inactivity_scores ++ [0]

--- a/lib/lambda_ethereum_consensus/state_transition/operations.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/operations.ex
@@ -158,7 +158,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Operations do
         |> Stream.map(&add_proposer_reward(&1, proposer_index, total_proposer_reward))
         |> Enum.map_reduce(committee_deltas, &update_balance/2)
 
-      {:ok, %BeaconState{state | balances: new_balances}}
+      {:ok, %BeaconState{state | balances: Aja.Vector.new(new_balances)}}
     end
   end
 
@@ -353,7 +353,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Operations do
     state.balances
     |> Stream.with_index()
     |> Enum.map_reduce(withdrawals, &maybe_decrease_balance/2)
-    |> then(fn {balances, []} -> %BeaconState{state | balances: balances} end)
+    |> then(fn {balances, []} -> %BeaconState{state | balances: Aja.Vector.new(balances)} end)
   end
 
   defp maybe_decrease_balance({balance, index}, [
@@ -653,7 +653,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Operations do
 
       {:ok,
        %BeaconState{
-         Mutators.increase_balance(state, proposer_index, proposer_reward)
+         BeaconState.increase_balance(state, proposer_index, proposer_reward)
          | previous_epoch_participation: new_previous_participation,
            current_epoch_participation: new_current_participation
        }}

--- a/lib/mix/tasks/generate_spec_tests.ex
+++ b/lib/mix/tasks/generate_spec_tests.ex
@@ -68,7 +68,7 @@ defmodule Mix.Tasks.GenerateSpecTests do
       end
 
       setup do
-        LambdaEthereumConsensus.StateTransition.Cache.initialize_tables()
+        LambdaEthereumConsensus.StateTransition.Cache.initialize_cache()
       end
     """
 

--- a/lib/spec/runners/rewards.ex
+++ b/lib/spec/runners/rewards.ex
@@ -60,7 +60,9 @@ defmodule RewardsTestRunner do
     inactivity_penalty_deltas = Enum.zip(rewards, penalties)
 
     deltas =
-      Enum.zip([source_deltas, target_deltas, head_deltas, inactivity_penalty_deltas])
+      [source_deltas, target_deltas, head_deltas, inactivity_penalty_deltas]
+      |> Stream.map(&Enum.map(&1, fn {reward, penalty} -> reward - penalty end))
+      |> Enum.zip()
 
     calculated_deltas =
       Constants.participation_flag_weights()

--- a/lib/spec/runners/ssz_static.ex
+++ b/lib/spec/runners/ssz_static.ex
@@ -63,25 +63,21 @@ defmodule SszStaticTestRunner do
     Stream.zip(actual, expected) |> Enum.map(fn {a, e} -> to_struct_checked(a, e) end)
   end
 
+  defp to_struct_checked(%Aja.Vector{} = actual, %Aja.Vector{} = expected) do
+    actual
+    |> Aja.Vector.to_list()
+    |> to_struct_checked(Aja.Vector.to_list(expected))
+    |> Aja.Vector.new()
+  end
+
   defp to_struct_checked(%name{} = actual, %{} = expected) do
     expected
-    |> Stream.map(&parse_map_entry(&1, actual))
+    |> Stream.map(fn {k, v} -> {k, to_struct_checked(Map.get(actual, k), v)} end)
     |> Map.new()
     |> then(&struct!(name, &1))
   end
 
   defp to_struct_checked(_actual, expected), do: expected
-
-  defp parse_map_entry({:validators = k, v}, actual) do
-    actual
-    |> Map.get(k)
-    |> Aja.Vector.to_list()
-    |> to_struct_checked(Aja.Vector.to_list(v))
-    |> Aja.Vector.new()
-    |> then(&{k, &1})
-  end
-
-  defp parse_map_entry({k, v}, actual), do: {k, to_struct_checked(Map.get(actual, k), v)}
 
   defp parse_type(%SpecTestCase{handler: handler}) do
     Module.concat(Types, handler)

--- a/lib/spec/runners/ssz_static.ex
+++ b/lib/spec/runners/ssz_static.ex
@@ -6,6 +6,7 @@ defmodule SszStaticTestRunner do
 
   use ExUnit.CaseTemplate
   use TestRunner
+  import Aja
 
   @disabled [
     "ContributionAndProof",
@@ -63,14 +64,10 @@ defmodule SszStaticTestRunner do
     Stream.zip(actual, expected) |> Enum.map(fn {a, e} -> to_struct_checked(a, e) end)
   end
 
-  # We are matching against an opaque struct, so dialyzer complains.
-  # However, we have no other way of doing this.
-  # TODO: remove if/when https://github.com/sabiwara/aja/pull/4 is merged
-  @dialyzer {:no_opaque, to_struct_checked: 2}
-  defp to_struct_checked(%Aja.Vector{} = actual, %Aja.Vector{} = expected) do
+  defp to_struct_checked(vec(_) = actual, vec(_) = expected) do
     actual
-    |> Aja.Vector.to_list()
-    |> to_struct_checked(Aja.Vector.to_list(expected))
+    |> Aja.Enum.to_list()
+    |> to_struct_checked(Aja.Enum.to_list(expected))
     |> Aja.Vector.new()
   end
 

--- a/lib/spec/runners/ssz_static.ex
+++ b/lib/spec/runners/ssz_static.ex
@@ -63,6 +63,10 @@ defmodule SszStaticTestRunner do
     Stream.zip(actual, expected) |> Enum.map(fn {a, e} -> to_struct_checked(a, e) end)
   end
 
+  # We are matching against an opaque struct, so dialyzer complains.
+  # However, we have no other way of doing this.
+  # TODO: remove if/when https://github.com/sabiwara/aja/pull/4 is merged
+  @dialyzer {:no_opaque, to_struct_checked: 2}
   defp to_struct_checked(%Aja.Vector{} = actual, %Aja.Vector{} = expected) do
     actual
     |> Aja.Vector.to_list()

--- a/lib/spec/utils.ex
+++ b/lib/spec/utils.ex
@@ -5,6 +5,7 @@ defmodule SpecTestUtils do
   alias LambdaEthereumConsensus.SszEx
 
   @vectors_dir Path.join(["test", "spec", "vectors", "tests"])
+  @vector_keys ["validators"]
 
   def vectors_dir, do: @vectors_dir
 
@@ -32,8 +33,8 @@ defmodule SpecTestUtils do
   def sanitize_yaml({"transactions", list}),
     do: {:transactions, Enum.map(list, &parse_as_string/1)}
 
-  def sanitize_yaml({"validators", list}) do
-    {:validators, list |> Stream.map(&sanitize_yaml/1) |> Aja.Vector.new()}
+  def sanitize_yaml({k, list}) when k in @vector_keys do
+    {String.to_atom(k), list |> Stream.map(&sanitize_yaml/1) |> Aja.Vector.new()}
   end
 
   def sanitize_yaml({k, v}), do: {String.to_atom(k), sanitize_yaml(v)}

--- a/lib/spec/utils.ex
+++ b/lib/spec/utils.ex
@@ -5,7 +5,12 @@ defmodule SpecTestUtils do
   alias LambdaEthereumConsensus.SszEx
 
   @vectors_dir Path.join(["test", "spec", "vectors", "tests"])
-  @vector_keys ["validators"]
+  @vector_keys [
+    "validators",
+    "balances",
+    "previous_epoch_participation",
+    "current_epoch_participation"
+  ]
 
   def vectors_dir, do: @vectors_dir
 

--- a/lib/types/beacon_chain/beacon_state.ex
+++ b/lib/types/beacon_chain/beacon_state.ex
@@ -167,30 +167,26 @@ defmodule Types.BeaconState do
 
       cond do
         is_unslashed and Predicates.is_in_inactivity_leak(state) ->
-          {0, 0}
+          0
 
         is_unslashed ->
           reward_numerator = base_reward * weight * unslashed_participating_increments
-          reward = div(reward_numerator, active_increments * weight_denominator)
-          {reward, 0}
+          div(reward_numerator, active_increments * weight_denominator)
 
         flag_index != Constants.timely_head_flag_index() ->
-          penalty = div(base_reward * weight, weight_denominator)
-          {0, penalty}
+          -div(base_reward * weight, weight_denominator)
 
         true ->
-          {0, 0}
+          0
       end
     end
 
     state.validators
     |> Stream.with_index()
     |> Stream.map(fn {validator, index} ->
-      if Predicates.is_eligible_validator(validator, previous_epoch) do
-        process_reward_and_penalty.(index)
-      else
-        {0, 0}
-      end
+      if Predicates.is_eligible_validator(validator, previous_epoch),
+        do: process_reward_and_penalty.(index),
+        else: 0
     end)
   end
 
@@ -217,10 +213,9 @@ defmodule Types.BeaconState do
       if Predicates.is_eligible_validator(validator, previous_epoch) and
            not MapSet.member?(matching_target_indices, index) do
         penalty_numerator = validator.effective_balance * inactivity_score
-        penalty = div(penalty_numerator, penalty_denominator)
-        {0, penalty}
+        -div(penalty_numerator, penalty_denominator)
       else
-        {0, 0}
+        0
       end
     end)
   end

--- a/lib/types/beacon_chain/beacon_state.ex
+++ b/lib/types/beacon_chain/beacon_state.ex
@@ -196,13 +196,10 @@ defmodule Types.BeaconState do
   @spec get_inactivity_penalty_deltas(t()) :: Enumerable.t({Types.gwei(), Types.gwei()})
   def get_inactivity_penalty_deltas(%__MODULE__{} = state) do
     previous_epoch = Accessors.get_previous_epoch(state)
+    target_index = Constants.timely_target_flag_index()
 
     {:ok, matching_target_indices} =
-      Accessors.get_unslashed_participating_indices(
-        state,
-        Constants.timely_target_flag_index(),
-        previous_epoch
-      )
+      Accessors.get_unslashed_participating_indices(state, target_index, previous_epoch)
 
     penalty_denominator =
       ChainSpec.get("INACTIVITY_SCORE_BIAS") *

--- a/lib/types/beacon_chain/beacon_state.ex
+++ b/lib/types/beacon_chain/beacon_state.ex
@@ -63,8 +63,8 @@ defmodule Types.BeaconState do
           # Per-epoch sums of slashed effective balances
           slashings: list(Types.gwei()),
           # Participation
-          previous_epoch_participation: list(Types.participation_flags()),
-          current_epoch_participation: list(Types.participation_flags()),
+          previous_epoch_participation: Aja.Vector.t(Types.participation_flags()),
+          current_epoch_participation: Aja.Vector.t(Types.participation_flags()),
           # Finality
           # Bit set for every recent justified epoch
           justification_bits: Types.bitvector(),
@@ -94,13 +94,17 @@ defmodule Types.BeaconState do
 
   def encode(%__MODULE__{} = map) do
     map
-    |> Map.update!(:validators, &Enum.to_list/1)
+    |> Map.update!(:validators, &Aja.Vector.to_list/1)
+    |> Map.update!(:previous_epoch_participation, &Aja.Vector.to_list/1)
+    |> Map.update!(:current_epoch_participation, &Aja.Vector.to_list/1)
     |> Map.update!(:latest_execution_payload_header, &Types.ExecutionPayloadHeader.encode/1)
   end
 
   def decode(%__MODULE__{} = map) do
     map
     |> Map.update!(:validators, &Aja.Vector.new/1)
+    |> Map.update!(:previous_epoch_participation, &Aja.Vector.new/1)
+    |> Map.update!(:current_epoch_participation, &Aja.Vector.new/1)
     |> Map.update!(:latest_execution_payload_header, &Types.ExecutionPayloadHeader.decode/1)
   end
 

--- a/lib/utils/diff.ex
+++ b/lib/utils/diff.ex
@@ -28,9 +28,11 @@ defmodule LambdaEthereumConsensus.Utils.Diff do
   @type base_diff :: %{optional(:left) => any(), optional(:right) => any()}
   @type t :: :unchanged | base_diff() | structured_diff()
 
+  import Aja
+
   @spec diff(any(), any()) :: t()
-  def diff(%Aja.Vector{} = a, %Aja.Vector{} = b) do
-    diff(Enum.to_list(a), Enum.to_list(b))
+  def diff(vec(_) = a, vec(_) = b) do
+    diff(Aja.Enum.to_list(a), Aja.Enum.to_list(b))
   end
 
   def diff(a, b) when is_map(a) and is_map(b) do

--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,7 @@ defmodule LambdaEthereumConsensus.MixProject do
       {:patch, "~> 0.12.0", only: [:test]},
       {:stream_data, "~> 0.5", only: [:test]},
       {:benchee, "~> 1.2", only: [:dev]},
-      {:aja, "~> 0.6.2"},
+      {:aja, "~> 0.6"},
       {:dialyxir, "~> 1.1", only: [:dev, :test], runtime: false},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false}
     ]


### PR DESCRIPTION
This reduces whole block processing time to ~10.5s