### PR TITLE
chore: add dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "mix"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/native/bls_nif"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/native/libp2p_port"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/" # Expands to `.github/workflows`
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR adds the configuration file for [github's dependabot version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates). Merging this with main should enable the feature.