### PR TITLE
fix: don't download blocks older than anchor slot in SyncBlocks

### DIFF
--- a/lib/lambda_ethereum_consensus/beacon/beacon_chain.ex
+++ b/lib/lambda_ethereum_consensus/beacon/beacon_chain.ex
@@ -36,10 +36,11 @@ defmodule LambdaEthereumConsensus.Beacon.BeaconChain do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
-  @spec get_current_slot() :: integer()
-  def get_current_slot do
-    GenServer.call(__MODULE__, :get_current_slot)
-  end
+  @spec get_current_slot() :: Types.slot()
+  def get_current_slot, do: GenServer.call(__MODULE__, :get_current_slot)
+
+  @spec get_anchor_slot() :: Types.slot()
+  def get_anchor_slot, do: GenServer.call(__MODULE__, :get_anchor_slot)
 
   @spec update_fork_choice_cache(Types.root(), Types.slot(), Checkpoint.t(), Checkpoint.t()) ::
           :ok
@@ -96,6 +97,7 @@ defmodule LambdaEthereumConsensus.Beacon.BeaconChain do
      %BeaconChainState{
        genesis_time: anchor_state.genesis_time,
        genesis_validators_root: anchor_state.genesis_validators_root,
+       anchor_slot: anchor_state.slot,
        time: time,
        cached_fork_choice: %{
          head_root: <<0::256>>,
@@ -109,6 +111,11 @@ defmodule LambdaEthereumConsensus.Beacon.BeaconChain do
   @impl true
   def handle_call(:get_current_slot, _from, state) do
     {:reply, compute_current_slot(state), state}
+  end
+
+  @impl true
+  def handle_call(:get_anchor_slot, _from, %{anchor_slot: slot} = state) do
+    {:reply, slot, state}
   end
 
   @impl true

--- a/lib/lambda_ethereum_consensus/beacon/beacon_chain.ex
+++ b/lib/lambda_ethereum_consensus/beacon/beacon_chain.ex
@@ -91,7 +91,7 @@ defmodule LambdaEthereumConsensus.Beacon.BeaconChain do
     schedule_next_tick()
 
     anchor_checkpoint = %Checkpoint{
-      root: anchor_state.latest_block_header |> Ssz.hash_tree_root!(),
+      root: Misc.get_latest_block_hash(anchor_state),
       epoch: Misc.compute_epoch_at_slot(anchor_state.slot)
     }
 

--- a/lib/lambda_ethereum_consensus/beacon/beacon_chain.ex
+++ b/lib/lambda_ethereum_consensus/beacon/beacon_chain.ex
@@ -15,6 +15,7 @@ defmodule LambdaEthereumConsensus.Beacon.BeaconChain do
       :genesis_time,
       :genesis_validators_root,
       :time,
+      :anchor_slot,
       :cached_fork_choice
     ]
 

--- a/lib/lambda_ethereum_consensus/beacon/beacon_node.ex
+++ b/lib/lambda_ethereum_consensus/beacon/beacon_node.ex
@@ -4,6 +4,7 @@ defmodule LambdaEthereumConsensus.Beacon.BeaconNode do
   use Supervisor
   require Logger
 
+  alias LambdaEthereumConsensus.StateTransition.Misc
   alias LambdaEthereumConsensus.Beacon.CheckpointSync
   alias LambdaEthereumConsensus.StateTransition.Cache
   alias LambdaEthereumConsensus.Store.{BlockStore, StateStore}
@@ -81,16 +82,8 @@ defmodule LambdaEthereumConsensus.Beacon.BeaconNode do
     Supervisor.init(children, strategy: :one_for_all)
   end
 
-  defp get_latest_block_hash(anchor_state) do
-    state_root = Ssz.hash_tree_root!(anchor_state)
-    # The latest_block_header.state_root was zeroed out to avoid circular dependencies
-    anchor_state.latest_block_header
-    |> Map.put(:state_root, state_root)
-    |> Ssz.hash_tree_root!()
-  end
-
   defp fetch_anchor_block(%Types.BeaconState{} = anchor_state) do
-    block_root = get_latest_block_hash(anchor_state)
+    block_root = Misc.get_latest_block_hash(anchor_state)
     BlockStore.get_block(block_root)
   end
 end

--- a/lib/lambda_ethereum_consensus/beacon/beacon_node.ex
+++ b/lib/lambda_ethereum_consensus/beacon/beacon_node.ex
@@ -4,9 +4,9 @@ defmodule LambdaEthereumConsensus.Beacon.BeaconNode do
   use Supervisor
   require Logger
 
-  alias LambdaEthereumConsensus.StateTransition.Misc
   alias LambdaEthereumConsensus.Beacon.CheckpointSync
   alias LambdaEthereumConsensus.StateTransition.Cache
+  alias LambdaEthereumConsensus.StateTransition.Misc
   alias LambdaEthereumConsensus.Store.{BlockStore, StateStore}
 
   def start_link(opts) do

--- a/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
+++ b/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
@@ -8,7 +8,6 @@ defmodule LambdaEthereumConsensus.Beacon.PendingBlocks do
   use GenServer
   require Logger
 
-  alias LambdaEthereumConsensus.Beacon.BeaconChain
   alias LambdaEthereumConsensus.ForkChoice
   alias LambdaEthereumConsensus.P2P.BlockDownloader
   alias Types.SignedBeaconBlock
@@ -29,12 +28,7 @@ defmodule LambdaEthereumConsensus.Beacon.PendingBlocks do
 
   @spec add_block(SignedBeaconBlock.t()) :: :ok
   def add_block(signed_block) do
-    # If block is older than checkpoint sync's genesis, we ignore it
-    if signed_block.message.slot > BeaconChain.get_anchor_slot() do
-      GenServer.cast(__MODULE__, {:add_block, signed_block})
-    else
-      :ok
-    end
+    GenServer.cast(__MODULE__, {:add_block, signed_block})
   end
 
   @spec is_pending_block(Types.root()) :: boolean()

--- a/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
+++ b/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
@@ -6,8 +6,9 @@ defmodule LambdaEthereumConsensus.Beacon.PendingBlocks do
   """
 
   use GenServer
-
   require Logger
+
+  alias LambdaEthereumConsensus.Beacon.BeaconChain
   alias LambdaEthereumConsensus.ForkChoice
   alias LambdaEthereumConsensus.P2P.BlockDownloader
   alias Types.SignedBeaconBlock
@@ -28,7 +29,12 @@ defmodule LambdaEthereumConsensus.Beacon.PendingBlocks do
 
   @spec add_block(SignedBeaconBlock.t()) :: :ok
   def add_block(signed_block) do
-    GenServer.cast(__MODULE__, {:add_block, signed_block})
+    # If block is older than checkpoint sync's genesis, we ignore it
+    if signed_block.message.slot > BeaconChain.get_anchor_slot() do
+      GenServer.cast(__MODULE__, {:add_block, signed_block})
+    else
+      :ok
+    end
   end
 
   @spec is_pending_block(Types.root()) :: boolean()

--- a/lib/lambda_ethereum_consensus/beacon/sync_blocks.ex
+++ b/lib/lambda_ethereum_consensus/beacon/sync_blocks.ex
@@ -24,7 +24,7 @@ defmodule LambdaEthereumConsensus.Beacon.SyncBlocks do
     # Initial sleep for faster app start
     Process.sleep(1000)
     checkpoint = BeaconChain.get_finalized_checkpoint()
-    initial_slot = Misc.compute_start_slot_at_epoch(checkpoint.epoch)
+    initial_slot = Misc.compute_start_slot_at_epoch(checkpoint.epoch) + 1
     last_slot = BeaconChain.get_current_slot()
 
     chunks =

--- a/lib/lambda_ethereum_consensus/beacon/sync_blocks.ex
+++ b/lib/lambda_ethereum_consensus/beacon/sync_blocks.ex
@@ -10,7 +10,6 @@ defmodule LambdaEthereumConsensus.Beacon.SyncBlocks do
   alias LambdaEthereumConsensus.Beacon.BeaconChain
   alias LambdaEthereumConsensus.Beacon.PendingBlocks
   alias LambdaEthereumConsensus.P2P.BlockDownloader
-  alias LambdaEthereumConsensus.StateTransition.Misc
 
   @blocks_per_chunk 16
 
@@ -23,8 +22,7 @@ defmodule LambdaEthereumConsensus.Beacon.SyncBlocks do
   def run(_opts) do
     # Initial sleep for faster app start
     Process.sleep(1000)
-    checkpoint = BeaconChain.get_finalized_checkpoint()
-    initial_slot = Misc.compute_start_slot_at_epoch(checkpoint.epoch) + 1
+    initial_slot = BeaconChain.get_anchor_slot() + 1
     last_slot = BeaconChain.get_current_slot()
 
     chunks =

--- a/lib/lambda_ethereum_consensus/beacon/sync_blocks.ex
+++ b/lib/lambda_ethereum_consensus/beacon/sync_blocks.ex
@@ -10,6 +10,7 @@ defmodule LambdaEthereumConsensus.Beacon.SyncBlocks do
   alias LambdaEthereumConsensus.Beacon.BeaconChain
   alias LambdaEthereumConsensus.Beacon.PendingBlocks
   alias LambdaEthereumConsensus.P2P.BlockDownloader
+  alias LambdaEthereumConsensus.StateTransition.Misc
 
   @blocks_per_chunk 16
 
@@ -22,7 +23,8 @@ defmodule LambdaEthereumConsensus.Beacon.SyncBlocks do
   def run(_opts) do
     # Initial sleep for faster app start
     Process.sleep(1000)
-    initial_slot = BeaconChain.get_anchor_slot() + 1
+    checkpoint = BeaconChain.get_finalized_checkpoint()
+    initial_slot = Misc.compute_start_slot_at_epoch(checkpoint.epoch) + 1
     last_slot = BeaconChain.get_current_slot()
 
     chunks =

--- a/lib/lambda_ethereum_consensus/fork_choice/simple_tree.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/simple_tree.ex
@@ -3,7 +3,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Simple.Tree do
 
   defmodule Node do
     @moduledoc false
-    defstruct [:parent_id, :id, :children_ids]
+    defstruct [:parent_id, :children_ids]
     @type id :: Types.root()
     @type parent_id :: id() | :root
     @type t :: %__MODULE__{

--- a/lib/lambda_ethereum_consensus/state_transition/misc.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/misc.ex
@@ -261,4 +261,13 @@ defmodule LambdaEthereumConsensus.StateTransition.Misc do
     flag = :math.pow(2, flag_index) |> round
     bor(flags, flag)
   end
+
+  @spec get_latest_block_hash(BeaconState.t()) :: Types.root()
+  def get_latest_block_hash(anchor_state) do
+    state_root = Ssz.hash_tree_root!(anchor_state)
+    # The latest_block_header.state_root was zeroed out to avoid circular dependencies
+    anchor_state.latest_block_header
+    |> Map.put(:state_root, state_root)
+    |> Ssz.hash_tree_root!()
+  end
 end


### PR DESCRIPTION
This PR fixes a race condition we had. If during start-up we received the anchor block's parent, we marked that one as pending, and thus also marked our current anchor block as pending, causing all block processing to stop.