### PR TITLE
fix: generate spectest before running compilation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,27 +190,27 @@ clean-tests:
 	-rm -r test/generated
 
 #🔴 spec-test: @ Run all spec tests
-spec-test: compile-all $(SPECTEST_GENERATED_ROOTDIR)
+spec-test: $(SPECTEST_GENERATED_ROOTDIR) compile-all
 	mix test --no-start test/generated/*/*/*
 
 #🔴 spec-test-config-%: @ Run all spec tests for a specific config (e.g. mainnet)
-spec-test-config-%: compile-all $(SPECTEST_GENERATED_ROOTDIR)
+spec-test-config-%: $(SPECTEST_GENERATED_ROOTDIR) compile-all
 	mix test --no-start test/generated/$*/*/*
 
 #🔴 spec-test-runner-%: @ Run all spec tests for a specific runner (e.g. epoch_processing)
-spec-test-runner-%: compile-all $(SPECTEST_GENERATED_ROOTDIR)
+spec-test-runner-%: $(SPECTEST_GENERATED_ROOTDIR) compile-all
 	mix test --no-start test/generated/*/*/$*.exs
 
 #🔴 spec-test-mainnet-%: @ Run spec tests for mainnet config, for the specified runner.
-spec-test-mainnet-%: compile-all $(SPECTEST_GENERATED_ROOTDIR)
+spec-test-mainnet-%: $(SPECTEST_GENERATED_ROOTDIR) compile-all
 	mix test --no-start test/generated/mainnet/*/$*.exs
 
 #🔴 spec-test-minimal-%: @ Run spec tests for minimal config, for the specified runner.
-spec-test-minimal-%:  compile-all $(SPECTEST_GENERATED_ROOTDIR)
+spec-test-minimal-%: $(SPECTEST_GENERATED_ROOTDIR) compile-all
 	mix test --no-start test/generated/minimal/*/$*.exs
 
 #🔴 spec-test-general-%: @ Run spec tests for general config, for the specified runner.
-spec-test-general-%: compile-all $(SPECTEST_GENERATED_ROOTDIR)
+spec-test-general-%: $(SPECTEST_GENERATED_ROOTDIR) compile-all
 	mix test --no-start test/generated/general/*/$*.exs
 
 #✅ lint: @ Check formatting and linting.


### PR DESCRIPTION
**Motivation**
Avoid getting this error

```
** (Mix) the application :lambda_ethereum_consensus has a different value set for key :fork during runtime compared to compile time. Since this application environment entry was marked as compile time, this difference can lead to different behaviour than expected:

  * Compile time value was set to: :capella
  * Runtime value was set to: :deneb

To fix this error, you might:

  * Make the runtime value match the compile time one

  * Recompile your project. If the misconfigured application is a dependency, you may need to run "mix deps.clean lambda_ethereum_consensus --build"

  * Alternatively, you can disable this check. If you are using releases, you can set :validate_compile_env to false in your release configuration. If you are using Mix to start your system, you can pass the --no-validate-compile-env flag
 ```
