### PR TITLE
fix: recompile configs and presets on file change

### DIFF
--- a/lib/chain_spec/configs/mainnet.ex
+++ b/lib/chain_spec/configs/mainnet.ex
@@ -2,8 +2,11 @@ defmodule MainnetConfig do
   @moduledoc """
   Mainnet config constants.
   """
+  file = "config/networks/mainnet/config.yaml"
 
-  @parsed_config ConfigUtils.load_config_from_file!("config/networks/mainnet/config.yaml")
+  @external_resource file
+
+  @parsed_config ConfigUtils.load_config_from_file!(file)
   @unified Map.merge(MainnetPreset.get_preset(), @parsed_config)
 
   def get(key), do: Map.fetch!(@unified, key)

--- a/lib/chain_spec/configs/minimal.ex
+++ b/lib/chain_spec/configs/minimal.ex
@@ -2,8 +2,11 @@ defmodule MinimalConfig do
   @moduledoc """
   Minimal config constants.
   """
+  file = "config/networks/minimal/config.yaml"
 
-  @parsed_config ConfigUtils.load_config_from_file!("config/networks/minimal/config.yaml")
+  @external_resource file
+
+  @parsed_config ConfigUtils.load_config_from_file!(file)
   @unified Map.merge(MinimalPreset.get_preset(), @parsed_config)
 
   def get(key), do: Map.fetch!(@unified, key)

--- a/lib/chain_spec/configs/sepolia.ex
+++ b/lib/chain_spec/configs/sepolia.ex
@@ -2,8 +2,11 @@ defmodule SepoliaConfig do
   @moduledoc """
   Sepolia config constants.
   """
+  file = "config/networks/sepolia/config.yaml"
 
-  @parsed_config ConfigUtils.load_config_from_file!("config/networks/sepolia/config.yaml")
+  @external_resource file
+
+  @parsed_config ConfigUtils.load_config_from_file!(file)
   @unified Map.merge(MainnetPreset.get_preset(), @parsed_config)
 
   def get(key), do: Map.fetch!(@unified, key)

--- a/lib/chain_spec/presets/mainnet.ex
+++ b/lib/chain_spec/presets/mainnet.ex
@@ -3,7 +3,10 @@ defmodule MainnetPreset do
   Mainnet preset constants.
   """
 
-  @parsed_preset ConfigUtils.load_preset_from_dir!("config/presets/mainnet")
+  file = "config/presets/mainnet"
+  @external_resource file
+
+  @parsed_preset ConfigUtils.load_preset_from_dir!(file)
 
   def get_preset, do: @parsed_preset
 end

--- a/lib/chain_spec/presets/minimal.ex
+++ b/lib/chain_spec/presets/minimal.ex
@@ -3,7 +3,10 @@ defmodule MinimalPreset do
   Minimal preset constants.
   """
 
-  @parsed_preset ConfigUtils.load_preset_from_dir!("config/presets/minimal")
+  file = "config/presets/minimal"
+  @external_resource file
+
+  @parsed_preset ConfigUtils.load_preset_from_dir!(file)
 
   def get_preset, do: @parsed_preset
 end


### PR DESCRIPTION
When changing the YAML files, the configs aren't automatically recompiled. This PR fixes that.