### PR TITLE
fix: wasn't linking data to time data in LRU cache

### DIFF
--- a/lib/lambda_ethereum_consensus/store/blocks.ex
+++ b/lib/lambda_ethereum_consensus/store/blocks.ex
@@ -104,6 +104,7 @@ defmodule LambdaEthereumConsensus.Store.Blocks do
     delete_ttl(block_root)
     uniq = :erlang.unique_integer([:monotonic])
     :ets.insert_new(@ets_ttl_data, {uniq, block_root})
+    :ets.update_element(@ets_block_by_hash, block_root, {3, uniq})
   end
 
   defp delete_ttl(block_root) do


### PR DESCRIPTION
This caused the cache to grow without bounds