### PR TITLE
fix: set used config before running test

### DIFF
--- a/test/unit/pending_blocks_test.exs
+++ b/test/unit/pending_blocks_test.exs
@@ -9,6 +9,8 @@ defmodule Unit.PendingBlocks do
   alias LambdaEthereumConsensus.Store.BlockStore
 
   setup do
+    Application.put_env(:lambda_ethereum_consensus, ChainSpec, config: MainnetConfig)
+
     # Lets trigger the process_blocks manually
     patch(PendingBlocks, :schedule_blocks_processing, fn -> :ok end)
     patch(PendingBlocks, :schedule_blocks_download, fn -> :ok end)


### PR DESCRIPTION
Sometimes this test would fail because some other test put the `MinimalConfig` in the config.
Here's an example: https://github.com/lambdaclass/lambda_ethereum_consensus/actions/runs/7488525574/job/20383206386