### PR TITLE
ci: fix CI required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,7 @@ jobs:
     name: All spec-tests passed
     needs: spectests-matrix
     runs-on: ubuntu-22.04
+    if: always()
     steps:
       - name: All spectests passed
         run: echo "All spec-tests passed!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,5 +336,10 @@ jobs:
     runs-on: ubuntu-22.04
     if: always()
     steps:
-      - name: All spectests passed
-        run: echo "All spec-tests passed!"
+      - if: needs.spectests-matrix.result == 'success'
+        name: All spectests passed
+        run: exit 0
+
+      - if: needs.spectests-matrix.result != 'success'
+        name: Some spectests failed
+        run: exit 1

--- a/.github/workflows/ci_skipped.yml
+++ b/.github/workflows/ci_skipped.yml
@@ -42,11 +42,8 @@ jobs:
     if: false
     steps: [run: true]
 
-  # NOTE: matrix jobs aren't expanded if skipped
-  spectests:
-    name: Run spec-tests
-    strategy:
-      matrix:
-        config: ["minimal", "general", "mainnet"]
+  spectests-success:
+    name: All spec-tests passed
     runs-on: ubuntu-22.04
+    if: false
     steps: [run: true]

--- a/test/spec/runners/fork_choice.ex
+++ b/test/spec/runners/fork_choice.ex
@@ -89,7 +89,6 @@ defmodule ForkChoiceTestRunner do
 
   @impl TestRunner
   def run_test_case(testcase) do
-    assert false
     case_dir = SpecTestCase.dir(testcase)
 
     anchor_state =

--- a/test/spec/runners/fork_choice.ex
+++ b/test/spec/runners/fork_choice.ex
@@ -89,6 +89,7 @@ defmodule ForkChoiceTestRunner do
 
   @impl TestRunner
   def run_test_case(testcase) do
+    assert false
     case_dir = SpecTestCase.dir(testcase)
 
     anchor_state =


### PR DESCRIPTION
This PR modifies the "All spec-tests passed" job to correctly fail when some of the spec-test jobs fail. It also updates the "CI-skipped" workflow with the new required job