### PR TITLE
feat: add block processing time metric

### DIFF
--- a/lib/lambda_ethereum_consensus/fork_choice/fork_choice.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/fork_choice.ex
@@ -110,28 +110,22 @@ defmodule LambdaEthereumConsensus.ForkChoice do
   end
 
   @impl GenServer
-  def handle_call({:on_block, block_root, %SignedBeaconBlock{} = signed_block}, _from, state) do
+  def handle_call({:on_block, block_root, %SignedBeaconBlock{} = signed_block}, _from, store) do
     slot = signed_block.message.slot
 
-    with {:ok, new_store} <- Handlers.on_block(state, signed_block),
-         # process block attestations
-         {:ok, new_store} <-
-           signed_block.message.body.attestations
-           |> apply_handler(new_store, &Handlers.on_attestation(&1, &2, true)),
-         # process block attester slashings
-         {:ok, new_store} <-
-           signed_block.message.body.attester_slashings
-           |> apply_handler(new_store, &Handlers.on_attester_slashing/2) do
-      BlockStore.store_block(signed_block)
-      Map.fetch!(new_store.block_states, block_root) |> StateStore.store_state()
-      :telemetry.execute([:sync, :on_block], %{slot: slot})
-      Logger.info("[Fork choice] Block #{slot} added to the store.")
-      {:reply, :ok, new_store}
-    else
+    result =
+      :telemetry.span([:sync, :on_block], %{slot: slot}, fn ->
+        {process_block(block_root, signed_block, store), %{slot: slot}}
+      end)
+
+    case result do
+      {:ok, new_store} ->
+        Logger.info("[Fork choice] Block #{slot} added to the store.")
+        {:reply, :ok, new_store}
+
       {:error, reason} ->
         Logger.error("[Fork choice] Failed to add block #{slot} to the store: #{reason}")
-
-        {:reply, :error, state}
+        {:reply, :error, store}
     end
   end
 
@@ -193,5 +187,21 @@ defmodule LambdaEthereumConsensus.ForkChoice do
       x, {:ok, st} -> {:cont, handler.(st, x)}
       _, {:error, _} = err -> {:halt, err}
     end)
+  end
+
+  defp process_block(block_root, %SignedBeaconBlock{} = signed_block, store) do
+    with {:ok, new_store} <- Handlers.on_block(store, signed_block),
+         # process block attestations
+         {:ok, new_store} <-
+           signed_block.message.body.attestations
+           |> apply_handler(new_store, &Handlers.on_attestation(&1, &2, true)),
+         # process block attester slashings
+         {:ok, new_store} <-
+           signed_block.message.body.attester_slashings
+           |> apply_handler(new_store, &Handlers.on_attester_slashing/2) do
+      BlockStore.store_block(signed_block)
+      Map.fetch!(new_store.block_states, block_root) |> StateStore.store_state()
+      {:ok, new_store}
+    end
   end
 end

--- a/lib/lambda_ethereum_consensus/telemetry.ex
+++ b/lib/lambda_ethereum_consensus/telemetry.ex
@@ -5,6 +5,9 @@ defmodule LambdaEthereumConsensus.Telemetry do
   use Supervisor
   import Telemetry.Metrics
 
+  @block_time_ms 12_000
+  @block_processing_buckets [0.5, 1.0, 1.5, 2, 4, 6, 8] |> Enum.map(&(&1 * @block_time_ms))
+
   def start_link(arg) do
     Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
   end
@@ -73,7 +76,19 @@ defmodule LambdaEthereumConsensus.Telemetry do
 
       # Sync metrics
       last_value("sync.store.slot"),
-      last_value("sync.on_block.slot"),
+      last_value("sync.on_block.stop.slot"),
+      # last_value("sync.on_block.start.system_time"),
+      # last_value("sync.on_block.start.monotonic_time"),
+      distribution("sync.on_block.stop.duration",
+        reporter_options: [buckets: @block_processing_buckets],
+        unit: {:native, :millisecond}
+      ),
+      # last_value("sync.on_block.stop.monotonic_time"),
+      distribution("sync.on_block.exception.duration",
+        reporter_options: [buckets: @block_processing_buckets],
+        unit: {:native, :millisecond}
+      ),
+      # last_value("sync.on_block.exception.monotonic_time"),
 
       # VM Metrics
       ## Memory

--- a/metrics/grafana/provisioning/dashboards/home.json
+++ b/metrics/grafana/provisioning/dashboards/home.json
@@ -36,105 +36,70 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "continuous-RdYlGr"
-          },
-          "mappings": [],
-          "max": 0.1,
-          "min": 0,
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 5,
-        "x": 0,
-        "y": 0
-      },
-      "id": 7,
-      "options": {
-        "minVizHeight": 75,
-        "minVizWidth": 75,
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true
-      },
-      "pluginVersion": "10.2.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(network_request_blocks{}[$__rate_interval]))",
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Block download rate",
-      "type": "gauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
             }
           },
-          "mappings": []
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
         },
         "overrides": []
       },
       "gridPos": {
         "h": 6,
-        "w": 7,
-        "x": 5,
+        "w": 12,
+        "x": 0,
         "y": 0
       },
-      "id": 5,
+      "id": 6,
       "options": {
         "legend": {
+          "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": false
-        },
-        "pieType": "pie",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -148,15 +113,28 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "sum by(reason) (network_request_count{result=~\"error|retry\",type=\"by_root\"})",
+          "expr": "sync_store_slot{}",
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "max_slot",
           "range": true,
-          "refId": "A"
+          "refId": "Max slot"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sync_on_block_slot{}",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "processed_slot",
+          "range": true,
+          "refId": "Processed slot"
         }
       ],
-      "title": "Error reasons",
-      "type": "piechart"
+      "title": "Current sync progress",
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -281,55 +259,17 @@
       },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
           "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
             }
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
+          "fieldMinMax": false
         },
         "overrides": []
       },
@@ -339,19 +279,47 @@
         "x": 0,
         "y": 6
       },
-      "id": 6,
+      "id": 22,
       "options": {
+        "calculate": false,
+        "calculation": {
+          "xBuckets": {
+            "mode": "size"
+          }
+        },
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "#ff00ffb3"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "show": true,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "ms"
         }
       },
+      "pluginVersion": "10.2.0",
       "targets": [
         {
           "datasource": {
@@ -359,28 +327,15 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "sync_store_slot{}",
+          "expr": "sum(increase(sync_on_block_stop_duration_bucket[$__interval])) by (le)",
           "instant": false,
-          "legendFormat": "max_slot",
+          "legendFormat": "__auto",
           "range": true,
-          "refId": "Max slot"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "editorMode": "code",
-          "expr": "sync_on_block_slot{}",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "processed_slot",
-          "range": true,
-          "refId": "Processed slot"
+          "refId": "Block processing time"
         }
       ],
-      "title": "Current sync progress",
-      "type": "timeseries"
+      "title": "Block processing time",
+      "type": "heatmap"
     },
     {
       "datasource": {
@@ -673,70 +628,105 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
+            "mode": "continuous-RdYlGr"
           },
           "mappings": [],
+          "max": 0.1,
+          "min": 0,
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
-              },
-              {
                 "color": "red",
-                "value": 80
+                "value": null
               }
             ]
-          }
+          },
+          "unit": "none"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 6,
-        "w": 24,
+        "w": 5,
         "x": 0,
         "y": 18
       },
-      "id": 13,
+      "id": 7,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "10.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(network_request_blocks{}[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Block download rate",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 7,
+        "x": 5,
+        "y": 18
+      },
+      "id": 5,
       "options": {
         "legend": {
-          "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": false
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
         },
         "tooltip": {
           "mode": "single",
@@ -749,112 +739,16 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "disableTextWrap": false,
           "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(network_pubsub_peers_count{result=\"add\"}) - sum(network_pubsub_peers_count{result=\"remove\"})",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
+          "expr": "sum by(reason) (network_request_count{result=~\"error|retry\",type=\"by_root\"})",
           "instant": false,
-          "interval": "",
-          "legendFormat": "current_peer_amount",
+          "legendFormat": "__auto",
           "range": true,
-          "refId": "A",
-          "useBackend": false
+          "refId": "A"
         }
       ],
-      "title": "Peers (Gossip)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "scaleDistribution": {
-              "type": "linear"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 24,
-        "x": 0,
-        "y": 24
-      },
-      "id": 14,
-      "options": {
-        "calculate": false,
-        "cellGap": 1,
-        "color": {
-          "exponent": 0.5,
-          "fill": "dark-orange",
-          "mode": "scheme",
-          "reverse": false,
-          "scale": "exponential",
-          "scheme": "Oranges",
-          "steps": 64
-        },
-        "exemplars": {
-          "color": "rgba(255,0,255,0.7)"
-        },
-        "filterValues": {
-          "le": 1e-9
-        },
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "show": true,
-          "showLegend": true
-        },
-        "rowsFrame": {
-          "layout": "auto"
-        },
-        "tooltip": {
-          "mode": "single",
-          "show": true,
-          "sort": "none",
-          "yHistogram": false
-        },
-        "yAxis": {
-          "axisPlacement": "left",
-          "reverse": false
-        }
-      },
-      "pluginVersion": "10.2.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "network_pubsub_topic_active_active",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "{{topic}}",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Topics Activity",
-      "type": "heatmap"
+      "title": "Error reasons",
+      "type": "piechart"
     },
     {
       "datasource": {
@@ -918,8 +812,8 @@
       "gridPos": {
         "h": 6,
         "w": 12,
-        "x": 0,
-        "y": 30
+        "x": 12,
+        "y": 18
       },
       "id": 12,
       "options": {
@@ -1057,11 +951,11 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 12,
-        "x": 12,
-        "y": 30
+        "w": 24,
+        "x": 0,
+        "y": 24
       },
-      "id": 11,
+      "id": 13,
       "options": {
         "legend": {
           "calcs": [],
@@ -1080,29 +974,112 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
+          "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "rate(peers_challenge_count{result=\"failed\"}[$__rate_interval])",
+          "exemplar": false,
+          "expr": "sum(network_pubsub_peers_count{result=\"add\"}) - sum(network_pubsub_peers_count{result=\"remove\"})",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "failed",
+          "interval": "",
+          "legendFormat": "current_peer_amount",
           "range": true,
-          "refId": "Challenge failed"
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Peers (Gossip)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
         },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 14,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "show": true,
+          "showLegend": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "show": true,
+          "sort": "none",
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false
+        }
+      },
+      "pluginVersion": "10.2.0",
+      "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
+          "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "rate(peers_challenge_count{result=\"passed\"}[$__rate_interval])",
-          "hide": false,
+          "exemplar": false,
+          "expr": "network_pubsub_topic_active_active",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "passed",
+          "interval": "",
+          "legendFormat": "{{topic}}",
           "range": true,
-          "refId": "Challenge passed"
+          "refId": "A",
+          "useBackend": false
         }
       ],
-      "title": "Peer challenges",
-      "type": "timeseries"
+      "title": "Topics Activity",
+      "type": "heatmap"
     },
     {
       "datasource": {
@@ -1270,7 +1247,7 @@
         "x": 12,
         "y": 36
       },
-      "id": 15,
+      "id": 11,
       "options": {
         "legend": {
           "calcs": [],
@@ -1289,21 +1266,28 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "disableTextWrap": false,
           "editorMode": "code",
-          "exemplar": false,
-          "expr": "network_pubsub_topics_graft_count{} - network_pubsub_topics_prune_count{}",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
+          "expr": "rate(peers_challenge_count{result=\"failed\"}[$__rate_interval])",
           "instant": false,
-          "interval": "",
-          "legendFormat": "{{topic}}",
+          "legendFormat": "failed",
           "range": true,
-          "refId": "A",
-          "useBackend": false
+          "refId": "Challenge failed"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "rate(peers_challenge_count{result=\"passed\"}[$__rate_interval])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "passed",
+          "range": true,
+          "refId": "Challenge passed"
         }
       ],
-      "title": "Grafted",
+      "title": "Peer challenges",
       "type": "timeseries"
     },
     {
@@ -1472,7 +1456,7 @@
         "x": 12,
         "y": 42
       },
-      "id": 16,
+      "id": 15,
       "options": {
         "legend": {
           "calcs": [],
@@ -1494,7 +1478,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "rate(network_pubsub_topics_deliver_message_count{}[$__rate_interval])",
+          "expr": "network_pubsub_topics_graft_count{} - network_pubsub_topics_prune_count{}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1505,7 +1489,7 @@
           "useBackend": false
         }
       ],
-      "title": "Deliver Messages",
+      "title": "Grafted",
       "type": "timeseries"
     },
     {
@@ -1699,6 +1683,107 @@
         "x": 12,
         "y": 48
       },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "rate(network_pubsub_topics_deliver_message_count{}[$__rate_interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{topic}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Deliver Messages",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 54
+      },
       "id": 19,
       "options": {
         "legend": {
@@ -1798,7 +1883,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 54
+        "y": 60
       },
       "id": 20,
       "options": {
@@ -1851,6 +1936,6 @@
   "timezone": "",
   "title": "Node",
   "uid": "90EXFQnIk",
-  "version": 4,
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
This PR adds a new metric, namely the time it takes to process a new block. It also adds a heatmap visualization. Note this has hardcoded bucket values, that need to be changed at the node level. We may need to change this in the future, but it should be as simple as changing the metric type.

New vis:
<img width="1005" alt="Captura de pantalla 2024-01-12 a la(s) 17 14 58" src="https://github.com/lambdaclass/lambda_ethereum_consensus/assets/47506558/4e960342-1588-46cf-a0c4-f1380a881026">
