### PR TITLE
perf: optimize `process_justification_and_finalization`

### DIFF
--- a/lib/lambda_ethereum_consensus/state_transition/accessors.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/accessors.ex
@@ -174,23 +174,6 @@ defmodule LambdaEthereumConsensus.StateTransition.Accessors do
     end
   end
 
-  def get_total_participating_balance(state, flag_index, epoch) do
-    epoch_participation =
-      if epoch == get_current_epoch(state) do
-        state.current_epoch_participation
-      else
-        state.previous_epoch_participation
-      end
-
-    state.validators
-    |> Aja.Vector.zip_with(epoch_participation, fn v, participation ->
-      {not v.slashed and Predicates.is_active_validator(v, epoch) and
-         Predicates.has_flag(participation, flag_index), v.effective_balance}
-    end)
-    |> Aja.Vector.filter(&elem(&1, 0))
-    |> Aja.Enum.reduce(0, fn {true, balance}, acc -> acc + balance end)
-  end
-
   @doc """
   Return the randao mix at a recent ``epoch``.
   """

--- a/lib/lambda_ethereum_consensus/state_transition/mutators.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/mutators.ex
@@ -147,7 +147,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Mutators do
           Types.bytes32(),
           Types.uint64(),
           Types.bls_signature()
-        ) :: {:ok, BeaconState.t()} | {:error, binary()}
+        ) :: {:ok, BeaconState.t()} | {:error, String.t()}
   def apply_deposit(state, pubkey, withdrawal_credentials, amount, signature) do
     case Enum.find_index(state.validators, fn validator -> validator.pubkey == pubkey end) do
       index when is_number(index) ->

--- a/lib/lambda_ethereum_consensus/state_transition/operations.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/operations.ex
@@ -535,7 +535,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Operations do
   Process voluntary exit.
   """
   @spec process_voluntary_exit(BeaconState.t(), Types.SignedVoluntaryExit.t()) ::
-          {:ok, BeaconState.t()} | {:error, binary()}
+          {:ok, BeaconState.t()} | {:error, String.t()}
   def process_voluntary_exit(state, signed_voluntary_exit) do
     voluntary_exit = signed_voluntary_exit.message
     validator_index = voluntary_exit.validator_index
@@ -791,7 +791,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Operations do
   end
 
   @spec process_eth1_data(BeaconState.t(), BeaconBlockBody.t()) ::
-          {:ok, BeaconState.t()} | {:error, binary}
+          {:ok, BeaconState.t()} | {:error, String.t()}
   def process_eth1_data(
         %BeaconState{} = state,
         %BeaconBlockBody{eth1_data: eth1_data}
@@ -936,7 +936,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Operations do
   end
 
   @spec process_operations(BeaconState.t(), BeaconBlockBody.t()) ::
-          {:ok, BeaconState.t()} | {:error, binary}
+          {:ok, BeaconState.t()} | {:error, String.t()}
   def process_operations(state, body) do
     # Ensure that outstanding deposits are processed up to the maximum number of deposits
     with :ok <- verify_deposits(state, body) do
@@ -957,7 +957,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Operations do
     end)
   end
 
-  @spec verify_deposits(BeaconState.t(), BeaconBlockBody.t()) :: :ok | {:error, binary}
+  @spec verify_deposits(BeaconState.t(), BeaconBlockBody.t()) :: :ok | {:error, String.t()}
   defp verify_deposits(state, body) do
     deposit_count = state.eth1_data.deposit_count - state.eth1_deposit_index
     deposit_limit = min(ChainSpec.get("MAX_DEPOSITS"), deposit_count)

--- a/lib/lambda_ethereum_consensus/state_transition/predicates.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/predicates.ex
@@ -69,7 +69,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Predicates do
   """
   @spec has_flag(Types.participation_flags(), integer) :: boolean
   def has_flag(participation_flags, flag_index) do
-    flag = 2 ** flag_index
+    flag = 1 <<< flag_index
     (participation_flags &&& flag) === flag
   end
 


### PR DESCRIPTION
This shaves ~0.6s off the block processing time. Briefly, it just replaces calls to `get_unslashed_participating_indices` and to `get_total_balance` with calls to a new function that merges both functions.