### PR TITLE
feat: add "DB-only" mode

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,8 +1,8 @@
 import Config
 
-{args, _remaining_args, _errors} =
-  OptionParser.parse(System.argv(),
-    switches: [
+{args, remaining_args} =
+  OptionParser.parse!(System.argv(),
+    strict: [
       network: :string,
       checkpoint_sync: :string,
       execution_endpoint: :string,
@@ -11,6 +11,11 @@ import Config
       db_only: :boolean
     ]
   )
+
+if not Enum.empty?(remaining_args) do
+  IO.puts("Unexpected argument received: #{Enum.take(remaining_args, 1)}")
+  System.halt(1)
+end
 
 network = Keyword.get(args, :network, "mainnet")
 checkpoint_sync = Keyword.get(args, :checkpoint_sync)

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,19 +1,24 @@
 import Config
 
-{args, remaining_args} =
-  OptionParser.parse!(System.argv(),
-    strict: [
-      network: :string,
-      checkpoint_sync: :string,
-      execution_endpoint: :string,
-      execution_jwt: :string,
-      mock_execution: :boolean,
-      mode: :string
-    ]
-  )
+switches = [
+  network: :string,
+  checkpoint_sync: :string,
+  execution_endpoint: :string,
+  execution_jwt: :string,
+  mock_execution: :boolean,
+  mode: :string
+]
 
-if not Enum.empty?(remaining_args) do
-  IO.puts("Unexpected argument received: #{Enum.take(remaining_args, 1)}")
+is_testing = Config.config_env() == :test
+
+# NOTE: we ignore invalid options because `mix test` passes us all test flags
+option = if is_testing, do: :switches, else: :strict
+
+{args, remaining_args} = OptionParser.parse!(System.argv(), [{option, switches}])
+
+if not is_testing and not Enum.empty?(remaining_args) do
+  invalid_arg = Enum.take(remaining_args, 1)
+  IO.puts("Unexpected argument received: #{invalid_arg}")
   System.halt(1)
 end
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -8,7 +8,7 @@ import Config
       execution_endpoint: :string,
       execution_jwt: :string,
       mock_execution: :boolean,
-      db_only: :boolean
+      mode: :string
     ]
   )
 
@@ -31,16 +31,20 @@ configs_per_network = %{
   "sepolia" => SepoliaConfig
 }
 
+valid_modes = ["full", "db"]
+raw_mode = Keyword.get(args, :mode, "full")
+
 mode =
-  if Keyword.get(args, :db_only, false) do
-    :db_only
+  if raw_mode in valid_modes do
+    String.to_atom(raw_mode)
   else
-    :full
+    IO.puts("Invalid mode given. Valid modes are: #{Enum.join(valid_modes, ", ")}")
+    System.halt(2)
   end
 
 config :lambda_ethereum_consensus, LambdaEthereumConsensus, mode: mode
 
-mock_execution = Keyword.get(args, :mock_execution, mode == :db_only or is_nil(jwt_path))
+mock_execution = Keyword.get(args, :mock_execution, mode == :db or is_nil(jwt_path))
 
 config :lambda_ethereum_consensus, ChainSpec, config: configs_per_network |> Map.fetch!(network)
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -7,7 +7,8 @@ import Config
       checkpoint_sync: :string,
       execution_endpoint: :string,
       execution_jwt: :string,
-      mock_execution: :boolean
+      mock_execution: :boolean,
+      db_only: :boolean
     ]
   )
 
@@ -15,7 +16,6 @@ network = Keyword.get(args, :network, "mainnet")
 checkpoint_sync = Keyword.get(args, :checkpoint_sync)
 execution_endpoint = Keyword.get(args, :execution_endpoint, "http://localhost:8551")
 jwt_path = Keyword.get(args, :execution_jwt)
-mock_execution = Keyword.get(args, :mock_execution, config_env() == :test or is_nil(jwt_path))
 
 config :lambda_ethereum_consensus, LambdaEthereumConsensus.ForkChoice,
   checkpoint_sync: checkpoint_sync
@@ -25,6 +25,17 @@ configs_per_network = %{
   "mainnet" => MainnetConfig,
   "sepolia" => SepoliaConfig
 }
+
+mode =
+  if Keyword.get(args, :db_only, false) do
+    :db_only
+  else
+    :full
+  end
+
+config :lambda_ethereum_consensus, LambdaEthereumConsensus, mode: mode
+
+mock_execution = Keyword.get(args, :mock_execution, mode == :db_only or is_nil(jwt_path))
 
 config :lambda_ethereum_consensus, ChainSpec, config: configs_per_network |> Map.fetch!(network)
 

--- a/lib/lambda_ethereum_consensus/application.ex
+++ b/lib/lambda_ethereum_consensus/application.ex
@@ -8,32 +8,11 @@ defmodule LambdaEthereumConsensus.Application do
 
   @impl true
   def start(_type, _args) do
-    checkpoint_sync =
-      Application.fetch_env!(:lambda_ethereum_consensus, LambdaEthereumConsensus.ForkChoice)[
-        :checkpoint_sync
-      ]
+    mode = get_operation_mode()
 
-    jwt_secret =
-      Application.fetch_env!(
-        :lambda_ethereum_consensus,
-        LambdaEthereumConsensus.Execution.EngineApi
-      )[:jwt_secret]
+    check_jwt_secret(mode)
 
-    if is_nil(jwt_secret) do
-      Logger.warning(
-        "[EngineAPI] A JWT secret is needed for communication with the execution engine. " <>
-          "Please specify the file to load it from with the --execution-jwt flag."
-      )
-    end
-
-    children = [
-      LambdaEthereumConsensus.Telemetry,
-      LambdaEthereumConsensus.Store.Db,
-      LambdaEthereumConsensus.Store.Blocks,
-      {LambdaEthereumConsensus.Beacon.BeaconNode, [checkpoint_sync]},
-      LambdaEthereumConsensus.P2P.Metadata,
-      BeaconApi.Endpoint
-    ]
+    children = get_children(mode)
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
@@ -48,5 +27,50 @@ defmodule LambdaEthereumConsensus.Application do
   def config_change(changed, _new, removed) do
     BeaconApi.Endpoint.config_change(changed, removed)
     :ok
+  end
+
+  defp get_children(:db_only) do
+    [
+      LambdaEthereumConsensus.Telemetry,
+      LambdaEthereumConsensus.Store.Db,
+      LambdaEthereumConsensus.Store.Blocks
+    ]
+  end
+
+  defp get_children(:full) do
+    get_children(:db_only) ++
+      [
+        {LambdaEthereumConsensus.Beacon.BeaconNode, [checkpoint_sync_url()]},
+        LambdaEthereumConsensus.P2P.Metadata,
+        BeaconApi.Endpoint
+      ]
+  end
+
+  def checkpoint_sync_url do
+    Application.fetch_env!(:lambda_ethereum_consensus, LambdaEthereumConsensus.ForkChoice)
+    |> Keyword.fetch!(:checkpoint_sync)
+  end
+
+  defp get_operation_mode do
+    Application.fetch_env!(:lambda_ethereum_consensus, LambdaEthereumConsensus)
+    |> Keyword.fetch!(:mode)
+  end
+
+  defp check_jwt_secret(:db_only), do: nil
+
+  defp check_jwt_secret(:full) do
+    jwt_secret =
+      Application.fetch_env!(
+        :lambda_ethereum_consensus,
+        LambdaEthereumConsensus.Execution.EngineApi
+      )
+      |> Keyword.fetch!(:jwt_secret)
+
+    if is_nil(jwt_secret) do
+      Logger.warning(
+        "[EngineAPI] A JWT secret is needed for communication with the execution engine. " <>
+          "Please specify the file to load it from with the --execution-jwt flag."
+      )
+    end
   end
 end

--- a/lib/lambda_ethereum_consensus/application.ex
+++ b/lib/lambda_ethereum_consensus/application.ex
@@ -29,7 +29,7 @@ defmodule LambdaEthereumConsensus.Application do
     :ok
   end
 
-  defp get_children(:db_only) do
+  defp get_children(:db) do
     [
       LambdaEthereumConsensus.Telemetry,
       LambdaEthereumConsensus.Store.Db,
@@ -39,7 +39,7 @@ defmodule LambdaEthereumConsensus.Application do
   end
 
   defp get_children(:full) do
-    get_children(:db_only) ++
+    get_children(:db) ++
       [
         {LambdaEthereumConsensus.Beacon.BeaconNode, [checkpoint_sync_url()]},
         LambdaEthereumConsensus.P2P.Metadata,
@@ -57,7 +57,7 @@ defmodule LambdaEthereumConsensus.Application do
     |> Keyword.fetch!(:mode)
   end
 
-  defp check_jwt_secret(:db_only), do: nil
+  defp check_jwt_secret(:db), do: nil
 
   defp check_jwt_secret(:full) do
     jwt_secret =


### PR DESCRIPTION
Closes #684

This PR introduces a new flag `--mode`, which sets the application mode. "db" starts the application with DB-related modules only, while "full" is the default and starts all features. This is useful for manual debugging and for running tests.