### PR TITLE
fix: process block attestations and slashings

### DIFF
--- a/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
@@ -88,22 +88,22 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
   @spec on_attestation(Store.t(), Attestation.t(), boolean()) ::
           {:ok, Store.t()} | {:error, String.t()}
   def on_attestation(%Store{} = store, %Attestation{} = attestation, is_from_block) do
-    if on_attestation_valid?(store, attestation, is_from_block) do
-      with {:ok, store} <- store_target_checkpoint_state(store, attestation.data.target),
-           # Get state at the `target` to fully validate attestation
-           target_state = store.checkpoint_states[attestation.data.target],
-           {:ok, indexed_attestation} <-
-             Accessors.get_indexed_attestation(target_state, attestation) do
-        if Predicates.is_valid_indexed_attestation(target_state, indexed_attestation) do
-          # Update latest messages for attesting indices
-          update_latest_messages(store, indexed_attestation.attesting_indices, attestation)
-        else
-          {:error, "invalid indexed attestation"}
-        end
-      end
-    else
-      {:error, "invalid on_attestation"}
+    with :ok <- check_attestation_valid(store, attestation, is_from_block),
+         {:ok, store} <- store_target_checkpoint_state(store, attestation.data.target),
+         # Get state at the `target` to fully validate attestation
+         target_state = store.checkpoint_states[attestation.data.target],
+         {:ok, indexed_attestation} <-
+           Accessors.get_indexed_attestation(target_state, attestation),
+         :ok <- check_valid_indexed_attestation(target_state, indexed_attestation) do
+      # Update latest messages for attesting indices
+      update_latest_messages(store, indexed_attestation.attesting_indices, attestation)
     end
+  end
+
+  defp check_valid_indexed_attestation(target_state, indexed_attestation) do
+    if Predicates.is_valid_indexed_attestation(target_state, indexed_attestation),
+      do: :ok,
+      else: {:error, "invalid indexed attestation"}
   end
 
   @doc """
@@ -265,35 +265,52 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
   end
 
   # Called ``validate_on_attestation`` in the spec.
-  defp on_attestation_valid?(store, attestation, is_from_block)
+  defp check_attestation_valid(store, attestation, is_from_block)
 
   # If the given attestation is not from a beacon block message, we have to check the target epoch scope.
-  defp on_attestation_valid?(%Store{} = store, %Attestation{} = attestation, false) do
-    target_epoch_against_current_time_valid?(store, attestation) and
-      on_attestation_valid?(store, attestation, true)
+  defp check_attestation_valid(%Store{} = store, %Attestation{} = attestation, false) do
+    with :ok <- target_epoch_against_current_time_valid?(store, attestation) do
+      check_attestation_valid(store, attestation, true)
+    end
   end
 
-  defp on_attestation_valid?(%Store{} = store, %Attestation{} = attestation, true) do
+  defp check_attestation_valid(%Store{} = store, %Attestation{} = attestation, true) do
     target = attestation.data.target
     block_root = attestation.data.beacon_block_root
 
     # NOTE: we use cond instead of an `and` chain for better formatting
     cond do
       # Check that the epoch number and slot number are matching
-      target.epoch != Misc.compute_epoch_at_slot(attestation.data.slot) -> false
+      target.epoch != Misc.compute_epoch_at_slot(attestation.data.slot) ->
+        {:error, "mismatched epoch and slot"}
+
       # Attestation target must be for a known block.
       # If target block is unknown, delay consideration until block is found
-      not Map.has_key?(store.blocks, target.root) -> false
+      # TODO: delay consideration until block is found
+      not Map.has_key?(store.blocks, target.root) ->
+        {:error, "unknown target block"}
+
       # Attestations must be for a known block. If block is unknown, delay consideration until the block is found
-      not Map.has_key?(store.blocks, block_root) -> false
+      # TODO: delay consideration until block is found
+      not Map.has_key?(store.blocks, block_root) ->
+        {:error, "unknown head block"}
+
       # Attestations must not be for blocks in the future. If not, the attestation should not be considered
-      store.blocks[block_root].slot > attestation.data.slot -> false
+      store.blocks[block_root].slot > attestation.data.slot ->
+        {:error, "future head block"}
+
       # LMD vote must be consistent with FFG vote target
-      target.root != Store.get_checkpoint_block(store, block_root, target.epoch) -> false
+      target.root != Store.get_checkpoint_block(store, block_root, target.epoch) ->
+        {:error, "mismatched head and target blocks"}
+
       # Attestations can only affect the fork choice of subsequent slots.
       # Delay consideration in the fork choice until their slot is in the past.
-      Store.get_current_slot(store) <= attestation.data.slot -> false
-      true -> true
+      # TODO: delay consideration
+      Store.get_current_slot(store) <= attestation.data.slot ->
+        {:error, "attestation is for a future slot"}
+
+      true ->
+        :ok
     end
   end
 
@@ -307,7 +324,8 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
     previous_epoch = max(current_epoch - 1, Constants.genesis_epoch())
 
     # If attestation target is from a future epoch, delay consideration until the epoch arrives
-    target.epoch in [current_epoch, previous_epoch]
+    # TODO: delay consideration until the epoch arrives
+    if target.epoch in [current_epoch, previous_epoch], do: :ok, else: {:error, "future epoch"}
   end
 
   # Store target checkpoint state if not yet seen

--- a/lib/lambda_ethereum_consensus/fork_choice/helpers.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/helpers.ex
@@ -33,12 +33,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Helpers do
     if anchor_block.state_root == anchor_state_root do
       anchor_epoch = Accessors.get_current_epoch(anchor_state)
 
-      finalized_checkpoint = %Checkpoint{
-        epoch: anchor_epoch,
-        root: anchor_block_root
-      }
-
-      justified_checkpoint = %Checkpoint{
+      anchor_checkpoint = %Checkpoint{
         epoch: anchor_epoch,
         root: anchor_block_root
       }
@@ -49,17 +44,17 @@ defmodule LambdaEthereumConsensus.ForkChoice.Helpers do
        %Store{
          time: time,
          genesis_time: anchor_state.genesis_time,
-         justified_checkpoint: justified_checkpoint,
-         finalized_checkpoint: finalized_checkpoint,
-         unrealized_justified_checkpoint: justified_checkpoint,
-         unrealized_finalized_checkpoint: finalized_checkpoint,
+         justified_checkpoint: anchor_checkpoint,
+         finalized_checkpoint: anchor_checkpoint,
+         unrealized_justified_checkpoint: anchor_checkpoint,
+         unrealized_finalized_checkpoint: anchor_checkpoint,
          proposer_boost_root: <<0::256>>,
          equivocating_indices: MapSet.new(),
          blocks: %{anchor_block_root => anchor_block},
          block_states: %{anchor_block_root => anchor_state},
-         checkpoint_states: %{justified_checkpoint => anchor_state},
+         checkpoint_states: %{anchor_checkpoint => anchor_state},
          latest_messages: %{},
-         unrealized_justifications: %{anchor_block_root => justified_checkpoint}
+         unrealized_justifications: %{anchor_block_root => anchor_checkpoint}
        }}
     else
       {:error, "Anchor block state root does not match anchor state root"}
@@ -89,7 +84,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Helpers do
   end
 
   defp get_weight(%Store{} = store, root) do
-    state = store.checkpoint_states[store.justified_checkpoint]
+    state = Map.fetch!(store.checkpoint_states, store.justified_checkpoint)
 
     # PERF: use ``Aja.Vector.foldl``
     attestation_score =

--- a/lib/lambda_ethereum_consensus/fork_choice/store.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/store.ex
@@ -117,6 +117,8 @@ defmodule LambdaEthereumConsensus.ForkChoice.Store do
            signed_block.message.body.attester_slashings
            |> apply_handler(new_store, &Handlers.on_attester_slashing/2) do
       BlockStore.store_block(signed_block)
+      {:ok, block_root} = BlockStore.get_block_root_by_slot(signed_block.message.slot)
+      Map.fetch!(new_store.block_states, block_root) |> StateStore.store_state()
       Logger.info("[Fork choice] Block #{signed_block.message.slot} added to the store.")
       {:reply, :ok, new_store}
     else

--- a/lib/lambda_ethereum_consensus/fork_choice/store.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/store.ex
@@ -36,9 +36,22 @@ defmodule LambdaEthereumConsensus.ForkChoice.Store do
     div(time - genesis_time, ChainSpec.get("SECONDS_PER_SLOT"))
   end
 
-  @spec get_current_status_message() :: {:ok, Types.StatusMessage.t()} | {:error, any}
+  @spec get_current_status_message() :: {:ok, Types.StatusMessage.t()} | {:error, String.t()}
   def get_current_status_message do
-    GenServer.call(__MODULE__, :get_current_status_message, @default_timeout)
+    # TODO: un-hardcode when get_head is optimized and/or cached
+    # GenServer.call(__MODULE__, :get_current_status_message, @default_timeout)
+
+    # hardcoded response from random peer
+    {:ok,
+     %Types.StatusMessage{
+       fork_digest: Base.decode16!("BBA4DA96"),
+       finalized_root:
+         Base.decode16!("7715794499C07D9954DD223EC2C6B846D3BAB27956D093000FADC1B8219F74D4"),
+       finalized_epoch: 228_168,
+       head_root:
+         Base.decode16!("D62A74AE0F933224133C5E6E1827A2835A1E705F0CDFEE3AD25808DDEA5572DB"),
+       head_slot: 7_301_450
+     }}
   end
 
   @spec has_block?(Types.root()) :: boolean()

--- a/lib/lambda_ethereum_consensus/fork_choice/store.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/store.ex
@@ -117,7 +117,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Store do
   end
 
   @impl GenServer
-  def handle_call({:on_block, _block_root, %SignedBeaconBlock{} = signed_block}, _from, state) do
+  def handle_call({:on_block, block_root, %SignedBeaconBlock{} = signed_block}, _from, state) do
     Logger.info("[Fork choice] Adding block #{signed_block.message.slot} to the store.")
 
     with {:ok, new_store} <- Handlers.on_block(state, signed_block),
@@ -130,7 +130,6 @@ defmodule LambdaEthereumConsensus.ForkChoice.Store do
            signed_block.message.body.attester_slashings
            |> apply_handler(new_store, &Handlers.on_attester_slashing/2) do
       BlockStore.store_block(signed_block)
-      {:ok, block_root} = BlockStore.get_block_root_by_slot(signed_block.message.slot)
       Map.fetch!(new_store.block_states, block_root) |> StateStore.store_state()
       Logger.info("[Fork choice] Block #{signed_block.message.slot} added to the store.")
       {:reply, :ok, new_store}

--- a/lib/lambda_ethereum_consensus/fork_choice/store.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/store.ex
@@ -13,7 +13,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Store do
   alias Types.SignedBeaconBlock
   alias Types.Store
 
-  @default_timeout 20_000
+  @default_timeout 100_000
 
   ##########################
   ### Public API


### PR DESCRIPTION
Fixes #564

We commented this out because it was too slow. This PR uncomments it and bypasses some attestation checks (for now).

Changelog:
* uncomments processing of attestations and attester-slashings included in blocks
* bypasses attestation processing for unknown-block attestations (as it was too difficult to fix right now) #573
* hardcodes the status message answer (`Helpers.get_head` is too slow, and uncached) #572
* increases `ForkChoice.Store`'s timeout