### PR TITLE
docs: fix typos

### DIFF
--- a/docs/bindings_go.md
+++ b/docs/bindings_go.md
@@ -6,7 +6,7 @@ The bindings are used to interact with the *go-libp2p* and *go-ethereum/p2p* lib
 As we couldn't find a way to communicate the two languages directly, we used some **C** code to communicate the two sides.
 However, as Go is a garbage-collected language, this brings some issues.
 
-<!-- TODO: add explanation about general bindings usage -->
+<!-- TODO: add an explanation about general bindings usage -->
 <!-- TODO: explain the callback -> message translation -->
 
 ## References and handles
@@ -57,7 +57,7 @@ func SumAndConsumeArray(arrayHandle C.uintptr_t) uint {
 
 What we have until now allows us to create long-living references, but we still need to free them manually (otherwise we leak memory).
 To fix this, we can treat them as native objects with Erlang's [*Resource objects*](https://www.erlang.org/doc/man/erl_nif.html#functionality).
-By treating them as resources with an associated type and destructor, we can let Erlang's garbage-collector manage the reference's lifetime.
+By treating them as resources with an associated type and destructor, we can let Erlang's garbage collector manage the reference's lifetime.
 It works as follows:
 
 <!-- TODO: add code examples -->

--- a/docs/bitvectors.md
+++ b/docs/bitvectors.md
@@ -2,13 +2,13 @@
 
 ## Representing integers
 
-Computers use transistors to store data. These electrical components only have two possible states: `clear` or `set`. Numerically, we represent the clear state as a `0` and and the set state as `1`. Using 1s and 0s, we can represent any integer number using the binary system, the same way we use the decimal system in our daily lives.
+Computers use transistors to store data. These electrical components only have two possible states: `clear` or `set`. Numerically, we represent the clear state as a `0` and the set state as `1`. Using 1s and 0s, we can represent any integer number using the binary system, the same way we use the decimal system in our daily lives.
 
-As an example, let's take the number 259. For its decimal representation, we use the digits 2, 5 and 9, because each digit, or coefficient, represents a power of 10:
+As an example, let's take the number 259. For its decimal representation, we use the digits 2, 5, and 9, because each digit, or coefficient, represents a power of 10:
 
 $$ 259 = 200 + 50 + 9 = 2*10^2 + 5*10^1 + 9*10^0 $$
 
-If we wanted to do the same the binary binary, we would use powers of two, and each individual symbol (or bit) can only be 0 or 1.
+If we wanted to do the same in the binary, we would use powers of two, and each symbol (or bit) can only be 0 or 1.
 
 $$ 259 = 256 + 2 + 1 = 1*2^{8} + 1*2^{1} + 1*2^0 $$
 
@@ -44,7 +44,7 @@ Representing it as a byte array, we get `bytes = [3, 1]`. The lowest index, `byt
 
 ### "Little-endian bit order"
 
-Why would we need a third representation? Let's first pose the problem. Imagine we have a fixed amount of validators, equal to 9, and we want to represent whether they attested in a block or not. If the validators 0, 1 and 8 attested, we may represent this with a boolean array, as follows:
+Why would we need a third representation? Let's first pose the problem. Imagine we have a fixed amount of validators, equal to 9, and we want to represent whether they attested in a block or not. If the validators 0, 1, and 8 attested, we may represent this with a boolean array, as follows:
 
 ```
 [true, true, false, false, false, false, false, false, true]
@@ -76,13 +76,13 @@ If we want to convert from each order to each other:
 
 - Little-endian byte order to big-endian: reverse the bytes.
 - Little-endian bit order to big-endian: reverse the bits of the whole number.
-- Little-endian bit order to little-endian byte order: reverse the bits of each individual byte. This is equivalent to reversing all bits (converting to big-endian) and then reversing the bytes (big-endian to little-endian byte order) but in a single step.
+- Little-endian bit order to little-endian byte order: reverse the bits of each byte. This is equivalent to reversing all bits (converting to big-endian) and then reversing the bytes (big-endian to little-endian byte order) but in a single step.
 
 ## Bit vectors
 
 ### Serialization (SSZ)
 
-`bitvectors` are exactly that: a set of booleans with fixed size. SSZ represents bit vectors as follows:
+`bitvectors` are exactly that: a set of booleans with a fixed size. SSZ represents bit vectors as follows:
 
 - Conceptually, a set is represented in little-endian bit ordering, padded with 0s at the end to get full bytes.
 - When serializing, we convert from little-endian bit ordering to little-endian byte ordering.
@@ -111,22 +111,22 @@ Moving it to little-endian byte order (we go byte by byte and reverse the bits):
 00000011 00000001
 ```
 
-This is how nodes send `bitvectors` over the network. We know that this array is of size 9 beforehand, so we know what bits are padding and should be ignored. For variable-sized bit arrays we'll use `bitlists`, which we'll talk about later.
+This is how nodes send `bitvectors` over the network. We know that this array is of size 9 beforehand, so we know what bits are padding and should be ignored. For variable-sized bit arrays, we'll use `bitlists`, which we'll talk about later.
 
 ### Internal representation
 
-There's a trick here: SSZ doesn't specify how to store a `bitvector` in memory after deserializing. We could, theoretically, read the serialized data, transform it from little-endian byte order to little-endian bit order, and use bit addressing (which elixir supports) to get individual values. This would imply, however, going through each byte and reversing the bits, which is a costly operation. If we stuck with little-endian byte order without transforming it, addressing individual bits would be more complicated, and shifting (moving every bit to the left or right) would be tricky.
+There's a trick here: SSZ doesn't specify how to store a `bitvector` in memory after deserializing. We could, theoretically, read the serialized data, transform it from little-endian byte order to little-endian bit order, and use bit addressing (which Elixir supports) to get individual values. This would imply, however, going through each byte and reversing the bits, which is a costly operation. If we stuck with little-endian byte order without transforming it, addressing individual bits would be more complicated, and shifting (moving every bit to the left or right) would be tricky.
 
 For this reason, we represent bitvectors in our node as big-endian binaries. That means that we reverse the bytes (a relatively cheap operation) and, for bit addressing, we just use the complementary index. An example:
 
-If we are still representing the number 259 (validators with index 0, 1 and 8 attested) we'll have the two following representations (note, elixir has a `bitstring` type that lets you address bit by bit and store an amount of bits that's not a multiple of 8):
+If we are still representing the number 259 (validators with index 0, 1, and 8 attested) we'll have the two following representations (note, elixir has a `bitstring` type that lets you address bit by bit and store several bits that's not a multiple of 8):
 
 ```
 110000001 -> little-endian bit order
 100000011 -> big-endian
 ```
 
-If we watch closely, we confirm something we said before: these are bit-mirrored representations. That means that if I want to know if the validator i voted, in the little-endian bit order, we address `bitvector[i]`, and in the big-endian order, we just use `bitvector[N-i]`, where `N=9` as it's the size of the vector.
+If we watch closely, we confirm something we said before: these are bit-mirrored representations. That means that if I want to know if the validator I voted, in the little-endian bit order, we address `bitvector[i]`, and in the big-endian order, we just use `bitvector[N-i]`, where `N=9` as it's the size of the vector.
 
 This is the code that performs this conversion:
 
@@ -139,9 +139,9 @@ def new(bitstring, size) when is_bitstring(bitstring) do
 end
 ```
 
-It reads the input as a little-endian number, and then constructs a big-endian binary representation of it.
+It reads the input as a little-endian number and then constructs a big-endian binary representation of it.
 
-Instead of using Elixir's bitstrings, a possible optimization (we'd need to benchmark it) would be to represent the array as the number 259 directly, and use bitwise operations to address bits or shift.
+Instead of using Elixir's bitstrings, a possible optimization (we'd need to benchmark it) would be to represent the array as the number 259 directly and use bitwise operations to address bits or shift.
 
 ## Bitlists
 
@@ -177,7 +177,7 @@ When deserializing, we'll look closely at the last byte, realize that there are 
 
 ### Edge case: already a multiple of 8
 
-It might be the case that we already have a multiple of 8 as the number of booleans we're representing. For instance, let's suppose that we have 8 validators and only the first and the second one attested. In little-endian bit order, that is:
+It might be the case that we already have a multiple of 8 as the number of booleans we're representing. For instance, let's suppose that we have 8 validators and only the first and the second ones attested. In little-endian bit order, that is:
 
 ```
 11000000

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -1,21 +1,21 @@
 # Clients
 
-As we talked previously, Ethereum is a network made by different computers. Its workflow would work, in theory, as follows:
+As we talked about previously, Ethereum is a network made by different computers. Its workflow would work, in theory, as follows:
 
-- A user of the network sends a transaction (e.g. an eth transfer) to the network.
+- A user of the network sends a transaction (e.g. an ETH transfer) to the network.
 - The network validates the transaction.
 - The network includes the transaction in a block.
 - The network includes the block in the chain, so the new state includes the transaction sent by the user. Any user can request this information and the change will be reflected.
 
 The problem here is: what does sending something to the network mean?
 
-## How does this actually work? Who talks with who?
+## How does this actually work? Who talks with whom?
 
-Ideally, each user has its own node installed in their computer and they interact with the network by sending their transactions and queries to their own node. This node propagates the message to other nodes and receives propagated messages from its peers to update its own view of the EVM state. When the user queries some state, the node answers with its own view.
+Ideally, each user has its own node installed in their computer and they interact with the network by sending their transactions and queries to their node. This node propagates the message to other nodes and receives propagated messages from its peers to update its view of the EVM state. When the user queries some state, the node answers with its own view.
 
 A full node is split into two clients:
 
-- **The execution client** knows how to represent EVM state and apply state changes (transactions) to generate new states. It represents the state machine.
+- **The execution client** knows how to represent the EVM state and apply state changes (transactions) to generate new states. It represents the state machine.
 - **The consensus client** knows very little about the state machine, but knows how to choose between different worldviews and agree with other nodes. It enables the execution client to apply the correct state transitions.
 
 Here's a block diagram of their interactions:
@@ -48,36 +48,36 @@ linkStyle 2 stroke:#ff0000,stroke-width:2px;
 linkStyle 3 stroke:#ff0000,stroke-width:2px;
 ```
 
-You might notice there's a section called "validator" in there, with red arrows. Your node is considered a validator if it has 32 ETH staked in the validator contract, which makes it capable of proposing new blocks and attesting for other proposals. That is: actively participating in the protocol and getting rewards for it.
+You might notice there's a section called "validator" in there, with red arrows. Your node is considered a validator if it has 32 ETH staked in the validator contract, which makes it capable of proposing new blocks and attesting to other proposals. That is: actively participating in the protocol and getting rewards for it.
 
-If you're not a validator you can still participate though! The block diagram is the same, without the red lines (and you won't receive rewards for it). You can still send transactions to your local node, propagate it to others and receive updates.
+If you're not a validator you can still participate though! The block diagram is the same, without the red lines (and you won't receive rewards for it). You can still send transactions to your local node, propagate them to others, and receive updates.
 
 ## Lifecycle of a transaction
 
-Here's the full sequence from the perspective of a non validator node:
+Here's the full sequence from the perspective of a non-validator node:
 
-1. A user builds, signs and sends a transaction to their execution client's JSON-RPC API. This is usually done with a wrapper library like `ethers` , `hardhat` or `foundry`.
+1. A user builds, signs, and sends a transaction to their execution client's JSON-RPC API. This is usually done with a wrapper library like `ethers`, `hardhat`, or `foundry`.
 2. The execution client receives the transaction and:
     1. Validates it (checks the user has enough ETH, the signature matches, etc).
     2. Adds it to its local mempool. The mempool is a local pool of transactions that are not yet executed.
-    3. Broadcasts it through the execution gossip layer, to other execution nodes. Other execution nodes include it in their own mempools.
+    3. Broadcasts it through the execution gossip layer, to other execution nodes. Other execution nodes include it in their mempools.
 3. A validator node is selected as a block proposer. As a proposer:
     1. Their execution client bundles many transactions from its mempool into a block.
-    2. All transactions in the bundle are executed locally and state change calculated.
+    2. All transactions in the bundle are executed locally and state change is calculated.
     3. Their consensus client gets this block (or as consensus calls it, "execution payload") and adds consensus layer information, like attestations, slashings, rewards, penalties, etc. The execution payload + consensus metadata forms a "beacon block".
     4. The beacon block is signed and sent over the consensus gossip layer to other nodes.
 4. A committee of validators validates that block and sends signed attestations for it over the consensus gossip protocol too.
 5. All nodes receive both the new proposed block and attestations. Then they:
-    1. Include the new block in their own local fork tree if its valid.
+    1. Include the new block in their local fork tree if it's valid.
     2. Save the attestations and update the weights of the blocks on the tree.
     3. Apply fork choice to recalculate, if necessary, what blocks are included in the canonical chain.
-    4. The changes + the new block are propagated to the execution node so transactions are applied and state is changed and up to date.
+    4. The changes + the new block are propagated to the execution node so transactions are applied and the state is changed and up to date.
 
 ## Caveats
 
-This is the ideal happy path. There are other ways in which this can work, and ways in which something can go wrong:
+This is the ideal happy path. There are other ways in which this can work and ways in which something can go wrong:
 
-- Not all users run their own node. They use services like infura or alchemy, that take JSON-RPC requests and process them with their own nodes. Wallets like metamask, for instance, use these.
-- There are intermediaries like flashbots, which are outside of the scope of this documentations, that cause variations in the "who talks to who" diagram.
+- Not all users run their own node. They use services like Infura or Alchemy, that take JSON-RPC requests and process them with their nodes. Wallets like metamask, for instance, use these.
+- There are intermediaries like Flashbots, which are outside of the scope of this documentation, that cause variations in the "who talks to who" diagram.
 
 In the [next document](architecture.md), we discuss zoom into the consensus node and how it works.

--- a/docs/consensus.md
+++ b/docs/consensus.md
@@ -16,15 +16,15 @@ A classical approach to representing a distributed state is to store all changes
 
 Storing the log is useful because each state change is immutable, and agreeing on them is easier than agreeing on the current state, which is always changing.
 
-Agreeing on the log is agreeing on the current state. How do we do that? We need two things: sybil resistence and consensus algorithms.
+Agreeing on the log is agreeing on the current state. How do we do that? We need two things: Sybil resistance and consensus algorithms.
 
-## Sybil resistence
+## Sybil resistance
 
 In a byzantine, trustless environment, we need to take several measures to make the network safe:
 
 - Cryptographic signatures validate the authority of transactions.
 - Transactions are batched in blocks so the overhead of consensus is reduced.
-- Verifying the integrity of blocks needs to be easy. For this reason, each block is linked to its parent, each block has a hash of its own contents, and part of each block's content is its parent hash. That means that changing any block in history will cause noticeable changes in the block's hash. **This makes the log a block chain**.
+- Verifying the integrity of blocks needs to be easy. For this reason, each block is linked to its parent, each block has a hash of its own contents, and part of each block's content is its parent hash. That means that changing any block in history will cause noticeable changes in the block's hash. **This makes the log a blockchain**.
 - We need nodes to pay a price for participating in consensus, or they can create millions of virtual nodes to vote/spam the network. Proof of work makes nodes solve very hard puzzles that take a lot of computational time and power so they can propose new blocks. Proof of stake does this more directly, with money: to propose a new block, you need to have 32 ETH staked and wait for your predetermined turn. If you do something invalid, other nodes will notice and punish you.
 
 ## Consensus algorithms
@@ -66,6 +66,6 @@ graph LR
 In post-merge Ethereum, consensus is reached by two combined fork-related algorithms:
 
 - LMD GHOST: a fork-choice algorithm based on votes (attestations). If a majority of nodes follow this algorithm, they will tend to converge to the same canonical chain. We expand more on it on [this document](fork_choice.md).
-- Casper FFG: provides some level of safety by defining a finalization criterion. It takes a fork tree and defines a strategy to prune it (make branches inaccessible). Once a block is tagged as "final", blocks that aren't either parents (which are also final) or descendants of it, are not valid blocks. This prevents long reorganizations, which might make users vulnerable to double spends. We expand on it in [this document](finality.md).
+- Casper FFG: provides some level of safety by defining a finalization criterion. It takes a fork tree and defines a strategy to prune it (make branches inaccessible). Once a block is tagged as "final", blocks that aren't either parents (which are also final) or descendants of it, are not valid blocks. This prevents long reorganizations, which might make users vulnerable to double-spends. We expand on it in [this document](finality.md).
 
-The recommended next read is the [clients document](clients.md), which explains, at a high level, how ethereum nodes interact with each other.
+The recommended next read is the [clients document](clients.md), which explains, at a high level, how Ethereum nodes interact with each other.

--- a/docs/finality.md
+++ b/docs/finality.md
@@ -1,5 +1,5 @@
 # Finalization: Casper FFG
 
-The name stands for Friendly Finality Gadget. It as a "finality gadget" as it always works on top of a block-proposing algorithm.
+The name stands for Friendly Finality Gadget. It is a "finality gadget" as it always works on top of a block-proposing algorithm.
 
-**This document will be expaned in a different PR**
+**This document will be expanded in a different PR**

--- a/docs/fork_choice.md
+++ b/docs/fork_choice.md
@@ -2,7 +2,7 @@
 
 Let's separate the two parts of the name.
 
-- GHOST: **G**reediest, **H**eaviest-**O**bserved **S**ub-**T**ree. The algorithm provides a strategy to choose between two forks/branches. Each branch points to a block, and each block can be thought of as the root of a subtree containing all of its child nodes. The weight of the subtree is the sum of the weights of all blocks in it. The weight of each individual block is obtained from the attestations on them.
+- GHOST: **G**reediest, **H**eaviest-**O**bserved **S**ub-**T**ree. The algorithm provides a strategy to choose between two forks/branches. Each branch points to a block, and each block can be thought of as the root of a subtree containing all of its child nodes. The weight of the subtree is the sum of the weights of all blocks in it. The weight of each block is obtained from the attestations on them.
 - LMD: each validator gives attestations/votes to the block they think is the current head of the chain (Message Driven). "Latest" means that only the last attestation for each validator will be taken into account.
 
 By choosing a fork, each node has a single, linear chain of blocks that it considers canonical. The last child of that chain is called the chain's "head".
@@ -11,7 +11,7 @@ By choosing a fork, each node has a single, linear chain of blocks that it consi
 
 When an attestation arrives, the `on_attestation` callback must:
 
-1. Perform the [validity checks](https://eth2book.info/capella/part3/forkchoice/phase0/#validate_on_attestation). tl;dr: the slot and epoch need to be right, the vote must be for a block we have, validate the signature and check it doesn't conflict with a different attestation by the same validator.
+1. Perform the [validity checks](https://eth2book.info/capella/part3/forkchoice/phase0/#validate_on_attestation). TL;DR: the slot and epoch need to be right, the vote must be for a block we have, validate the signature, and check it doesn't conflict with a different attestation by the same validator.
 2. [Save the attestation](https://eth2book.info/capella/part3/forkchoice/phase0/#update_latest_messages) as that validator's latest message. If there's one already, update the value.
 
 ## Choosing forks
@@ -21,11 +21,11 @@ We now have a store of each validator's latest vote, which allows LMD GHOST to w
 We first need to calculate each block's weight:
 
 - For leaf blocks, we calculate their weight by checking how many votes they have.
-- For each branch block we calculate its weight as the sum of the weight of every child, plus its own votes. We repeat this until we reach the root, which will be the last finalized block (there won't be any branches before, so there won't be any more fork-choice to perform).
+- For each branch block we calculate its weight as the sum of the weight of every child, plus its votes. We repeat this until we reach the root, which will be the last finalized block (there won't be any branches before, so there won't be any more fork-choice to perform).
 
-This way we calculate the weight not only for each block, but for the subtree where that block is the root.
+This way we calculate the weight not only for each block but for the subtree where that block is the root.
 
-Afterwards, when we want to determine which is the head of the chain, we traverse the tree, starting from the root, and greedily (without looking further ahead) we go block by block chosing the sub-tree with the highest weight.
+Afterward, when we want to determine which is the head of the chain, we traverse the tree, starting from the root, and greedily (without looking further ahead) we go block by block choosing the sub-tree with the highest weight.
 
 Let's look at an example:
 
@@ -45,7 +45,7 @@ graph LR
 
 Here, individual block weights are represented by "b", while subtree weights are represented by "w". Some observations:
 
-- $W = B$ for all leaf blocks, as leafs are their own whole subtree.
+- $W = B$ for all leaf blocks, as leaves are their whole subtree.
 - $W_A=W_C+W_B +B_A= B_B + B_C + B_A$
 - While the individual weight of $A$ is smaller than $B$, its children make the $A$ subtree heavier than the $B$ subtree, so its chosen by LMD GHOST over $B$.
 
@@ -57,17 +57,17 @@ $$W_N = B_N + \sum_i^{i \in \text{children}[N]}W_i$$
 
 In the previous scheme, there are two rewards:
 
-- Proposer rewards, given to a proposer when their block is included in the chain. This also adds an incentive for them to try to predict the most-likely branch to be the canonical one.
-- Attester rewards, which are smaller. These are given if the blocks they attest to are included.
+- Proposer rewards, are given to a proposer when their block is included in the chain. This also adds an incentive for them to try to predict the most likely branch to be the canonical one.
+- Attester rewards, given if the blocks they attest to are included. They are smaller than proposer rewards.
 
 These incentives, however, are not enough. To maximize their likelihood of getting rewards, they may misbehave:
 
 - Proposers may propose a block for every current fork.
 - Attesters may attest to every current head in their local chains.
 
-These misbehaviors debilitate the protocol (they give weight to all forks) and no honest node running fork-choice would take part on them. To prevent them, nodes that are detected while doing them are slashed (punished), which means that they are excluded from the validator set and a portion of their stake is burned.
+These misbehaviors debilitate the protocol (they give weight to all forks) and no honest node running fork-choice would take part in them. To prevent them, nodes that are detected while doing them are slashed (punished), which means that they are excluded from the validator set and a portion of their stake is burned.
 
-Nodes provide proofs of the offenses, and proposers including them in blocks get whistleblower rewards. Proofs are:
+Nodes provide proof of the offenses, and proposers including them in blocks get whistle-blower rewards. Proofs are:
 
 - For proposer slashing: two block headers in the same slot signed by the same signature.
 - For attester slashing: two attestations signed in the same slot by the same signature.
@@ -76,4 +76,4 @@ Nodes provide proofs of the offenses, and proposers including them in blocks get
 
 - Majority honest progress: if the network has over 50% nodes running this algorithm honestly, the chain progresses and each older block is exponentially more unlikely to be reverted.
 - Stability: fork-choice is self-reinforcing and acts as a good predictor of the next block.
-- Manipulation resistence. Not only is it hard to build a secret chain and propose it, but it prevents getting attestations for it, so the current canonical one is always more likely to be heavier. This holds even if the length of the secret chain is higher.
+- Manipulation resistance. Not only is it hard to build a secret chain and propose it, but it prevents getting attestations for it, so the current canonical one is always more likely to be heavier. This holds even if the length of the secret chain is higher.


### PR DESCRIPTION
This PR fixes some typos present in the docs, with the help of an online grammar checker.