### PR TITLE
docs: update consolidated specs to v1.4.0-beta.7

### DIFF
--- a/docs/specs/beacon-chain.md
+++ b/docs/specs/beacon-chain.md
@@ -184,6 +184,7 @@ The following values are (non-configurable) constants used throughout the specif
 
 | Name | Value |
 | - | - |
+| `UINT64_MAX` | `uint64(2**64 - 1)` |
 | `GENESIS_SLOT` | `Slot(0)` |
 | `GENESIS_EPOCH` | `Epoch(0)` |
 | `FAR_FUTURE_EPOCH` | `Epoch(2**64 - 1)` |
@@ -921,6 +922,8 @@ def integer_squareroot(n: uint64) -> uint64:
     """
     Return the largest integer ``x`` such that ``x**2 <= n``.
     """
+    if n == UINT64_MAX:
+        return uint64(4294967295)
     x = n
     y = (x + 1) // 2
     while y < x:

--- a/docs/specs/beacon-chain.md
+++ b/docs/specs/beacon-chain.md
@@ -2035,6 +2035,8 @@ def process_slot(state: BeaconState) -> None:
 
 ### Epoch processing
 
+*Note*: The function `process_historical_summaries_update` replaces `process_historical_roots_update` in Capella.
+
 ```python
 def process_epoch(state: BeaconState) -> None:
     process_justification_and_finalization(state)

--- a/docs/specs/fork-choice.md
+++ b/docs/specs/fork-choice.md
@@ -870,3 +870,83 @@ As per EIP-3675, before a post-transition block is finalized, `notify_forkchoice
 
 The `safe_block_hash` parameter MUST be set to return value of
 [`get_safe_execution_payload_hash(store: Store)`](../../fork_choice/safe-block.md#get_safe_execution_payload_hash) function.
+
+##### `should_override_forkchoice_update`
+
+If proposer boost re-orgs are implemented and enabled (see `get_proposer_head`) then additional care
+must be taken to ensure that the proposer is able to build an execution payload.
+
+If a beacon node knows it will propose the next block then it SHOULD NOT call
+`notify_forkchoice_updated` if it detects the current head to be weak and potentially capable of
+being re-orged. Complete information for evaluating `get_proposer_head` _will not_ be available
+immediately after the receipt of a new block, so an approximation of those conditions should be
+used when deciding whether to send or suppress a fork choice notification. The exact conditions
+used may be implementation-specific, a suggested implementation is below.
+
+Let `validator_is_connected(validator_index: ValidatorIndex) -> bool` be a function that indicates
+whether the validator with `validator_index` is connected to the node (e.g. has sent an unexpired
+proposer preparation message).
+
+```python
+def should_override_forkchoice_update(store: Store, head_root: Root) -> bool:
+    head_block = store.blocks[head_root]
+    parent_root = head_block.parent_root
+    parent_block = store.blocks[parent_root]
+    current_slot = get_current_slot(store)
+    proposal_slot = head_block.slot + Slot(1)
+
+    # Only re-org the head_block block if it arrived later than the attestation deadline.
+    head_late = is_head_late(store, head_root)
+
+    # Shuffling stable.
+    shuffling_stable = is_shuffling_stable(proposal_slot)
+
+    # FFG information of the new head_block will be competitive with the current head.
+    ffg_competitive = is_ffg_competitive(store, head_root, parent_root)
+
+    # Do not re-org if the chain is not finalizing with acceptable frequency.
+    finalization_ok = is_finalization_ok(store, proposal_slot)
+
+    # Only suppress the fork choice update if we are confident that we will propose the next block.
+    parent_state_advanced = store.block_states[parent_root].copy()
+    process_slots(parent_state_advanced, proposal_slot)
+    proposer_index = get_beacon_proposer_index(parent_state_advanced)
+    proposing_reorg_slot = validator_is_connected(proposer_index)
+
+    # Single slot re-org.
+    parent_slot_ok = parent_block.slot + 1 == head_block.slot
+    proposing_on_time = is_proposing_on_time(store)
+
+    # Note that this condition is different from `get_proposer_head`
+    current_time_ok = (head_block.slot == current_slot
+                       or (proposal_slot == current_slot and proposing_on_time))
+    single_slot_reorg = parent_slot_ok and current_time_ok
+
+    # Check the head weight only if the attestations from the head slot have already been applied.
+    # Implementations may want to do this in different ways, e.g. by advancing
+    # `store.time` early, or by counting queued attestations during the head block's slot.
+    if current_slot > head_block.slot:
+        head_weak = is_head_weak(store, head_root)
+        parent_strong = is_parent_strong(store, parent_root)
+    else:
+        head_weak = True
+        parent_strong = True
+
+    return all([head_late, shuffling_stable, ffg_competitive, finalization_ok,
+                proposing_reorg_slot, single_slot_reorg,
+                head_weak, parent_strong])
+```
+
+*Note*: The ordering of conditions is a suggestion only. Implementations are free to
+optimize by re-ordering the conditions from least to most expensive and by returning early if
+any of the early conditions are `False`.
+
+In case `should_override_forkchoice_update` returns `True`, a node SHOULD instead call
+`notify_forkchoice_updated` with parameters appropriate for building upon the parent block. Care
+must be taken to compute the correct `payload_attributes`, as they may change depending on the slot
+of the block to be proposed (due to withdrawals).
+
+If `should_override_forkchoice_update` returns `True` but `get_proposer_head` later chooses the
+canonical head rather than its parent, then this is a misprediction that will cause the node
+to construct a payload with less notice. The result of `get_proposer_head` MUST be preferred over
+the result of `should_override_forkchoice_update` (when proposer reorgs are enabled).

--- a/docs/specs/fork-choice.md
+++ b/docs/specs/fork-choice.md
@@ -16,8 +16,10 @@
     - [`get_forkchoice_store`](#get_forkchoice_store)
     - [`get_slots_since_genesis`](#get_slots_since_genesis)
     - [`get_current_slot`](#get_current_slot)
+    - [`get_current_store_epoch`](#get_current_store_epoch)
     - [`compute_slots_since_epoch_start`](#compute_slots_since_epoch_start)
     - [`get_ancestor`](#get_ancestor)
+    - [`calculate_committee_fraction`](#calculate_committee_fraction)
     - [`get_checkpoint_block`](#get_checkpoint_block)
     - [`get_weight`](#get_weight)
     - [`get_voting_source`](#get_voting_source)
@@ -26,6 +28,15 @@
     - [`get_head`](#get_head)
     - [`update_checkpoints`](#update_checkpoints)
     - [`update_unrealized_checkpoints`](#update_unrealized_checkpoints)
+    - [Proposer head and reorg helpers](#proposer-head-and-reorg-helpers)
+      - [`is_head_late`](#is_head_late)
+      - [`is_shuffling_stable`](#is_shuffling_stable)
+      - [`is_ffg_competitive`](#is_ffg_competitive)
+      - [`is_finalization_ok`](#is_finalization_ok)
+      - [`is_proposing_on_time`](#is_proposing_on_time)
+      - [`is_head_weak`](#is_head_weak)
+      - [`is_parent_strong`](#is_parent_strong)
+      - [`get_proposer_head`](#get_proposer_head)
     - [Pull-up tip helpers](#pull-up-tip-helpers)
       - [`compute_pulled_up_tip`](#compute_pulled_up_tip)
     - [`on_tick` helpers](#on_tick-helpers)
@@ -81,11 +92,16 @@ Any of the above handlers that trigger an unhandled exception (e.g. a failed ass
 
 ### Configuration
 
-| Name                   | Value        |
-| ---------------------- | ------------ |
-| `PROPOSER_SCORE_BOOST` | `uint64(40)` |
+| Name                                  | Value        |
+| ------------------------------------- | ------------ |
+| `PROPOSER_SCORE_BOOST`                | `uint64(40)` |
+| `REORG_HEAD_WEIGHT_THRESHOLD`         | `uint64(20)` |
+| `REORG_PARENT_WEIGHT_THRESHOLD`       | `uint64(160)`|
+| `REORG_MAX_EPOCHS_SINCE_FINALIZATION` | `Epoch(2)`   |
 
-- The proposer score boost is worth `PROPOSER_SCORE_BOOST` percentage of the committee's weight, i.e., for slot with committee weight `committee_weight` the boost weight is equal to `(committee_weight * PROPOSER_SCORE_BOOST) // 100`.
+- The proposer score boost and re-org weight threshold are percentage
+  values that are measured with respect to the weight of a single committee. See
+  `calculate_committee_fraction`.
 
 ### Helpers
 
@@ -120,6 +136,7 @@ class Store(object):
     equivocating_indices: Set[ValidatorIndex]
     blocks: Dict[Root, BeaconBlock] = field(default_factory=dict)
     block_states: Dict[Root, BeaconState] = field(default_factory=dict)
+    block_timeliness: Dict[Root, boolean] = field(default_factory=dict)
     checkpoint_states: Dict[Checkpoint, BeaconState] = field(default_factory=dict)
     latest_messages: Dict[ValidatorIndex, LatestMessage] = field(default_factory=dict)
     unrealized_justifications: Dict[Root, Checkpoint] = field(default_factory=dict)
@@ -129,8 +146,7 @@ class Store(object):
 
 ```python
 def is_previous_epoch_justified(store: Store) -> bool:
-    current_slot = get_current_slot(store)
-    current_epoch = compute_epoch_at_slot(current_slot)
+    current_epoch = get_current_store_epoch(store)
     return store.justified_checkpoint.epoch + 1 == current_epoch
 ```
 
@@ -179,6 +195,13 @@ def get_current_slot(store: Store) -> Slot:
     return Slot(GENESIS_SLOT + get_slots_since_genesis(store))
 ```
 
+### `get_current_store_epoch`
+
+```python
+def get_current_store_epoch(store: Store) -> Epoch:
+    return compute_epoch_at_slot(get_current_slot(store))
+```
+
 #### `compute_slots_since_epoch_start`
 
 ```python
@@ -196,6 +219,14 @@ def get_ancestor(store: Store, root: Root, slot: Slot) -> Root:
     return root
 ```
 
+### `calculate_committee_fraction`
+
+```python
+def calculate_committee_fraction(state: BeaconState, committee_percent: uint64) -> Gwei:
+    committee_weight = get_total_active_balance(state) // SLOTS_PER_EPOCH
+    return Gwei((committee_weight * committee_percent) // 100)
+```
+
 #### `get_checkpoint_block`
 
 ```python
@@ -205,6 +236,15 @@ def get_checkpoint_block(store: Store, root: Root, epoch: Epoch) -> Root:
     """
     epoch_first_slot = compute_start_slot_at_epoch(epoch)
     return get_ancestor(store, root, epoch_first_slot)
+```
+
+#### `get_proposer_score`
+
+```python
+def get_proposer_score(store: Store) -> Gwei:
+    justified_checkpoint_state = store.checkpoint_states[store.justified_checkpoint]
+    committee_weight = get_total_active_balance(justified_checkpoint_state) // SLOTS_PER_EPOCH
+    return (committee_weight * PROPOSER_SCORE_BOOST) // 100
 ```
 
 #### `get_weight`
@@ -230,8 +270,7 @@ def get_weight(store: Store, root: Root) -> Gwei:
     proposer_score = Gwei(0)
     # Boost is applied if ``root`` is an ancestor of ``proposer_boost_root``
     if get_ancestor(store, store.proposer_boost_root, store.blocks[root].slot) == root:
-        committee_weight = get_total_active_balance(state) // SLOTS_PER_EPOCH
-        proposer_score = (committee_weight * PROPOSER_SCORE_BOOST) // 100
+        proposer_score = get_proposer_score(store)
     return attestation_score + proposer_score
 ```
 
@@ -243,7 +282,7 @@ def get_voting_source(store: Store, block_root: Root) -> Checkpoint:
     Compute the voting source checkpoint in event that block with root ``block_root`` is the head block
     """
     block = store.blocks[block_root]
-    current_epoch = compute_epoch_at_slot(get_current_slot(store))
+    current_epoch = get_current_store_epoch(store)
     block_epoch = compute_epoch_at_slot(block.slot)
     if current_epoch > block_epoch:
         # The block is from a prior epoch, the voting source will be pulled-up
@@ -276,13 +315,15 @@ def filter_block_tree(store: Store, block_root: Root, blocks: Dict[Root, BeaconB
             return True
         return False
 
-    current_epoch = compute_epoch_at_slot(get_current_slot(store))
+    current_epoch = get_current_store_epoch(store)
     voting_source = get_voting_source(store, block_root)
 
-    # The voting source should be at the same height as the store's justified checkpoint
+    # The voting source should be either at the same height as the store's justified checkpoint or
+    # not more than two epochs ago
     correct_justified = (
         store.justified_checkpoint.epoch == GENESIS_EPOCH
         or voting_source.epoch == store.justified_checkpoint.epoch
+        or voting_source.epoch + 2 >= current_epoch
     )
 
     # If the previous epoch is justified, the block should be pulled-up. In this case, check that unrealized
@@ -380,6 +421,114 @@ def update_unrealized_checkpoints(store: Store, unrealized_justified_checkpoint:
         store.unrealized_finalized_checkpoint = unrealized_finalized_checkpoint
 ```
 
+#### Proposer head and reorg helpers
+
+_Implementing these helpers is optional_.
+
+##### `is_head_late`
+```python
+def is_head_late(store: Store, head_root: Root) -> bool:
+    return not store.block_timeliness[head_root]
+```
+
+##### `is_shuffling_stable`
+```python
+def is_shuffling_stable(slot: Slot) -> bool:
+    return slot % SLOTS_PER_EPOCH != 0
+```
+
+##### `is_ffg_competitive`
+
+```python
+def is_ffg_competitive(store: Store, head_root: Root, parent_root: Root) -> bool:
+    return (store.unrealized_justifications[head_root] == store.unrealized_justifications[parent_root])
+```
+
+##### `is_finalization_ok`
+
+```python
+def is_finalization_ok(store: Store, slot: Slot) -> bool:
+    epochs_since_finalization = compute_epoch_at_slot(slot) - store.finalized_checkpoint.epoch
+    return epochs_since_finalization <= REORG_MAX_EPOCHS_SINCE_FINALIZATION
+```
+
+##### `is_proposing_on_time`
+
+```python
+def is_proposing_on_time(store: Store) -> bool:
+    # Use half `SECONDS_PER_SLOT // INTERVALS_PER_SLOT` as the proposer reorg deadline
+    time_into_slot = (store.time - store.genesis_time) % SECONDS_PER_SLOT
+    proposer_reorg_cutoff = SECONDS_PER_SLOT // INTERVALS_PER_SLOT // 2
+    return time_into_slot <= proposer_reorg_cutoff
+```
+
+##### `is_head_weak`
+
+```python
+def is_head_weak(store: Store, head_root: Root) -> bool:
+    justified_state = store.checkpoint_states[store.justified_checkpoint]
+    reorg_threshold = calculate_committee_fraction(justified_state, REORG_HEAD_WEIGHT_THRESHOLD)
+    head_weight = get_weight(store, head_root)
+    return head_weight < reorg_threshold
+```
+
+##### `is_parent_strong`
+
+```python
+def is_parent_strong(store: Store, parent_root: Root) -> bool:
+    justified_state = store.checkpoint_states[store.justified_checkpoint]
+    parent_threshold = calculate_committee_fraction(justified_state, REORG_PARENT_WEIGHT_THRESHOLD)
+    parent_weight = get_weight(store, parent_root)
+    return parent_weight > parent_threshold
+```
+
+##### `get_proposer_head`
+
+```python
+def get_proposer_head(store: Store, head_root: Root, slot: Slot) -> Root:
+    head_block = store.blocks[head_root]
+    parent_root = head_block.parent_root
+    parent_block = store.blocks[parent_root]
+
+    # Only re-org the head block if it arrived later than the attestation deadline.
+    head_late = is_head_late(store, head_root)
+
+    # Do not re-org on an epoch boundary where the proposer shuffling could change.
+    shuffling_stable = is_shuffling_stable(slot)
+
+    # Ensure that the FFG information of the new head will be competitive with the current head.
+    ffg_competitive = is_ffg_competitive(store, head_root, parent_root)
+
+    # Do not re-org if the chain is not finalizing with acceptable frequency.
+    finalization_ok = is_finalization_ok(store, slot)
+
+    # Only re-org if we are proposing on-time.
+    proposing_on_time = is_proposing_on_time(store)
+
+    # Only re-org a single slot at most.
+    parent_slot_ok = parent_block.slot + 1 == head_block.slot
+    current_time_ok = head_block.slot + 1 == slot
+    single_slot_reorg = parent_slot_ok and current_time_ok
+
+    # Check that the head has few enough votes to be overpowered by our proposer boost.
+    assert store.proposer_boost_root != head_root  # ensure boost has worn off
+    head_weak = is_head_weak(store, head_root)
+
+    # Check that the missing votes are assigned to the parent and not being hoarded.
+    parent_strong = is_parent_strong(store, parent_root)
+
+    if all([head_late, shuffling_stable, ffg_competitive, finalization_ok,
+            proposing_on_time, single_slot_reorg, head_weak, parent_strong]):
+        # We can re-org the current head by building upon its parent block.
+        return parent_root
+    else:
+        return head_root
+```
+
+*Note*: The ordering of conditions is a suggestion only. Implementations are free to
+optimize by re-ordering the conditions from least to most expensive and by returning early if
+any of the early conditions are `False`.
+
 #### Execution helpers (new in Bellatrix)
 
 ##### `PayloadAttributes`
@@ -464,7 +613,7 @@ def compute_pulled_up_tip(store: Store, block_root: Root) -> None:
 
     # If the block is from a prior epoch, apply the realized values
     block_epoch = compute_epoch_at_slot(store.blocks[block_root].slot)
-    current_epoch = compute_epoch_at_slot(get_current_slot(store))
+    current_epoch = get_current_store_epoch(store)
     if block_epoch < current_epoch:
         update_checkpoints(store, state.current_justified_checkpoint, state.finalized_checkpoint)
 ```
@@ -500,7 +649,7 @@ def validate_target_epoch_against_current_time(store: Store, attestation: Attest
     target = attestation.data.target
 
     # Attestations must be from the current or previous epoch
-    current_epoch = compute_epoch_at_slot(get_current_slot(store))
+    current_epoch = get_current_store_epoch(store)
     # Use GENESIS_EPOCH for previous when genesis to avoid underflow
     previous_epoch = current_epoch - 1 if current_epoch > GENESIS_EPOCH else GENESIS_EPOCH
     # If attestation target is from a future epoch, delay consideration until the epoch arrives
@@ -618,10 +767,15 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     # Add new state for this block to the store
     store.block_states[block_root] = state
 
-    # Add proposer score boost if the block is timely
+    # Add block timeliness to the store
     time_into_slot = (store.time - store.genesis_time) % SECONDS_PER_SLOT
     is_before_attesting_interval = time_into_slot < SECONDS_PER_SLOT // INTERVALS_PER_SLOT
-    if get_current_slot(store) == block.slot and is_before_attesting_interval:
+    is_timely = get_current_slot(store) == block.slot and is_before_attesting_interval
+    store.block_timeliness[hash_tree_root(block)] = is_timely
+
+    # Add proposer score boost if the block is timely and not conflicting with an existing block
+    is_first_block = store.proposer_boost_root == Root()
+    if is_timely and is_first_block:
         store.proposer_boost_root = hash_tree_root(block)
 
     # Update checkpoints in store if necessary

--- a/docs/specs/p2p-interface.md
+++ b/docs/specs/p2p-interface.md
@@ -105,11 +105,11 @@ This applies to transports that are natively incapable of multiplexing (e.g. TCP
 and is omitted for capable transports (e.g. QUIC).
 
 Two multiplexers are commonplace in libp2p implementations:
-[mplex](https://github.com/libp2p/specs/tree/master/mplex) and [yamux](https://github.com/hashicorp/yamux/blob/master/spec.md).
+[mplex](https://github.com/libp2p/specs/tree/master/mplex) and [yamux](https://github.com/libp2p/specs/blob/master/yamux/README.md).
 Their protocol IDs are, respectively: `/mplex/6.7.0` and `/yamux/1.0.0`.
 
 Clients MUST support [mplex](https://github.com/libp2p/specs/tree/master/mplex)
-and MAY support [yamux](https://github.com/hashicorp/yamux/blob/master/spec.md).
+and MAY support [yamux](https://github.com/libp2p/specs/blob/master/yamux/README.md).
 If both are supported by the client, yamux MUST take precedence during negotiation.
 See the [Rationale](#design-decision-rationale) section below for tradeoffs.
 
@@ -321,7 +321,7 @@ The following validations MUST pass before forwarding the `signed_beacon_block` 
   i.e. validate that `signed_beacon_block.message.slot <= current_slot`
   (a client MAY queue future blocks for processing at the appropriate slot).
 - _[IGNORE]_ The block is from a slot greater than the latest finalized slot --
-  i.e. validate that `signed_beacon_block.message.slot > compute_start_slot_at_epoch(state.finalized_checkpoint.epoch)`
+  i.e. validate that `signed_beacon_block.message.slot > compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)`
   (a client MAY choose to validate and store such blocks for additional purposes -- e.g. slashing detection, archive nodes, etc).
 - _[IGNORE]_ The block is the first block with valid signature received for the proposer for the slot, `signed_beacon_block.message.slot`.
 - _[REJECT]_ The proposer signature, `signed_beacon_block.signature`, is valid with respect to the `proposer_index` pubkey.
@@ -371,11 +371,16 @@ to subscribing nodes (typically validators) to be included in future blocks.
 
 The following validations MUST pass before forwarding the `signed_aggregate_and_proof` on the network.
 (We define the following for convenience -- `aggregate_and_proof = signed_aggregate_and_proof.message` and `aggregate = aggregate_and_proof.aggregate`)
+- _[REJECT]_ The committee index is within the expected range -- i.e. `aggregate.data.index < get_committee_count_per_slot(state, aggregate.data.target.epoch)`.
 - _[IGNORE]_ `aggregate.data.slot` is within the last `ATTESTATION_PROPAGATION_SLOT_RANGE` slots (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
   i.e. `aggregate.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= aggregate.data.slot`
   (a client MAY queue future aggregates for processing at the appropriate slot).
 - _[REJECT]_ The aggregate attestation's epoch matches its target -- i.e. `aggregate.data.target.epoch ==
   compute_epoch_at_slot(aggregate.data.slot)`
+- _[REJECT]_ The number of aggregation bits matches the committee size -- i.e.
+  `len(aggregate.aggregation_bits) == len(get_beacon_committee(state, aggregate.data.slot, aggregate.data.index))`.
+- _[REJECT]_ The aggregate attestation has participants --
+  that is, `len(get_attesting_indices(state, aggregate.data, aggregate.aggregation_bits)) >= 1`.
 - _[IGNORE]_ A valid aggregate attestation defined by `hash_tree_root(aggregate.data)` whose `aggregation_bits` is a non-strict superset has _not_ already been seen.
   (via aggregate gossip, within a verified block, or through the creation of an equivalent aggregate locally).
 - _[IGNORE]_ The `aggregate` is the first valid aggregate received for the aggregator
@@ -394,6 +399,8 @@ The following validations MUST pass before forwarding the `signed_aggregate_and_
   (via both gossip and non-gossip sources)
   (a client MAY queue aggregates for processing once block is retrieved).
 - _[REJECT]_ The block being voted for (`aggregate.data.beacon_block_root`) passes validation.
+- _[REJECT]_ The aggregate attestation's target block is an ancestor of the block named in the LMD vote -- i.e.
+  `get_checkpoint_block(store, aggregate.data.beacon_block_root, aggregate.data.target.epoch) == aggregate.data.target.root`
 - _[IGNORE]_ The current `finalized_checkpoint` is an ancestor of the `block` defined by `aggregate.data.beacon_block_root` -- i.e.
   `get_checkpoint_block(store, aggregate.data.beacon_block_root, finalized_checkpoint.epoch)
   == store.finalized_checkpoint.root`
@@ -491,7 +498,7 @@ The `beacon_attestation_{subnet_id}` topics are used to propagate unaggregated a
 to the subnet `subnet_id` (typically beacon and persistent committees) to be aggregated before being gossiped to `beacon_aggregate_and_proof`.
 
 The following validations MUST pass before forwarding the `attestation` on the subnet.
-- _[REJECT]_ The committee index is within the expected range -- i.e. `data.index < get_committee_count_per_slot(state, data.target.epoch)`.
+- _[REJECT]_ The committee index is within the expected range -- i.e. `attestation.data.index < get_committee_count_per_slot(state, attestation.data.target.epoch)`.
 - _[REJECT]_ The attestation is for the correct subnet --
   i.e. `compute_subnet_for_attestation(committees_per_slot, attestation.data.slot, attestation.data.index) == subnet_id`,
   where `committees_per_slot = get_committee_count_per_slot(state, attestation.data.target.epoch)`,
@@ -505,7 +512,7 @@ The following validations MUST pass before forwarding the `attestation` on the s
 - _[REJECT]_ The attestation is unaggregated --
   that is, it has exactly one participating validator (`len([bit for bit in attestation.aggregation_bits if bit]) == 1`, i.e. exactly 1 bit is set).
 - _[REJECT]_ The number of aggregation bits matches the committee size -- i.e.
-  `len(attestation.aggregation_bits) == len(get_beacon_committee(state, data.slot, data.index))`.
+  `len(attestation.aggregation_bits) == len(get_beacon_committee(state, attestation.data.slot, attestation.data.index))`.
 - _[IGNORE]_ There has been no other valid attestation seen on an attestation subnet
   that has an identical `attestation.data.target.epoch` and participating validator index.
 - _[REJECT]_ The signature of `attestation` is valid.
@@ -823,9 +830,9 @@ The fields are, as seen by the client at the time of sending the message:
     - `current_fork_version` is the fork version at the node's current epoch defined by the wall-clock time
       (not necessarily the epoch to which the node is sync)
     - `genesis_validators_root` is the static `Root` found in `state.genesis_validators_root`
-- `finalized_root`: `state.finalized_checkpoint.root` for the state corresponding to the head block
+- `finalized_root`: `store.finalized_checkpoint.root` according to [fork choice](./fork-choice.md).
   (Note this defaults to `Root(b'\x00' * 32)` for the genesis finalized checkpoint).
-- `finalized_epoch`: `state.finalized_checkpoint.epoch` for the state corresponding to the head block.
+- `finalized_epoch`: `store.finalized_checkpoint.epoch` according to [fork choice](./fork-choice.md).
 - `head_root`: The `hash_tree_root` root of the current head block (`BeaconBlock`).
 - `head_slot`: The slot of the block corresponding to the `head_root`.
 
@@ -1004,6 +1011,9 @@ Clients MUST support requesting blocks since the latest finalized epoch.
 
 Clients MUST respond with at least one block, if they have it.
 Clients MAY limit the number of blocks in the response.
+
+Clients MAY include a block in the response as soon as it passes the gossip validation rules.
+Clients SHOULD NOT respond with blocks that fail the beacon chain state transition.
 
 `/eth2/beacon_chain/req/beacon_blocks_by_root/1/` is deprecated. Clients MAY respond with an empty list during the deprecation transition period.
 

--- a/docs/specs/p2p-interface.md
+++ b/docs/specs/p2p-interface.md
@@ -349,7 +349,7 @@ Alias `block = signed_beacon_block.message`, `execution_payload = block.body.exe
   then validate the following:
   - _[REJECT]_ The block's execution payload timestamp is correct with respect to the slot
       -- i.e. `execution_payload.timestamp == compute_timestamp_at_slot(state, block.slot)`.
-  - If `exection_payload` verification of block's parent by an execution node is *not* complete:
+  - If `execution_payload` verification of block's parent by an execution node is *not* complete:
     - [REJECT] The block's parent (defined by `block.parent_root`) passes all
       validation (excluding execution node verification of the `block.body.execution_payload`).
   - otherwise:

--- a/docs/specs/validator.md
+++ b/docs/specs/validator.md
@@ -457,15 +457,22 @@ A validator has two primary responsibilities to the beacon chain: [proposing blo
 A validator is expected to propose a [`SignedBeaconBlock`](./beacon-chain.md#signedbeaconblock) at
 the beginning of any `slot` during which `is_proposer(state, validator_index)` returns `True`.
 
-To propose, the validator selects the `BeaconBlock`, `parent` which:
+To propose, the validator selects a `BeaconBlock`, `parent` using this process:
 
-1. In their view of fork choice is the head of the chain at the start of
-   `slot`, after running `on_tick` and applying any queued attestations from `slot - 1`.
-2. Is from a slot strictly less than the slot of the block about to be proposed,
-   i.e. `parent.slot < slot`.
+1. Compute fork choice's view of the head at the start of `slot`, after running
+   `on_tick` and applying any queued attestations from `slot - 1`.
+   Set `head_root = get_head(store)`.
+2. Compute the _proposer head_, which is the head upon which the proposer SHOULD build in order to
+   incentivise timely block propagation by other validators.
+   Set `parent_root = get_proposer_head(store, head_root, slot)`.
+   A proposer may set `parent_root == head_root` if proposer re-orgs are not implemented or have
+   been disabled.
+3. Let `parent` be the block with `parent_root`.
 
 The validator creates, signs, and broadcasts a `block` that is a child of `parent`
-that satisfies a valid [beacon chain state transition](./beacon-chain.md#beacon-chain-state-transition-function).
+and satisfies a valid [beacon chain state transition](./beacon-chain.md#beacon-chain-state-transition-function).
+Note that the parent's slot must be strictly less than the slot of the block about to be proposed,
+i.e. `parent.slot < slot`.
 
 There is one proposer per slot, so if there are N active validators any individual validator
 will on average be assigned to propose once per N slots (e.g. at 312,500 validators = 10 million ETH, that's once per ~6 weeks).
@@ -1087,7 +1094,7 @@ def get_contribution_and_proof_signature(state: BeaconState,
 
 "Slashing" is the burning of some amount of validator funds and immediate ejection from the active validator set. In Phase 0, there are two ways in which funds can be slashed: [proposer slashing](#proposer-slashing) and [attester slashing](#attester-slashing). Although being slashed has serious repercussions, it is simple enough to avoid being slashed all together by remaining *consistent* with respect to the messages a validator has previously signed.
 
-*Note*: Signed data must be within a sequential `Fork` context to conflict. Messages cannot be slashed across diverging forks. If the previous fork version is 1 and the chain splits into fork 2 and 102, messages from 1 can slashable against messages in forks 1, 2, and 102. Messages in 2 cannot be slashable against messages in 102, and vice versa.
+*Note*: Signed data must be within a sequential `Fork` context to conflict. Messages cannot be slashed across diverging forks. If the previous fork version is 1 and the chain splits into fork 2 and 102, messages from 1 can be slashable against messages in forks 1, 2, and 102. Messages in 2 cannot be slashable against messages in 102, and vice versa.
 
 ### Proposer slashing
 


### PR DESCRIPTION
Closes #769

Updates the consolidated specs from version ~v1.3.0 to [v1.4.0-beta.7](https://github.com/ethereum/consensus-specs/tree/v1.4.0-beta.7).