### PR TITLE
refactor: improve return values from execution client.

### DIFF
--- a/lib/lambda_ethereum_consensus/execution/execution_client.ex
+++ b/lib/lambda_ethereum_consensus/execution/execution_client.ex
@@ -9,21 +9,19 @@ defmodule LambdaEthereumConsensus.Execution.ExecutionClient do
   Verifies the validity of the data contained in the new payload and notifies the Execution client of a new payload
   """
   @spec verify_and_notify_new_payload(Types.ExecutionPayload.t()) ::
-          {:ok, boolean()} | {:error, any}
+          {:ok, atom()} | {:error, String.t()}
   def verify_and_notify_new_payload(execution_payload) do
     result = EngineApi.new_payload(execution_payload)
 
     case result do
       {:ok, %{"status" => "SYNCING"}} ->
-        {:ok, true}
+        {:ok, :optimistic}
 
       {:ok, %{"status" => "VALID"}} ->
-        Logger.info("Block execution payload is valid")
-        {:ok, true}
+        {:ok, :valid}
 
       {:ok, %{"status" => "INVALID"}} ->
-        Logger.error("Block execution payload is invalid")
-        {:ok, false}
+        {:ok, :invalid}
 
       {:error, error} ->
         {:error, error}

--- a/lib/lambda_ethereum_consensus/execution/execution_client.ex
+++ b/lib/lambda_ethereum_consensus/execution/execution_client.ex
@@ -9,7 +9,7 @@ defmodule LambdaEthereumConsensus.Execution.ExecutionClient do
   Verifies the validity of the data contained in the new payload and notifies the Execution client of a new payload
   """
   @spec verify_and_notify_new_payload(Types.ExecutionPayload.t()) ::
-          {:ok, atom()} | {:error, String.t()}
+          {:ok, :optimistic | :valid | :invalid} | {:error, String.t()}
   def verify_and_notify_new_payload(execution_payload) do
     result = EngineApi.new_payload(execution_payload)
 

--- a/lib/spec/runners/operations.ex
+++ b/lib/spec/runners/operations.ex
@@ -97,8 +97,10 @@ defmodule OperationsTestRunner do
       YamlElixir.read_from_file!(case_dir <> "/execution.yaml")
       |> SpecTestUtils.sanitize_yaml()
 
+    status = if execution_valid, do: :valid, else: :invalid
+
     result =
-      Operations.process_execution_payload(pre, body, fn _payload -> {:ok, execution_valid} end)
+      Operations.process_execution_payload(pre, body, fn _payload -> {:ok, status} end)
 
     case post do
       nil ->


### PR DESCRIPTION
**Motivation**
Eventually we will need to store if the block was optimistic or not, so we need to pass that back to the state transition function
