### PR TITLE
feat: add message queues aggregated lengths metric

### DIFF
--- a/lib/lambda_ethereum_consensus/telemetry.ex
+++ b/lib/lambda_ethereum_consensus/telemetry.ex
@@ -14,7 +14,7 @@ defmodule LambdaEthereumConsensus.Telemetry do
     children = [
       # Telemetry poller will execute the given period measurements
       # every 10_000ms. Learn more here: https://hexdocs.pm/telemetry_metrics
-      {:telemetry_poller, measurements: periodic_measurements(), period: 10_000},
+      {:telemetry_poller, measurements: periodic_measurements(), period: 15_000},
       # Add reporters as children of your supervision tree.
       # {Telemetry.Metrics.ConsoleReporter, metrics: metrics()},
       {TelemetryMetricsPrometheus, [metrics: metrics()]}
@@ -93,7 +93,8 @@ defmodule LambdaEthereumConsensus.Telemetry do
       ## System counts
       last_value("vm.system_counts.process_count"),
       last_value("vm.system_counts.atom_count"),
-      last_value("vm.system_counts.port_count")
+      last_value("vm.system_counts.port_count"),
+      last_value("vm.message_queues.length")
     ]
   end
 
@@ -101,7 +102,19 @@ defmodule LambdaEthereumConsensus.Telemetry do
     [
       # A module, function and arguments to be invoked periodically.
       # This function must call :telemetry.execute/3 and a metric must be added above.
-      # {Module, :count, []}
+      {__MODULE__, :message_queues_length, []}
     ]
+  end
+
+  def message_queues_length do
+    total_len =
+      Process.list()
+      |> Stream.map(fn pid ->
+        {:message_queue_len, len} = Process.info(pid, :message_queue_len)
+        len
+      end)
+      |> Enum.sum()
+
+    :telemetry.execute([:vm, :message_queues], %{length: total_len})
   end
 end

--- a/metrics/grafana/provisioning/dashboards/home.json
+++ b/metrics/grafana/provisioning/dashboards/home.json
@@ -1570,6 +1570,102 @@
       "gridPos": {
         "h": 6,
         "w": 12,
+        "x": 0,
+        "y": 48
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "vm_message_queues_length",
+          "instant": false,
+          "legendFormat": "total_message_queue_length",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total message queue length",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
         "x": 12,
         "y": 48
       },

--- a/metrics/grafana/provisioning/dashboards/home.json
+++ b/metrics/grafana/provisioning/dashboards/home.json
@@ -1592,16 +1592,46 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
+          "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "vm_message_queues_length",
+          "expr": "sum(vm_message_queue_length{process!~\"LambdaEthereumConsensus.ForkChoice|LambdaEthereumConsensus.Beacon.PendingBlocks\"})",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
           "instant": false,
           "legendFormat": "total_message_queue_length",
           "range": true,
-          "refId": "A"
+          "refId": "Total",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "vm_message_queue_length{process=\"LambdaEthereumConsensus.ForkChoice\"}",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{process}}",
+          "range": true,
+          "refId": "ForkChoice"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "vm_message_queue_length{process=\"LambdaEthereumConsensus.Beacon.PendingBlocks\"}",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{process}}",
+          "range": true,
+          "refId": "PendingBlocks"
         }
       ],
-      "title": "Total message queue length",
+      "title": "Message queue length",
       "type": "timeseries"
     },
     {
@@ -1821,6 +1851,6 @@
   "timezone": "",
   "title": "Node",
   "uid": "90EXFQnIk",
-  "version": 1,
+  "version": 4,
   "weekStart": ""
 }


### PR DESCRIPTION
We are having trouble with overflowing message queues. This metric might be useful for easy debugging of these kind of issues.

![Uploading Captura de pantalla 2024-01-09 a la(s) 18.09.01.png…]()

