### PR TITLE
fix: use pattern-matching instead of `String` when encoding `u256`s

### DIFF
--- a/lib/ssz.ex
+++ b/lib/ssz.ex
@@ -165,7 +165,7 @@ defmodule Ssz do
   end
 
   @spec encode_u256(Types.uint256()) :: Types.bytes32()
-  def encode_u256(num) when num < @max_u256, do: <<num::little-size(256)>>
+  def encode_u256(num) when num <= @max_u256, do: <<num::little-size(256)>>
 
   @spec decode_u256(Types.bytes32()) :: Types.uint256()
   def decode_u256(<<num::little-size(256)>>), do: num

--- a/lib/ssz.ex
+++ b/lib/ssz.ex
@@ -164,9 +164,9 @@ defmodule Ssz do
     function_exported?(module, function, arity)
   end
 
-  @spec encode_u256(non_neg_integer) :: binary
+  @spec encode_u256(Types.uint256()) :: Types.bytes32()
   def encode_u256(num) when num < @max_u256, do: <<num::little-size(256)>>
 
-  @spec decode_u256(binary) :: non_neg_integer
+  @spec decode_u256(Types.bytes32()) :: Types.uint256()
   def decode_u256(<<num::little-size(256)>>), do: num
 end

--- a/lib/ssz.ex
+++ b/lib/ssz.ex
@@ -4,6 +4,8 @@ defmodule Ssz do
   """
   use Rustler, otp_app: :lambda_ethereum_consensus, crate: "ssz_nif"
 
+  @max_u256 2 ** 256 - 1
+
   ##### Functional wrappers
   @spec to_ssz(struct | list(struct)) :: {:ok, binary} | {:error, String.t()}
   def to_ssz(map)
@@ -163,12 +165,8 @@ defmodule Ssz do
   end
 
   @spec encode_u256(non_neg_integer) :: binary
-  def encode_u256(num) do
-    num
-    |> :binary.encode_unsigned(:little)
-    |> String.pad_trailing(32, <<0>>)
-  end
+  def encode_u256(num) when num < @max_u256, do: <<num::little-size(256)>>
 
   @spec decode_u256(binary) :: non_neg_integer
-  def decode_u256(num), do: :binary.decode_unsigned(num, :little)
+  def decode_u256(<<num::little-size(256)>>), do: num
 end


### PR DESCRIPTION
Fixes #627