### PR TITLE
fix: bugs in Libp2pPort and IncomingRequests.Handler

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -148,7 +148,7 @@ case Keyword.get(args, :log_file) do
     config :logger, :default_formatter,
       format: {LogfmtEx, :format},
       colors: [enabled: false],
-      metadata: [:mfa]
+      metadata: [:mfa, :slot]
 
     config :logfmt_ex, :opts,
       message_key: "msg",

--- a/lib/lambda_ethereum_consensus/p2p/incoming_requests/handler.ex
+++ b/lib/lambda_ethereum_consensus/p2p/incoming_requests/handler.ex
@@ -93,14 +93,14 @@ defmodule LambdaEthereumConsensus.P2P.IncomingRequests.Handler do
   end
 
   defp handle_req("beacon_blocks_by_root/2/ssz_snappy", message_id, message) do
-    with {:ok, %{body: body}} <-
+    with {:ok, roots} <-
            ReqResp.decode_request(message, TypeAliases.beacon_blocks_by_root_request()) do
-      count = length(body)
+      count = length(roots)
       Logger.info("[BlocksByRoot] requested #{count} number of blocks")
       truncated_count = min(count, ChainSpec.get("MAX_REQUEST_BLOCKS"))
 
       response_chunk =
-        body
+        roots
         |> Enum.take(truncated_count)
         |> Enum.map(&Blocks.get_signed_block/1)
         |> Enum.map(&map_block_result/1)

--- a/lib/lambda_ethereum_consensus/p2p/incoming_requests/handler.ex
+++ b/lib/lambda_ethereum_consensus/p2p/incoming_requests/handler.ex
@@ -81,6 +81,7 @@ defmodule LambdaEthereumConsensus.P2P.IncomingRequests.Handler do
 
       end_slot = start_slot + (truncated_count - 1)
 
+      # TODO: extend cache to support slots as keys
       response_chunk =
         start_slot..end_slot
         |> Enum.map(&BlockDb.get_block_by_slot/1)
@@ -117,8 +118,11 @@ defmodule LambdaEthereumConsensus.P2P.IncomingRequests.Handler do
     :ok
   end
 
+  defp map_block_result(:not_found), do: map_block_result(nil)
   defp map_block_result(nil), do: {:error, {3, "Resource Unavailable"}}
   defp map_block_result(:empty_slot), do: :skip
+  defp map_block_result({:ok, block}), do: map_block_result(block)
+  defp map_block_result({:error, _}), do: {:error, {2, "Server Error"}}
 
   defp map_block_result(block),
     do: {:ok, {block, BeaconChain.get_fork_digest_for_slot(block.message.slot)}}

--- a/lib/lambda_ethereum_consensus/p2p/incoming_requests/handler.ex
+++ b/lib/lambda_ethereum_consensus/p2p/incoming_requests/handler.ex
@@ -117,10 +117,9 @@ defmodule LambdaEthereumConsensus.P2P.IncomingRequests.Handler do
     :ok
   end
 
-  defp map_block_result({:ok, block}),
-    do: {:ok, {block, BeaconChain.get_fork_digest_for_slot(block.message.slot)}}
-
-  defp map_block_result({:error, _}), do: {:error, {2, "Server Error"}}
-  defp map_block_result(:not_found), do: {:error, {3, "Resource Unavailable"}}
+  defp map_block_result(nil), do: {:error, {3, "Resource Unavailable"}}
   defp map_block_result(:empty_slot), do: :skip
+
+  defp map_block_result(block),
+    do: {:ok, {block, BeaconChain.get_fork_digest_for_slot(block.message.slot)}}
 end

--- a/lib/lambda_ethereum_consensus/validator/utils.ex
+++ b/lib/lambda_ethereum_consensus/validator/utils.ex
@@ -70,7 +70,7 @@ defmodule LambdaEthereumConsensus.Validator.Utils do
   @spec get_attestation_signature(BeaconState.t(), AttestationData.t(), Bls.privkey()) ::
           Types.bls_signature()
   def get_attestation_signature(%BeaconState{} = state, attestation_data, privkey) do
-    domain_beacon_attester = ChainSpec.get("DOMAIN_BEACON_ATTESTER")
+    domain_beacon_attester = Constants.domain_beacon_attester()
     domain = Accessors.get_domain(state, domain_beacon_attester, attestation_data.target.epoch)
     signing_root = Misc.compute_signing_root(attestation_data, domain)
     # Can't fail, unless privkey is invalid

--- a/lib/lambda_ethereum_consensus/validator/validator.ex
+++ b/lib/lambda_ethereum_consensus/validator/validator.ex
@@ -28,7 +28,7 @@ defmodule LambdaEthereumConsensus.Validator do
       duties: {:not_computed, :not_computed},
       # TODO: get validator from config
       validator: 150_112,
-      privkey: <<0::256>>
+      privkey: <<652_916_760::256>>
     }
 
     {:ok, state, {:continue, nil}}

--- a/lib/lambda_ethereum_consensus/validator/validator.ex
+++ b/lib/lambda_ethereum_consensus/validator/validator.ex
@@ -171,7 +171,7 @@ defmodule LambdaEthereumConsensus.Validator do
 
   defp produce_attestation(duty, head_root, privkey) do
     {index_in_committee, committee_length, committee_index, slot} = duty
-    head_state = BlockStates.get_state!(head_root) |> StateTransition.process_slots(slot)
+    head_state = BlockStates.get_state!(head_root) |> process_slots(slot)
     head_epoch = Misc.compute_epoch_at_slot(slot)
 
     epoch_boundary_block_root =
@@ -206,5 +206,12 @@ defmodule LambdaEthereumConsensus.Validator do
 
     subnet_id = compute_subnet_ids_for_duties([duty], head_state, head_epoch)
     {subnet_id, attestation}
+  end
+
+  defp process_slots(%{slot: old_slot} = state, slot) when old_slot == slot, do: state
+
+  defp process_slots(state, slot) do
+    {:ok, st} = StateTransition.process_slots(slot)
+    st
   end
 end

--- a/lib/lambda_ethereum_consensus/validator/validator.ex
+++ b/lib/lambda_ethereum_consensus/validator/validator.ex
@@ -211,7 +211,7 @@ defmodule LambdaEthereumConsensus.Validator do
   defp process_slots(%{slot: old_slot} = state, slot) when old_slot == slot, do: state
 
   defp process_slots(state, slot) do
-    {:ok, st} = StateTransition.process_slots(slot)
+    {:ok, st} = StateTransition.process_slots(state, slot)
     st
   end
 end

--- a/lib/libp2p_port.ex
+++ b/lib/libp2p_port.ex
@@ -208,7 +208,7 @@ defmodule LambdaEthereumConsensus.Libp2pPort do
       direction: "elixir->"
     })
 
-    cast_command(pid, {:unsubscribe, %LeaveTopic{name: topic_name}})
+    cast_command(pid, {:leave, %LeaveTopic{name: topic_name}})
   end
 
   @doc """


### PR DESCRIPTION
This PR fixes six bugs:
- match on old `BeaconBlocksByRoot` struct
- not matching new possible results in `map_block_result`
- use of old enum value `:unsubscribe` in `Lib2pPort`
- validator not handling `StateTransition.process_slots` results
- BLS library not allowing all-balls as secret key
- default logger not logging any metadata