### PR TITLE
chore: append "-url" to "checkpoint-sync" flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
       run: mix compile --warnings-as-errors
     - name: Run the node
       # NOTE: this starts and then stops the application. It should catch simple runtime errors
-      run: mix run -- --checkpoint-sync https://sync-mainnet.beaconcha.in/
+      run: mix run -- --checkpoint-sync-url https://sync-mainnet.beaconcha.in/
 
   test:
     name: Test

--- a/Makefile
+++ b/Makefile
@@ -116,11 +116,11 @@ iex: compile-all
 
 #▶️ checkpoint-sync: @ Run an interactive terminal using checkpoint sync.
 checkpoint-sync: compile-all
-	iex -S mix run -- --checkpoint-sync https://sync-mainnet.beaconcha.in/
+	iex -S mix run -- --checkpoint-sync-url https://sync-mainnet.beaconcha.in/
 
 #▶️ sepolia: @ Run an interactive terminal using sepolia network
 sepolia: compile-all
-	iex -S mix run -- --checkpoint-sync https://sepolia.beaconstate.info --network sepolia
+	iex -S mix run -- --checkpoint-sync-url https://sepolia.beaconstate.info --network sepolia
 
 #🔴 test: @ Run tests
 test: compile-all

--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ The iex terminal can be closed by pressing ctrl+c two times.
 ### Checkpoint Sync
 
 You can also sync from a checkpoint given by a trusted third-party.
-For that, get the URL that serves the checkpoint, and pass it to the node with the "--checkpoint-sync" flag:
+You can specify a URL to fetch it from with the "--checkpoint-sync-url" flag:
 
 ```shell
-iex -S mix run -- --checkpoint-sync <your_url_here>
+iex -S mix run -- --checkpoint-sync-url <your_url_here>
 ```
 
 Some public endpoints can be found in [eth-clients.github.io/checkpoint-sync-endpoints](https://eth-clients.github.io/checkpoint-sync-endpoints/).

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -2,7 +2,7 @@ import Config
 
 switches = [
   network: :string,
-  checkpoint_sync: :string,
+  checkpoint_sync_url: :string,
   execution_endpoint: :string,
   execution_jwt: :string,
   mock_execution: :boolean,
@@ -23,12 +23,12 @@ if not is_testing and not Enum.empty?(remaining_args) do
 end
 
 network = Keyword.get(args, :network, "mainnet")
-checkpoint_sync = Keyword.get(args, :checkpoint_sync)
+checkpoint_sync_url = Keyword.get(args, :checkpoint_sync_url)
 execution_endpoint = Keyword.get(args, :execution_endpoint, "http://localhost:8551")
 jwt_path = Keyword.get(args, :execution_jwt)
 
 config :lambda_ethereum_consensus, LambdaEthereumConsensus.ForkChoice,
-  checkpoint_sync: checkpoint_sync
+  checkpoint_sync_url: checkpoint_sync_url
 
 configs_per_network = %{
   "minimal" => MinimalConfig,

--- a/lib/lambda_ethereum_consensus/application.ex
+++ b/lib/lambda_ethereum_consensus/application.ex
@@ -49,7 +49,7 @@ defmodule LambdaEthereumConsensus.Application do
 
   def checkpoint_sync_url do
     Application.fetch_env!(:lambda_ethereum_consensus, LambdaEthereumConsensus.ForkChoice)
-    |> Keyword.fetch!(:checkpoint_sync)
+    |> Keyword.fetch!(:checkpoint_sync_url)
   end
 
   defp get_operation_mode do

--- a/lib/lambda_ethereum_consensus/beacon/beacon_node.ex
+++ b/lib/lambda_ethereum_consensus/beacon/beacon_node.ex
@@ -26,7 +26,7 @@ defmodule LambdaEthereumConsensus.Beacon.BeaconNode do
 
       :not_found ->
         Logger.error(
-          "[Sync] No initial state or block found. Please specify the URL to fetch them from via the --checkpoint-sync flag"
+          "[Sync] No initial state or block found. Please specify the URL to fetch them from via the --checkpoint-sync-url flag"
         )
 
         System.stop(1)

--- a/lib/lambda_ethereum_consensus/beacon/checkpoint_sync.ex
+++ b/lib/lambda_ethereum_consensus/beacon/checkpoint_sync.ex
@@ -10,7 +10,7 @@ defmodule LambdaEthereumConsensus.Beacon.CheckpointSync do
   @doc """
   Safely retrieves the last finalized state and block
   """
-  @spec get_state(String.t()) ::
+  @spec get_finalized_block_and_state(String.t()) ::
           {:ok, {Types.BeaconState.t(), Types.SignedBeaconBlock.t()}} | {:error, any()}
   def get_finalized_block_and_state(url) do
     tasks = [Task.async(__MODULE__, :get_state, [url]), Task.async(__MODULE__, :get_block, [url])]


### PR DESCRIPTION
This PR renames `--checkpoint-sync` flag to `--checkpoint-sync-url` flag, in order to prepare for #726. Also, this name is the one used by both Teku and Lighthouse.