### PR TITLE
fix: add missing networking configuration for Sepolia network

### DIFF
--- a/config/networks/sepolia/config.yaml
+++ b/config/networks/sepolia/config.yaml
@@ -1,6 +1,6 @@
 # Extends the mainnet preset
-PRESET_BASE: 'mainnet'
-CONFIG_NAME: 'sepolia'
+PRESET_BASE: "mainnet"
+CONFIG_NAME: "sepolia"
 
 # Genesis
 # ---------------------------------------------------------------
@@ -9,7 +9,6 @@ MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 1300
 MIN_GENESIS_TIME: 1655647200
 GENESIS_FORK_VERSION: 0x90000069
 GENESIS_DELAY: 86400
-
 
 # Forking
 # ---------------------------------------------------------------
@@ -49,7 +48,6 @@ SHARD_COMMITTEE_PERIOD: 256
 # 2**11 (= 2,048) Eth1 blocks ~8 hours
 ETH1_FOLLOW_DISTANCE: 2048
 
-
 # Validator cycle
 # ---------------------------------------------------------------
 # 2**2 (= 4)
@@ -63,7 +61,6 @@ MIN_PER_EPOCH_CHURN_LIMIT: 4
 # 2**16 (= 65,536)
 CHURN_LIMIT_QUOTIENT: 65536
 
-
 # Fork choice
 # ---------------------------------------------------------------
 # 40%
@@ -75,16 +72,31 @@ DEPOSIT_CHAIN_ID: 11155111
 DEPOSIT_NETWORK_ID: 11155111
 DEPOSIT_CONTRACT_ADDRESS: 0x7f02C3E3c98b133055B8B348B2Ac625669Ed295D
 
-# Network
+# Networking
 # ---------------------------------------------------------------
-SUBNETS_PER_NODE: 2
+# `10 * 2**20` (= 10485760, 10 MiB)
 GOSSIP_MAX_SIZE: 10485760
+# `2**10` (= 1024)
+MAX_REQUEST_BLOCKS: 1024
+# `2**8` (= 256)
+EPOCHS_PER_SUBNET_SUBSCRIPTION: 256
+# `MIN_VALIDATOR_WITHDRAWABILITY_DELAY + CHURN_LIMIT_QUOTIENT // 2` (= 33024, ~5 months)
 MIN_EPOCHS_FOR_BLOCK_REQUESTS: 33024
+# `10 * 2**20` (=10485760, 10 MiB)
 MAX_CHUNK_SIZE: 10485760
+# 5s
 TTFB_TIMEOUT: 5
+# 10s
 RESP_TIMEOUT: 10
+ATTESTATION_PROPAGATION_SLOT_RANGE: 32
+# 500ms
+MAXIMUM_GOSSIP_CLOCK_DISPARITY: 500
 MESSAGE_DOMAIN_INVALID_SNAPPY: 0x00000000
 MESSAGE_DOMAIN_VALID_SNAPPY: 0x01000000
+# 2 subnets per node
+SUBNETS_PER_NODE: 2
+# 2**8 (= 64)
 ATTESTATION_SUBNET_COUNT: 64
 ATTESTATION_SUBNET_EXTRA_BITS: 0
+# ceillog2(ATTESTATION_SUBNET_COUNT) + ATTESTATION_SUBNET_EXTRA_BITS
 ATTESTATION_SUBNET_PREFIX_BITS: 6


### PR DESCRIPTION
Some configuration data was missing, so I copied them from the mainnet one since they are similar (didn't double-check, but they should be the same, cc @mpaulucci ).