### PR TITLE
fix: make spec test generation depend on selected version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ $(SPECTEST_ROOTDIR)/%_${SPECTEST_VERSION}.tar.gz:
 	curl -L -o "$@" \
 		"https://github.com/ethereum/consensus-spec-tests/releases/download/${SPECTEST_VERSION}/$*.tar.gz"
 
-$(VECTORS_DIR)/%: $(SPECTEST_ROOTDIR)/%_${SPECTEST_VERSION}.tar.gz
+$(VECTORS_DIR)/%: $(SPECTEST_ROOTDIR)/%_${SPECTEST_VERSION}.tar.gz .spectest_version
 	-rm -rf $@
 	tar -xzmf "$<" -C $(SPECTEST_ROOTDIR)
 

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ compile-all: compile-native $(PROTOBUF_EX_FILES) download-beacon-node-oapi
 #🗑️ clean: @ Remove the build files.
 clean:
 	-mix clean
+	-rm -rf test/generated
 	-rm $(GO_ARCHIVES) $(GO_HEADERS) $(OUTPUT_DIR)/*
 
 #📊 grafana-up: @ Start grafana server.

--- a/test/spec/tasks/generate_spec_tests.ex
+++ b/test/spec/tasks/generate_spec_tests.ex
@@ -16,8 +16,13 @@ defmodule Mix.Tasks.GenerateSpecTests do
   @shortdoc "Generates tests for spec test files"
   @impl Mix.Task
   def run(_args) do
-    {:ok, file_names} = File.ls(Path.join(["test", "spec", "runners"]))
+    generated_folder = Path.join(["test", "generated"])
+    {:ok, file_names} = Path.join(["test", "spec", "runners"]) |> File.ls()
     runners = Enum.map(file_names, &Path.basename(&1, ".ex"))
+
+    # Empty test folder
+    File.rm_rf!(generated_folder)
+    File.mkdir_p!(generated_folder)
 
     # Generate all tests for Capella fork
     for config <- @configs, runner <- runners do
@@ -34,7 +39,7 @@ defmodule Mix.Tasks.GenerateSpecTests do
       generate_test(config, fork, "shuffling")
     end
 
-    File.touch(Path.join(["test", "generated"]))
+    File.touch(generated_folder)
   end
 
   defp generate_test(config, fork, runner) do


### PR DESCRIPTION
I was having some problems when changing the version listed in `.spectest_version`. This PR fixes that.