### PR TITLE
chore: rename `verify_and_notify_new_payload` to `notify_new_payload`.

### DIFF
--- a/lib/lambda_ethereum_consensus/execution/execution_client.ex
+++ b/lib/lambda_ethereum_consensus/execution/execution_client.ex
@@ -8,9 +8,9 @@ defmodule LambdaEthereumConsensus.Execution.ExecutionClient do
   @doc """
   Verifies the validity of the data contained in the new payload and notifies the Execution client of a new payload
   """
-  @spec verify_and_notify_new_payload(Types.ExecutionPayload.t()) ::
+  @spec notify_new_payload(Types.ExecutionPayload.t()) ::
           {:ok, :optimistic | :valid | :invalid} | {:error, String.t()}
-  def verify_and_notify_new_payload(execution_payload) do
+  def notify_new_payload(execution_payload) do
     result = EngineApi.new_payload(execution_payload)
 
     case result do

--- a/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
@@ -165,7 +165,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
     # Make it a task so it runs concurrently with the state transition
     payload_verification_task =
       Task.async(fn ->
-        ExecutionClient.verify_and_notify_new_payload(block.body.execution_payload)
+        ExecutionClient.notify_new_payload(block.body.execution_payload)
         |> handle_verify_payload_result()
       end)
 


### PR DESCRIPTION
**Motivation**
I want to avoid confusion, since the two functions exists in the spec, but the one we're implementing is actually `notify_new_payload`.
