### PR TITLE
chore: alias `mix compile` and `mix clean` to `make` targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
       with:
         workspaces: ${{ env.RUST_WORKSPACES }}
     - name: Compile Elixir (Warnings as errors)
-      run: mix compile --warnings-as-errors
+      run: mix compile.elixir --warnings-as-errors
     - name: Retrieve PLT Cache
       uses: actions/cache@v3
       id: plt-cache
@@ -166,7 +166,7 @@ jobs:
       with:
         workspaces: ${{ env.RUST_WORKSPACES }}
     - name: Compile Elixir (Warnings as errors)
-      run: mix compile --warnings-as-errors
+      run: mix compile.elixir --warnings-as-errors
     - name: Run the node
       # NOTE: this starts and then stops the application. It should catch simple runtime errors
       run: mix run -- --checkpoint-sync https://sync-mainnet.beaconcha.in/

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 		clean-vectors download-vectors uncompress-vectors proto \
 		spec-test-% spec-test spec-test-config-% spec-test-runner-% \
 		spec-test-mainnet-% spec-test-minimal-% spec-test-general-% \
-		clean-tests gen-spec compile-all download-beacon-node-oapi
+		clean-tests gen-spec compile-all download-beacon-node-oapi \
+		clean-artifacts prepare-artifacts
 
 # Delete current file when command fails
 .DELETE_ON_ERROR:
@@ -85,13 +86,17 @@ proto: $(PROTOBUF_EX_FILES) $(PROTOBUF_GO_FILES)
 #🔨 compile-native: @ Compile C and Go artifacts.
 compile-native: $(OUTPUT_DIR)/libp2p_nif.so $(OUTPUT_DIR)/libp2p_port
 
+prepare-artifacts: compile-native $(PROTOBUF_EX_FILES) download-beacon-node-oapi
+
 #🔨 compile-all: @ Compile the elixir project and its dependencies.
-compile-all: compile-native $(PROTOBUF_EX_FILES) download-beacon-node-oapi
+compile-all:
 	mix compile
 
 #🗑️ clean: @ Remove the build files.
 clean:
 	-mix clean
+
+clean-artifacts:
 	-rm $(GO_ARCHIVES) $(GO_HEADERS) $(OUTPUT_DIR)/*
 
 #📊 grafana-up: @ Start grafana server.

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule LambdaEthereumConsensus.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       dialyzer: dialyzer(),
+      aliases: aliases(),
       elixirc_paths: compiler_paths(Mix.env()),
       warn_test_pattern: "_remove_warning.exs",
       preferred_cli_env: [
@@ -74,4 +75,11 @@ defmodule LambdaEthereumConsensus.MixProject do
     do: ["test/spec", "test/fixtures"] ++ compiler_paths(:prod)
 
   defp compiler_paths(_), do: ["lib", "proto"]
+
+  defp aliases do
+    [
+      compile: ["cmd make prepare-artifacts", "compile"],
+      clean: ["clean", "cmd make clean-artifacts"]
+    ]
+  end
 end


### PR DESCRIPTION
This PR changes the mix compile and clean tasks to also compile and clean other artifacts, via mix aliases.