### PR TITLE
fix: run `mix clean` on `clean` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ compile-all: compile-native $(PROTOBUF_EX_FILES)
 
 #🗑️ clean: @ Remove the build files.
 clean:
+	-mix clean
 	-rm $(GO_ARCHIVES) $(GO_HEADERS) $(OUTPUT_DIR)/*
 
 #📊 grafana-up: @ Start grafana server.


### PR DESCRIPTION
When running `make clean`, following runs could fail to load rustler-compiled artifacts. I guess this is because we are removing these on `make clean`, but didn't remove the NIF modules so they weren't recompiled.