### PR TITLE
perf: inline `SszEx.hash` function

### DIFF
--- a/bench/ssz.exs
+++ b/bench/ssz.exs
@@ -35,7 +35,7 @@ Benchee.run(
   time: 5
 )
 
-## Benchmark Merkleization 
+## Benchmark Merkleization
 
 list = Stream.cycle([65_535]) |> Enum.take(316)
 schema = {:list, {:int, 16}, 1024}

--- a/lib/lambda_ethereum_consensus/state_transition/misc.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/misc.ex
@@ -170,7 +170,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Misc do
     first_8_bytes
   end
 
-  @spec uint_to_bytes(non_neg_integer(), 8 | 32 | 64) :: binary()
+  @spec uint_to_bytes(non_neg_integer(), 8 | 16 | 32 | 64) :: binary()
   def uint_to_bytes(value, size) do
     # Converts an unsigned integer value to a bytes value
     <<value::unsigned-integer-little-size(size)>>

--- a/lib/ssz_ex.ex
+++ b/lib/ssz_ex.ex
@@ -18,6 +18,7 @@ defmodule LambdaEthereumConsensus.SszEx do
   @zero_chunk <<0::size(@bits_per_chunk)>>
   @zero_hashes ZeroHashes.compute_zero_hashes()
 
+  @compile {:inline, hash: 1}
   @spec hash(iodata()) :: binary()
   def hash(data), do: :crypto.hash(:sha256, data)
 

--- a/lib/types/store.ex
+++ b/lib/types/store.ex
@@ -39,6 +39,7 @@ defmodule Types.Store do
           proposer_boost_root: Types.root() | nil,
           equivocating_indices: MapSet.t(Types.validator_index()),
           checkpoint_states: %{Checkpoint.t() => BeaconState.t()},
+          # NOTE: the `Checkpoint` values in latest_messages are `LatestMessage`s
           latest_messages: %{Types.validator_index() => Checkpoint.t()},
           unrealized_justifications: %{Types.root() => Checkpoint.t()},
           tree_cache: Tree.t()


### PR DESCRIPTION
Since the function is just an "alias" to `:crypto.hash`, we can safely inline all calls. This gives a ~5% performance increase when hashing, according to benchmarks.