### PR TITLE
fix: use `tmp/` for test DBs

### DIFF
--- a/test/spec/tasks/generate_spec_tests.ex
+++ b/test/spec/tasks/generate_spec_tests.ex
@@ -70,7 +70,7 @@ defmodule Mix.Tasks.GenerateSpecTests do
       use ExUnit.Case, async: false
 
       setup_all do
-        start_link_supervised!({LambdaEthereumConsensus.Store.Db, dir: "test/generated/#{config}_#{fork}_#{runner}_test_db"})
+        start_link_supervised!({LambdaEthereumConsensus.Store.Db, dir: "tmp/#{config}_#{fork}_#{runner}_test_db"})
         start_link_supervised!(LambdaEthereumConsensus.Store.Blocks)
         start_link_supervised!(LambdaEthereumConsensus.Store.BlockStates)
         Application.put_env(:lambda_ethereum_consensus, ChainSpec, config: #{chain_spec_config(config)})


### PR DESCRIPTION
When running `make spec-test` it sometimes clashes with db files, trying to load them as test files, while failing to run. This fixes that by using a different folder for the DBs