### PR TITLE
ci: run the spectests for deneb hard-fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,11 @@ jobs:
       - name: Uncompress vectors
         run: make test/spec/vectors/tests/${{ matrix.config }}
       - name: Generate tests
-        run: FORK=${{ matrix.fork }} make gen-spec
+        run: make gen-spec
       - name: Run tests
-        run: FORK=${{ matrix.fork }} mix test --no-start test/generated/${{ matrix.config }}/*/*
+        run: |
+          if [[ "${{ matrix.config }}" == "general" ]] ; then
+            FORK=${{ matrix.fork }} mix test --no-start test/generated/general/*/*
+          else
+            FORK=${{ matrix.fork }} mix test --no-start test/generated/${{ matrix.config }}/${{ matrix.fork }}/*
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,7 +319,8 @@ jobs:
       - name: Uncompress vectors
         run: make test/spec/vectors/tests/${{ matrix.config }}
       - name: Generate tests
-        run: make gen-spec
+        # NOTE: we need to set FORK because this compiles the whole project
+        run: FORK=${{ matrix.fork }} make gen-spec
       - name: Run tests
         run: |
           if [[ "${{ matrix.config }}" == "general" ]] ; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,7 @@ jobs:
     needs: [compile-native, download-spectests, download-beacon-node-oapi]
     strategy:
       matrix:
+        fork: ["capella", "deneb"]
         config: ["minimal", "general", "mainnet"]
     runs-on: ubuntu-22.04
     steps:
@@ -318,6 +319,6 @@ jobs:
       - name: Uncompress vectors
         run: make test/spec/vectors/tests/${{ matrix.config }}
       - name: Generate tests
-        run: make gen-spec
+        run: FORK=${{ matrix.fork }} make gen-spec
       - name: Run tests
-        run: mix test --no-start test/generated/${{ matrix.config }}/*/*
+        run: FORK=${{ matrix.fork }} mix test --no-start test/generated/${{ matrix.config }}/*/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,10 +267,11 @@ jobs:
         if: steps.output-cache.outputs.cache-hit != 'true'
         run: make download-vectors
 
-  spectests:
+  spectests-matrix:
     name: Run spec-tests
     needs: [compile-native, download-spectests, download-beacon-node-oapi]
     strategy:
+      fail-fast: false
       matrix:
         fork: ["capella", "deneb"]
         config: ["minimal", "general", "mainnet"]
@@ -328,3 +329,11 @@ jobs:
           else
             FORK=${{ matrix.fork }} mix test --no-start test/generated/${{ matrix.config }}/${{ matrix.fork }}/*
           fi
+
+  spectests-success:
+    name: All spec-tests passed
+    needs: spectests-matrix
+    runs-on: ubuntu-22.04
+    steps:
+      - name: All spectests passed
+        run: echo "All spec-tests passed!"

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,8 +2,20 @@
 import Config
 
 # Configure fork
-# Available: :capella, :deneb
-config :lambda_ethereum_consensus, :fork, :capella
+# Available: "capella", "deneb"
+# Used only for testing
+fork_raw = System.get_env("FORK", "capella")
+
+fork =
+  case fork_raw do
+    "capella" -> :capella
+    "deneb" -> :deneb
+    v -> raise "Invalid fork specified: #{v}"
+  end
+
+IO.puts("compilation done for fork: #{fork_raw}")
+
+config :lambda_ethereum_consensus, :fork, fork
 
 # Configure logging
 config :logger, level: :info, truncate: :infinity

--- a/test/spec/tasks/generate_spec_tests.ex
+++ b/test/spec/tasks/generate_spec_tests.ex
@@ -24,12 +24,12 @@ defmodule Mix.Tasks.GenerateSpecTests do
     File.rm_rf!(generated_folder)
     File.mkdir_p!(generated_folder)
 
-    # Generate all tests for Capella fork
+    # Generate all tests for the Capella fork
     for config <- @configs, runner <- runners do
       generate_test(config, "capella", runner)
     end
 
-    # Generate all tests for Deneb fork
+    # Generate all tests for the Deneb fork
     for config <- @configs, runner <- runners do
       generate_test(config, "deneb", runner)
     end

--- a/test/spec/tasks/generate_spec_tests.ex
+++ b/test/spec/tasks/generate_spec_tests.ex
@@ -24,12 +24,12 @@ defmodule Mix.Tasks.GenerateSpecTests do
     File.rm_rf!(generated_folder)
     File.mkdir_p!(generated_folder)
 
-    # Generate all tests for the Capella fork
+    # Generate all tests for Capella fork
     for config <- @configs, runner <- runners do
       generate_test(config, "capella", runner)
     end
 
-    # Generate all tests for the Deneb fork
+    # Generate all tests for Deneb fork
     for config <- @configs, runner <- runners do
       generate_test(config, "deneb", runner)
     end


### PR DESCRIPTION
This PR adds the deneb spectests to the CI along with an "All spec-tests passed" job to simplify required checks. Before merging this, we'll need to modify them to un-require the old spectests, and require the new job.