### PR TITLE
perf: add `shuffle_list` function

### DIFF
--- a/bench/shuffling_bench.ex
+++ b/bench/shuffling_bench.ex
@@ -1,0 +1,21 @@
+alias LambdaEthereumConsensus.StateTransition.Shuffling
+alias LambdaEthereumConsensus.StateTransition.Misc
+
+index_count = 1000
+seed = :crypto.strong_rand_bytes(32)
+input = 0..(index_count - 1)//1
+
+Benchee.run(
+  %{
+    "shuffle_list" => fn ->
+      Shuffling.shuffle_list(Aja.Vector.new(input), seed)
+    end,
+    "compute_shuffled_index" => fn ->
+      for index <- input do
+        Misc.compute_shuffled_index(index, index_count, seed)
+      end
+    end
+  },
+  warmup: 2,
+  time: 5
+)

--- a/lib/lambda_ethereum_consensus/state_transition/shuffling.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/shuffling.ex
@@ -1,0 +1,154 @@
+defmodule LambdaEthereumConsensus.StateTransition.Shuffling do
+  @moduledoc """
+  Shuffling state transition functions
+  """
+  require Aja
+  alias LambdaEthereumConsensus.SszEx
+  import Bitwise
+
+  @seed_size 32
+  @position_size 4
+
+  @doc """
+  Performs a full shuffle of a list of indices.
+  This function is equivalent to running `compute_shuffled_index` for each index in the list.
+
+  Shuffling the whole list should be 10-100x faster than shuffling each single item.
+
+  ## Examples
+    iex> shuffled = Shuffling.shuffle_list(Aja.Vector.new(0..99), <<0::32*8>>)
+    iex> {:ok, new_index } = Misc.compute_shuffled_index(54, 100, <<0::32*8>>)
+    iex> shuffled |> Aja.Enum.at(54) == new_index
+    true
+  """
+  @spec shuffle_list(Aja.Vector.t(), binary()) :: Aja.Vector.t()
+
+  def shuffle_list(_input, seed) when byte_size(seed) != @seed_size do
+    raise("Seed must be #{@seed_size} bytes long")
+  end
+
+  def shuffle_list(input, _seed) when Aja.vec_size(input) == 0 do
+    input
+  end
+
+  def shuffle_list(input, seed) do
+    rounds = ChainSpec.get("SHUFFLE_ROUND_COUNT")
+    shuffle_round(input, rounds - 1, seed)
+  end
+
+  @spec shuffle_round(Aja.Vector.t(), non_neg_integer(), binary()) ::
+          Aja.Vector.t()
+  def shuffle_round(input, round, seed) do
+    input_size = Aja.Enum.count(input)
+
+    round_bytes =
+      :binary.encode_unsigned(round, :little)
+
+    pivot =
+      (seed <> round_bytes)
+      |> SszEx.hash()
+      |> :binary.part(0, 8)
+      |> :binary.decode_unsigned(:little)
+      |> rem(input_size)
+
+    mirror = (pivot + 1) >>> 1
+    source = (seed <> round_bytes <> position_bytes(pivot >>> 8)) |> SszEx.hash()
+    byte_v = :binary.at(source, (pivot &&& 0xFF) >>> 3)
+
+    {_source, _byte_v, input} =
+      Enum.reduce(0..(mirror - 1)//1, {source, byte_v, input}, fn i, {source, byte_v, input} ->
+        j = pivot - i
+
+        source =
+          if (j &&& 0xFF) == 0xFF do
+            (seed <> round_bytes <> position_bytes(j >>> 8)) |> SszEx.hash()
+          else
+            source
+          end
+
+        byte_v =
+          if (j &&& 0x07) == 0x07 do
+            :binary.at(source, (j &&& 0xFF) >>> 3)
+          else
+            byte_v
+          end
+
+        bit_v = byte_v >>> (j &&& 0x07) &&& 0x01
+
+        input =
+          if bit_v == 1 do
+            swap_values(input, i, j)
+          else
+            input
+          end
+
+        {source, byte_v, input}
+      end)
+
+    mirror = (pivot + input_size + 1) >>> 1
+    list_end = input_size - 1
+    source = (seed <> round_bytes <> position_bytes(list_end >>> 8)) |> SszEx.hash()
+    byte_v = :binary.at(source, (list_end &&& 0xFF) >>> 3)
+
+    {_source, _byte_v, input} =
+      Enum.reduce((pivot + 1)..(mirror - 1)//1, {source, byte_v, input}, fn i,
+                                                                            {source, byte_v,
+                                                                             input} ->
+        loop_iter = i - (pivot + 1)
+        j = list_end - loop_iter
+
+        source =
+          if (j &&& 0xFF) == 0xFF do
+            (seed <> round_bytes <> position_bytes(j >>> 8)) |> SszEx.hash()
+          else
+            source
+          end
+
+        byte_v =
+          if (j &&& 0x07) == 0x07 do
+            :binary.at(source, (j &&& 0xFF) >>> 3)
+          else
+            byte_v
+          end
+
+        bit_v = byte_v >>> (j &&& 0x07) &&& 0x01
+
+        input =
+          if bit_v == 1 do
+            swap_values(input, i, j)
+          else
+            input
+          end
+
+        {source, byte_v, input}
+      end)
+
+    if round > 0 do
+      shuffle_round(input, round - 1, seed)
+    else
+      input
+    end
+  end
+
+  @spec position_bytes(integer()) :: binary()
+  defp position_bytes(position) when position >= 0 do
+    :binary.encode_unsigned(position, :little)
+    |> pad_binary(@position_size)
+    |> binary_part(0, @position_size)
+  end
+
+  defp pad_binary(binary, n) do
+    byte_size = byte_size(binary)
+    padding = max(n - byte_size, 0)
+    <<binary::binary, 0::size(padding * 8)>>
+  end
+
+  def swap_values(list, i, j) do
+    value_i = Aja.Enum.at(list, i)
+    value_j = Aja.Enum.at(list, j)
+
+    list
+    |> Aja.Vector.replace_at(i, value_j)
+    |> Aja.Vector.replace_at(j, value_i)
+  end
+end

--- a/lib/lambda_ethereum_consensus/state_transition/shuffling.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/shuffling.ex
@@ -33,12 +33,15 @@ defmodule LambdaEthereumConsensus.StateTransition.Shuffling do
 
   def shuffle_list(input, seed) do
     rounds = ChainSpec.get("SHUFFLE_ROUND_COUNT")
-    shuffle_round(input, rounds - 1, seed)
+    shuffle_list(input, rounds - 1, seed)
   end
 
-  @spec shuffle_round(Aja.Vector.t(), non_neg_integer(), binary()) ::
+  @spec shuffle_list(Aja.Vector.t(), non_neg_integer(), binary()) ::
           Aja.Vector.t()
-  def shuffle_round(input, round, seed) do
+
+  defp shuffle_list(input, round, _seed) when round < 0, do: input
+
+  defp shuffle_list(input, round, seed) do
     input_size = Aja.Enum.count(input)
 
     round_bytes =
@@ -123,11 +126,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Shuffling do
         {source, byte_v, input}
       end)
 
-    if round > 0 do
-      shuffle_round(input, round - 1, seed)
-    else
-      input
-    end
+    shuffle_list(input, round - 1, seed)
   end
 
   @spec position_bytes(integer()) :: binary()

--- a/test/spec/runners/shuffling.ex
+++ b/test/spec/runners/shuffling.ex
@@ -7,6 +7,7 @@ defmodule ShufflingTestRunner do
   use TestRunner
 
   alias LambdaEthereumConsensus.StateTransition.Misc
+  alias LambdaEthereumConsensus.StateTransition.Shuffling
 
   # Remove handler from here once you implement the corresponding functions
   @disabled_handlers [
@@ -34,27 +35,17 @@ defmodule ShufflingTestRunner do
     for index <- 0..(index_count - 1) do
       result = Misc.compute_shuffled_index(index, index_count, seed)
 
-      case result do
-        {:ok, value} ->
-          assert value == Enum.fetch!(indices, index)
-
-        {:error, _} ->
-          assert index >= index_count or index_count == 0
+      if index >= index_count or index_count == 0 do
+        assert result == {:error, "invalid index_count"}
+      else
+        assert result == {:ok, Enum.fetch!(indices, index)}
       end
     end
 
-    # Testing the reverse lookup; implemented by running the shuffling rounds in reverse, from (index_count - 1) to 0
-    # NOTE: this is the same as before, but the test-format specs suggest including this check
-    for index <- (index_count - 1)..0 do
-      result = Misc.compute_shuffled_index(index, index_count, seed)
+    shuffled_list =
+      Shuffling.shuffle_list(0..(index_count - 1)//1 |> Aja.Vector.new(), seed)
+      |> Aja.Enum.to_list()
 
-      case result do
-        {:ok, value} ->
-          assert value == Enum.fetch!(indices, index)
-
-        {:error, _} ->
-          assert index >= index_count or index_count == 0
-      end
-    end
+    assert shuffled_list == indices
   end
 end

--- a/test/unit/shuffling_test.exs
+++ b/test/unit/shuffling_test.exs
@@ -1,0 +1,23 @@
+defmodule Unit.ShufflingTest do
+  @moduledoc false
+
+  use ExUnit.Case
+
+  alias LambdaEthereumConsensus.StateTransition.Misc
+  alias LambdaEthereumConsensus.StateTransition.Shuffling
+
+  doctest LambdaEthereumConsensus.StateTransition.Shuffling
+
+  test "Shuffling a whole list should be equivalent to shuffing each single item" do
+    seed = 1..32 |> Enum.map(fn _ -> :rand.uniform(256) - 1 end) |> :erlang.iolist_to_binary()
+    index_count = 100
+    input = 0..(index_count - 1)
+
+    shuffled = Shuffling.shuffle_list(Aja.Vector.new(input), seed)
+
+    for index <- input do
+      {:ok, new_index} = Misc.compute_shuffled_index(index, index_count, seed)
+      assert Aja.Enum.at(shuffled, index) == new_index
+    end
+  end
+end


### PR DESCRIPTION
**Motivation**
Shuffling a whole list should be much more efficient than calling `compute_shuffled_index` on every single item.

**Description**
Lighthouse implementations claims it can be up to 250x more efficient than computing `compute_shuffled_index` through the entire list, see: https://github.com/sigp/lighthouse/blob/c11638c36c25f3af910eecd33a6e45d1caa99f1f/consensus/swap_or_not_shuffle/src/shuffle_list.rs#L55

In my case I've observed "only" 10x improvements so far:

```
Name                             ips        average  deviation         median         99th %
shuffle_list                  254.79        3.92 ms    ±10.57%        3.90 ms        4.29 ms
compute_shuffled_index         22.14       45.17 ms     ±2.66%       45.24 ms       52.94 ms

Comparison:
shuffle_list                  254.79
compute_shuffled_index         22.14 - 11.51x slower +41.25 ms
```

TODO: Integrate this function into the code.