### PR TITLE
fix: declare `host.docker.internal` in docker compose schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,15 +96,15 @@ clean:
 
 #📊 grafana-up: @ Start grafana server.
 grafana-up:
-	cd metrics/ && docker-compose up -d
+	cd metrics/ && docker compose up -d
 
 #📊 grafana-down: @ Stop grafana server.
 grafana-down:
-	cd metrics/ && docker-compose down
+	cd metrics/ && docker compose down
 
 #🗑️ grafana-clean: @ Remove the grafana data.
 grafana-clean:
-	cd metrics/ && docker-compose down -v
+	cd metrics/ && docker compose down -v
 
 #▶️ start: @ Start application with Beacon API.
 start: compile-all

--- a/metrics/docker-compose.yml
+++ b/metrics/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       open:
         aliases:
           - prometheus
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   grafana:
     image: grafana/grafana


### PR DESCRIPTION
Running the container in Linux with `docker compose` was resulting in errors due to `host.docker.internal` not being configured.