### PR TITLE
fix: warnings in CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
         protoc --elixir_out=./lib proto/libp2p.proto
         mix deps.get
     - name: Run tests
-      run: mix test --no-start --trace --exclude spectest
+      run: mix test --no-start --warnings-as-errors --trace --exclude spectest
 
   lint:
     name: Lint

--- a/test/integration/fork_choice/handlers_test.exs
+++ b/test/integration/fork_choice/handlers_test.exs
@@ -2,7 +2,6 @@ defmodule Integration.ForkChoice.HandlersTest do
   use ExUnit.Case
 
   alias LambdaEthereumConsensus.ForkChoice.Handlers
-  alias LambdaEthereumConsensus.ForkChoice.Helpers
   alias LambdaEthereumConsensus.Store.BlockStore
   alias LambdaEthereumConsensus.Store.Db
   alias LambdaEthereumConsensus.Store.StateStore
@@ -21,7 +20,7 @@ defmodule Integration.ForkChoice.HandlersTest do
     {:ok, signed_block} = BlockStore.get_block_by_slot(state.slot)
     {:ok, new_signed_block} = BlockStore.get_block_by_slot(state.slot + 1)
 
-    assert {:ok, store} = Store.get_forkchoice_store(state, signed_block.message, false)
+    assert {:ok, store} = Types.Store.get_forkchoice_store(state, signed_block.message, true)
     new_store = Handlers.on_tick(store, :os.system_time(:second))
 
     assert {:ok, _} = Handlers.on_block(new_store, new_signed_block)


### PR DESCRIPTION
We had some stale code that was throwing warnings with CI passing. This PR fixes those warnings and adds a flag in CI to catch these.