### PR TITLE
fix: metadata genserver not returning state

### DIFF
--- a/lib/lambda_ethereum_consensus/p2p/metadata.ex
+++ b/lib/lambda_ethereum_consensus/p2p/metadata.ex
@@ -26,14 +26,14 @@ defmodule LambdaEthereumConsensus.P2P.Metadata do
     GenServer.call(__MODULE__, :get_metadata)
   end
 
-  @spec set_attestation_subnet(integer(), boolean()) :: any()
+  @spec set_attestation_subnet(integer(), boolean()) :: :ok
   def set_attestation_subnet(i, set) do
-    GenServer.call(__MODULE__, {:set_attestation_subnet, i, set})
+    GenServer.cast(__MODULE__, {:set_attestation_subnet, i, set})
   end
 
-  @spec set_sync_committee(integer(), boolean()) :: any()
+  @spec set_sync_committee(integer(), boolean()) :: :ok
   def set_sync_committee(i, set) do
-    GenServer.call(__MODULE__, {:set_sync_committee, i, set})
+    GenServer.cast(__MODULE__, {:set_sync_committee, i, set})
   end
 
   ##########################

--- a/lib/lambda_ethereum_consensus/p2p/metadata.ex
+++ b/lib/lambda_ethereum_consensus/p2p/metadata.ex
@@ -58,7 +58,7 @@ defmodule LambdaEthereumConsensus.P2P.Metadata do
 
   @impl true
   def handle_call(:get_metadata, _from, metadata) do
-    {:reply, metadata}
+    {:reply, metadata, metadata}
   end
 
   @impl true

--- a/lib/lambda_ethereum_consensus/p2p/metadata.ex
+++ b/lib/lambda_ethereum_consensus/p2p/metadata.ex
@@ -26,12 +26,12 @@ defmodule LambdaEthereumConsensus.P2P.Metadata do
     GenServer.call(__MODULE__, :get_metadata)
   end
 
-  @spec set_attestation_subnet(integer(), boolean()) :: :ok
+  @spec set_attestation_subnet(non_neg_integer(), boolean()) :: :ok
   def set_attestation_subnet(i, set) do
     GenServer.cast(__MODULE__, {:set_attestation_subnet, i, set})
   end
 
-  @spec set_sync_committee(integer(), boolean()) :: :ok
+  @spec set_sync_committee(non_neg_integer(), boolean()) :: :ok
   def set_sync_committee(i, set) do
     GenServer.cast(__MODULE__, {:set_sync_committee, i, set})
   end
@@ -76,12 +76,7 @@ defmodule LambdaEthereumConsensus.P2P.Metadata do
   ### Private Functions
   ##########################
 
-  @spec set_or_clear(BitVector.t(), integer(), boolean()) :: BitVector.t()
-  defp set_or_clear(bitvector, i, set) do
-    if set do
-      BitVector.set(bitvector, i)
-    else
-      BitVector.clear(bitvector, i)
-    end
-  end
+  @spec set_or_clear(BitVector.t(), non_neg_integer(), boolean()) :: BitVector.t()
+  defp set_or_clear(bitvector, i, true), do: BitVector.set(bitvector, i)
+  defp set_or_clear(bitvector, i, false), do: BitVector.clear(bitvector, i)
 end

--- a/lib/lambda_ethereum_consensus/p2p/metadata.ex
+++ b/lib/lambda_ethereum_consensus/p2p/metadata.ex
@@ -18,7 +18,7 @@ defmodule LambdaEthereumConsensus.P2P.Metadata do
 
   @spec get_seq_number() :: Types.uint64()
   def get_seq_number do
-    GenServer.call(__MODULE__, {:get_seq_number})
+    GenServer.call(__MODULE__, :get_seq_number)
   end
 
   @spec get_metadata() :: Metadata.t()
@@ -51,38 +51,25 @@ defmodule LambdaEthereumConsensus.P2P.Metadata do
   end
 
   @impl true
-  def handle_call({:get_seq_number}, _from, metadata) do
-    seq_number = Map.fetch!(metadata, :seq_number)
+  def handle_call(:get_seq_number, _, %Metadata{seq_number: seq_number} = metadata) do
     {:reply, seq_number, metadata}
   end
 
   @impl true
-  def handle_call(:get_metadata, _from, metadata) do
+  def handle_call(:get_metadata, _, metadata) do
     {:reply, metadata, metadata}
   end
 
   @impl true
-  def handle_cast({:set_attestation_subnet, i, set}, metadata) do
+  def handle_cast({:set_attestation_subnet, i, set}, %{seq_number: seq_number} = metadata) do
     attnets = set_or_clear(metadata.attnets, i, set)
-
-    {:noreply,
-     %{
-       metadata
-       | attnets: attnets,
-         seq_number: metadata.seq_number + 1
-     }}
+    {:noreply, %{metadata | attnets: attnets, seq_number: seq_number + 1}}
   end
 
   @impl true
-  def handle_cast({:set_sync_committee, i, set}, metadata) do
+  def handle_cast({:set_sync_committee, i, set}, %{seq_number: seq_number} = metadata) do
     syncnets = set_or_clear(metadata.syncnets, i, set)
-
-    {:noreply,
-     %{
-       metadata
-       | syncnets: syncnets,
-         seq_number: metadata.seq_number + 1
-     }}
+    {:noreply, %{metadata | syncnets: syncnets, seq_number: seq_number + 1}}
   end
 
   ##########################


### PR DESCRIPTION
Two bugs:
- 7b746f0ebc8943c75e3353fd4642b36429028532: `GenServer.handle_call` not returning state
- 85e3e161d8354c2eaeb93f78a0078206e31447e5: some setters (unused, so no problem) used `GenServer.call` instead of `GenServer.cast`, while the handlers used `handle_call`