### PR TITLE
refactor: simplify `PendingBlocks`

### DIFF
--- a/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
+++ b/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
@@ -93,12 +93,8 @@ defmodule LambdaEthereumConsensus.Beacon.PendingBlocks do
         parent_status == :invalid ->
           state |> Map.put(block_root, {nil, :invalid})
 
-        # If parent is processing, block is pending
-        parent_status == :processing ->
-          state
-
-        # If parent is pending, block is pending
-        parent_status == :pending ->
+        # If parent isn't processed, block is pending
+        parent_status in [:processing, :pending, :download] ->
           state
 
         # If parent is not in fork choice, download parent

--- a/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
+++ b/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
@@ -51,7 +51,7 @@ defmodule LambdaEthereumConsensus.Beacon.PendingBlocks do
     block_root = Ssz.hash_tree_root!(block)
 
     # If already processing or processed, ignore it
-    if state |> Map.get(block_root) or Blocks.has_block?(block_root) do
+    if Map.has_key?(state, block_root) or Blocks.has_block?(block_root) do
       {:noreply, state}
     else
       {:noreply, state |> Map.put(block_root, {signed_block, :pending})}

--- a/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
+++ b/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
@@ -14,7 +14,9 @@ defmodule LambdaEthereumConsensus.Beacon.PendingBlocks do
   alias Types.SignedBeaconBlock
 
   @type block_status :: :pending | :invalid | :processing | :download | :unknown
-  @type state :: %{Types.root() => {SignedBeaconBlock.t() | nil, block_status()}}
+  @type block_info ::
+          {SignedBeaconBlock.t(), :pending} | {nil, :invalid | :processing | :download}
+  @type state :: %{Types.root() => block_info()}
 
   ##########################
   ### Public API

--- a/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
+++ b/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
@@ -56,16 +56,15 @@ defmodule LambdaEthereumConsensus.Beacon.PendingBlocks do
   end
 
   @impl true
-  def handle_cast({:block_processed, block_root, is_valid?}, state) do
-    if is_valid? do
-      state |> Map.delete(block_root)
-    else
-      state
-      |> Map.put(block_root, {nil, :invalid})
-    end
-    |> then(fn state ->
-      {:noreply, state}
-    end)
+  def handle_cast({:block_processed, block_root, true}, state) do
+    # Block is valid
+    {:noreply, state |> Map.delete(block_root)}
+  end
+
+  @impl true
+  def handle_cast({:block_processed, block_root, false}, state) do
+    # Block is invalid
+    {:noreply, state |> Map.put(block_root, {nil, :invalid})}
   end
 
   @spec handle_info(any(), state()) :: {:noreply, state()}

--- a/lib/lambda_ethereum_consensus/store/blocks.ex
+++ b/lib/lambda_ethereum_consensus/store/blocks.ex
@@ -53,6 +53,9 @@ defmodule LambdaEthereumConsensus.Store.Blocks do
     end
   end
 
+  @spec has_block?(Types.root()) :: boolean()
+  def has_block?(block_root), do: not (get_signed_block(block_root) |> is_nil())
+
   @spec get_block!(Types.root()) :: BeaconBlock.t()
   def get_block!(block_root) do
     case get_block(block_root) do


### PR DESCRIPTION
This PR:
- avoids checking if a block's parent was processed if we know it's being downloaded
- checks preemptively if a block was already processed when adding the block to `PendingBlocks`
- restricts the `state` type to expected values
- simplifies the code a bit (adding a `has_block?` helper, and removing an `if`)

The first two could potentially solve a message queue overflow we're having with the `Blocks` cache.