### PR TITLE
fix: calculate fork context when subscribing to topics

### DIFF
--- a/lib/lambda_ethereum_consensus/beacon/beacon_node.ex
+++ b/lib/lambda_ethereum_consensus/beacon/beacon_node.ex
@@ -6,6 +6,7 @@ defmodule LambdaEthereumConsensus.Beacon.BeaconNode do
 
   alias LambdaEthereumConsensus.Beacon.CheckpointSync
   alias LambdaEthereumConsensus.StateTransition.Cache
+  alias LambdaEthereumConsensus.StateTransition.Misc
   alias LambdaEthereumConsensus.Store.{BlockStore, StateStore}
 
   def start_link(opts) do
@@ -58,12 +59,14 @@ defmodule LambdaEthereumConsensus.Beacon.BeaconNode do
   defp init_children(anchor_state, anchor_block) do
     Cache.initialize_cache()
 
+    fork_digest = Misc.compute_fork_digest(anchor_state.fork.current_version, anchor_state.genesis_validators_root)
+
     children = [
       {LambdaEthereumConsensus.ForkChoice.Store, {anchor_state, anchor_block}},
       {LambdaEthereumConsensus.Beacon.PendingBlocks, []},
       {LambdaEthereumConsensus.Beacon.SyncBlocks, []},
       {LambdaEthereumConsensus.P2P.IncomingRequests, []},
-      {LambdaEthereumConsensus.P2P.GossipSub, []}
+      {LambdaEthereumConsensus.P2P.GossipSub, [fork_digest |> Base.encode16(case: :lower)]},
     ]
 
     Supervisor.init(children, strategy: :one_for_all)

--- a/lib/lambda_ethereum_consensus/p2p/gossip/consumer.ex
+++ b/lib/lambda_ethereum_consensus/p2p/gossip/consumer.ex
@@ -1,4 +1,4 @@
-defmodule LambdaEthereumConsensus.P2P.GossipConsumer do
+defmodule LambdaEthereumConsensus.P2P.Gossip.Consumer do
   @moduledoc """
   This module consumes events created by Subscriber.
   """
@@ -35,7 +35,7 @@ defmodule LambdaEthereumConsensus.P2P.GossipConsumer do
       }) do
     with {:ok, decompressed} <- :snappyer.decompress(data),
          {:ok, res} <- Ssz.from_ssz(decompressed, ssz_type),
-         :ok <- handler.handle_message(topic, res) do
+         :ok <- handler.(res) do
       message
     else
       {:error, reason} ->

--- a/lib/lambda_ethereum_consensus/p2p/gossip/gossipsub.ex
+++ b/lib/lambda_ethereum_consensus/p2p/gossip/gossipsub.ex
@@ -12,7 +12,7 @@ defmodule LambdaEthereumConsensus.P2P.GossipSub do
   end
 
   @impl true
-  def init([fork_digest]) do
+  def init([fork_digest_context]) do
     topics = [
       {"beacon_block", Types.SignedBeaconBlock, &Handler.handle_beacon_block/1},
       {"beacon_aggregate_and_proof", Types.SignedAggregateAndProof, &Handler.handle_beacon_aggregate_and_proof/1}
@@ -27,7 +27,7 @@ defmodule LambdaEthereumConsensus.P2P.GossipSub do
 
     children =
       for {topic_msg, ssz_type, handler} <- topics do
-        topic = "/eth2/#{fork_digest}/#{topic_msg}/ssz_snappy"
+        topic = "/eth2/#{fork_digest_context}/#{topic_msg}/ssz_snappy"
         {Consumer, %{topic: topic, ssz_type: ssz_type, handler: handler}}
       end
 

--- a/lib/lambda_ethereum_consensus/p2p/gossip/gossipsub.ex
+++ b/lib/lambda_ethereum_consensus/p2p/gossip/gossipsub.ex
@@ -15,7 +15,8 @@ defmodule LambdaEthereumConsensus.P2P.GossipSub do
   def init([fork_digest_context]) do
     topics = [
       {"beacon_block", Types.SignedBeaconBlock, &Handler.handle_beacon_block/1},
-      {"beacon_aggregate_and_proof", Types.SignedAggregateAndProof, &Handler.handle_beacon_aggregate_and_proof/1}
+      {"beacon_aggregate_and_proof", Types.SignedAggregateAndProof,
+       &Handler.handle_beacon_aggregate_and_proof/1}
       # {"beacon_attestation_0", Types.Attestation},
       # {"voluntary_exit", Types.SignedVoluntaryExit},
       # {"proposer_slashing", Types.ProposerSlashing},

--- a/lib/lambda_ethereum_consensus/p2p/gossip/handler.ex
+++ b/lib/lambda_ethereum_consensus/p2p/gossip/handler.ex
@@ -10,9 +10,7 @@ defmodule LambdaEthereumConsensus.P2P.Gossip.Handler do
   alias LambdaEthereumConsensus.Utils.BitVector
   alias Types.{AggregateAndProof, SignedAggregateAndProof, SignedBeaconBlock}
 
-  def handle_beacon_block(
-        %SignedBeaconBlock{message: block} = signed_block
-      ) do
+  def handle_beacon_block(%SignedBeaconBlock{message: block} = signed_block) do
     current_slot = BeaconChain.get_current_slot()
 
     if block.slot > current_slot - ChainSpec.get("SLOTS_PER_EPOCH") do
@@ -24,9 +22,9 @@ defmodule LambdaEthereumConsensus.P2P.Gossip.Handler do
     :ok
   end
 
-  def handle_beacon_aggregate_and_proof(
-        %SignedAggregateAndProof{message: %AggregateAndProof{aggregate: aggregate}}
-      ) do
+  def handle_beacon_aggregate_and_proof(%SignedAggregateAndProof{
+        message: %AggregateAndProof{aggregate: aggregate}
+      }) do
     votes = BitVector.count(aggregate.aggregation_bits)
     slot = aggregate.data.slot
     root = aggregate.data.beacon_block_root |> Base.encode16()

--- a/lib/lambda_ethereum_consensus/p2p/gossip/handler.ex
+++ b/lib/lambda_ethereum_consensus/p2p/gossip/handler.ex
@@ -1,4 +1,4 @@
-defmodule LambdaEthereumConsensus.P2P.GossipHandler do
+defmodule LambdaEthereumConsensus.P2P.Gossip.Handler do
   @moduledoc """
   Module that implements the handle_message callback,
   used in the GossipConsumer module to handle messages.
@@ -10,11 +10,7 @@ defmodule LambdaEthereumConsensus.P2P.GossipHandler do
   alias LambdaEthereumConsensus.Utils.BitVector
   alias Types.{AggregateAndProof, SignedAggregateAndProof, SignedBeaconBlock}
 
-  @spec handle_message(String.t(), struct) :: :ok
-  def handle_message(topic_name, payload)
-
-  def handle_message(
-        "/eth2/bba4da96/beacon_block/ssz_snappy",
+  def handle_beacon_block(
         %SignedBeaconBlock{message: block} = signed_block
       ) do
     current_slot = Store.get_current_slot()
@@ -28,8 +24,7 @@ defmodule LambdaEthereumConsensus.P2P.GossipHandler do
     :ok
   end
 
-  def handle_message(
-        "/eth2/bba4da96/beacon_aggregate_and_proof/ssz_snappy",
+  def handle_beacon_aggregate_and_proof(
         %SignedAggregateAndProof{message: %AggregateAndProof{aggregate: aggregate}}
       ) do
     votes = BitVector.count(aggregate.aggregation_bits)
@@ -42,12 +37,5 @@ defmodule LambdaEthereumConsensus.P2P.GossipHandler do
     Logger.debug(
       "[Gossip] Aggregate decoded for slot #{slot}. Root: #{root}. Total attestations: #{votes}"
     )
-  end
-
-  def handle_message(topic_name, payload) do
-    payload
-    |> inspect(limit: :infinity)
-    |> then(&"[#{topic_name}] decoded: '#{&1}'")
-    |> Logger.debug()
   end
 end


### PR DESCRIPTION
**Motivation**
We want to support more networks than mainnet

**Description**
Gets the fork digest from the anchor state. Uses the fork digest to subscribe to the corresponding topic
