### PR TITLE
feat: update `process_execution_payload`

### DIFF
--- a/lib/constants.ex
+++ b/lib/constants.ex
@@ -123,4 +123,7 @@ defmodule Constants do
 
   @spec bytes_per_field_element() :: Types.uint64()
   def bytes_per_field_element, do: 32
+
+  @spec versioned_hash_version_kzg() :: <<_::8>>
+  def versioned_hash_version_kzg, do: <<1>>
 end

--- a/lib/lambda_ethereum_consensus/execution/engine_api.ex
+++ b/lib/lambda_ethereum_consensus/execution/engine_api.ex
@@ -13,20 +13,12 @@ defmodule LambdaEthereumConsensus.Execution.EngineApi do
   @spec exchange_capabilities() :: {:ok, any} | {:error, any}
   def exchange_capabilities, do: impl().exchange_capabilities()
 
-  @spec new_payload(ExecutionPayload.t()) ::
-          {:ok, any} | {:error, any}
+  @spec new_payload(ExecutionPayload.t()) :: {:ok, any} | {:error, any}
   def new_payload(execution_payload), do: impl().new_payload(execution_payload)
 
   @spec forkchoice_updated(map, map | any) :: {:ok, any} | {:error, any}
   def forkchoice_updated(forkchoice_state, payload_attributes),
     do: impl().forkchoice_updated(forkchoice_state, payload_attributes)
 
-  defp impl do
-    Application.fetch_env!(
-      :lambda_ethereum_consensus,
-      __MODULE__
-    )[
-      :implementation
-    ]
-  end
+  defp impl, do: Application.fetch_env!(:lambda_ethereum_consensus, __MODULE__)[:implementation]
 end

--- a/lib/lambda_ethereum_consensus/execution/execution_client.ex
+++ b/lib/lambda_ethereum_consensus/execution/execution_client.ex
@@ -31,6 +31,9 @@ defmodule LambdaEthereumConsensus.Execution.ExecutionClient do
     end
   end
 
+  # TODO: implement
+  def notify_new_payload(_execution_payload, _parent_beacon_block_root), do: {:ok, :valid}
+
   @doc """
   This function performs three actions *atomically*:
   * Re-organizes the execution payload chain and corresponding state to make `head_block_hash` the head.
@@ -60,17 +63,41 @@ defmodule LambdaEthereumConsensus.Execution.ExecutionClient do
   """
   @spec valid_block_hash?(ExecutionPayload.t()) ::
           {:ok, :optimistic | :valid | :invalid} | {:error, String.t()}
-  # TODO: Implement this function
+  # TODO: implement
   def valid_block_hash?(_execution_payload), do: {:ok, :valid}
+  def valid_block_hash?(_execution_payload, _parent_beacon_block_root), do: {:ok, :valid}
+
+  @doc """
+  Return ``true`` if and only if the version hashes computed by the blob transactions of
+  ``new_payload_request.execution_payload`` matches ``new_payload_request.version_hashes``.
+  """
+  @spec valid_versioned_hashes?(ExecutionPayload.t()) ::
+          {:ok, :optimistic | :valid | :invalid} | {:error, String.t()}
+  # TODO: implement
+  def valid_versioned_hashes?(_new_payload_request), do: {:ok, :valid}
 
   @doc """
   Same as `notify_new_payload`, but with additional checks.
   """
+  # DENEB
   @spec verify_and_notify_new_payload(NewPayloadRequest.t()) ::
           {:ok, :optimistic | :valid | :invalid} | {:error, String.t()}
-  def verify_and_notify_new_payload(%NewPayloadRequest{} = new_payload_request) do
-    with {:ok, :valid} <- valid_block_hash?(new_payload_request.execution_payload) do
-      notify_new_payload(new_payload_request.execution_payload)
+  def verify_and_notify_new_payload(
+        %NewPayloadRequest{
+          execution_payload: execution_payload,
+          parent_beacon_block_root: parent_beacon_block_root
+        } = new_payload_request
+      ) do
+    with {:ok, :valid} <- valid_block_hash?(execution_payload, parent_beacon_block_root),
+         {:ok, :valid} <- valid_versioned_hashes?(new_payload_request) do
+      notify_new_payload(execution_payload, parent_beacon_block_root)
+    end
+  end
+
+  # CAPELLA
+  def verify_and_notify_new_payload(%NewPayloadRequest{execution_payload: execution_payload}) do
+    with {:ok, :valid} <- valid_block_hash?(execution_payload) do
+      notify_new_payload(execution_payload)
     end
   end
 end

--- a/lib/lambda_ethereum_consensus/execution/execution_client.ex
+++ b/lib/lambda_ethereum_consensus/execution/execution_client.ex
@@ -53,4 +53,24 @@ defmodule LambdaEthereumConsensus.Execution.ExecutionClient do
 
     EngineApi.forkchoice_updated(fork_choice_state, nil)
   end
+
+  @doc """
+  Equivalent to is_valid_block_hash from the spec.
+  Return ``true`` if and only if ``execution_payload.block_hash`` is computed correctly.
+  """
+  @spec valid_block_hash?(ExecutionPayload.t()) ::
+          {:ok, :optimistic | :valid | :invalid} | {:error, String.t()}
+  # TODO: Implement this function
+  def valid_block_hash?(_execution_payload), do: {:ok, :valid}
+
+  @doc """
+  Same as `notify_new_payload`, but with additional checks.
+  """
+  @spec verify_and_notify_new_payload(NewPayloadRequest.t()) ::
+          {:ok, :optimistic | :valid | :invalid} | {:error, String.t()}
+  def verify_and_notify_new_payload(%NewPayloadRequest{} = new_payload_request) do
+    with {:ok, :valid} <- valid_block_hash?(new_payload_request.execution_payload) do
+      notify_new_payload(new_payload_request.execution_payload)
+    end
+  end
 end

--- a/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
@@ -165,10 +165,13 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
   def compute_post_state(%Store{} = store, %SignedBeaconBlock{} = signed_block, state) do
     %{message: block} = signed_block
 
+    payload = block.body.execution_payload
+
     # Make it a task so it runs concurrently with the state transition
     payload_verification_task =
       Task.async(fn ->
-        ExecutionClient.notify_new_payload(block.body.execution_payload)
+        %NewPayloadRequest{execution_payload: payload}
+        |> ExecutionClient.verify_and_notify_new_payload()
         |> handle_verify_payload_result()
       end)
 

--- a/lib/lambda_ethereum_consensus/hard_fork_alias_injection.ex
+++ b/lib/lambda_ethereum_consensus/hard_fork_alias_injection.ex
@@ -26,4 +26,22 @@ defmodule HardForkAliasInjection do
 
   @compile {:inline, deneb?: 0}
   def deneb?, do: unquote(is_deneb)
+
+  @doc """
+  Compiles to the first argument if on deneb, otherwise to the second argument.
+
+  ## Examples
+
+      iex> HardForkAliasInjection.on_deneb(true, false)
+      #{is_deneb}
+  """
+  if is_deneb do
+    defmacro on_deneb(code, _default) do
+      code
+    end
+  else
+    defmacro on_deneb(_code, default) do
+      default
+    end
+  end
 end

--- a/lib/lambda_ethereum_consensus/hard_fork_alias_injection.ex
+++ b/lib/lambda_ethereum_consensus/hard_fork_alias_injection.ex
@@ -24,5 +24,6 @@ defmodule HardForkAliasInjection do
     end
   end
 
+  @compile {:inline, deneb?: 0}
   def deneb?, do: unquote(is_deneb)
 end

--- a/lib/lambda_ethereum_consensus/state_transition/misc.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/misc.ex
@@ -276,6 +276,6 @@ defmodule LambdaEthereumConsensus.StateTransition.Misc do
   @spec kzg_commitment_to_versioned_hash(Types.kzg_commitment()) :: Types.bytes32()
   def kzg_commitment_to_versioned_hash(kzg_commitment) do
     hash = SszEx.hash(kzg_commitment) |> binary_slice(1..31)
-    <<Constants.versioned_hash_version_kzg(), hash::binary(31)>>
+    <<Constants.versioned_hash_version_kzg(), hash::binary-size(31)>>
   end
 end

--- a/lib/lambda_ethereum_consensus/state_transition/misc.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/misc.ex
@@ -272,4 +272,10 @@ defmodule LambdaEthereumConsensus.StateTransition.Misc do
     |> Map.put(:state_root, state_root)
     |> Ssz.hash_tree_root!()
   end
+
+  @spec kzg_commitment_to_versioned_hash(Types.kzg_commitment()) :: Types.bytes32()
+  def kzg_commitment_to_versioned_hash(kzg_commitment) do
+    hash = SszEx.hash(kzg_commitment) |> binary_slice(1..31)
+    <<Constants.versioned_hash_version_kzg(), hash::binary(31)>>
+  end
 end

--- a/lib/lambda_ethereum_consensus/state_transition/operations.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/operations.ex
@@ -217,10 +217,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Operations do
   """
   @spec process_execution_payload(BeaconState.t(), BeaconBlockBody.t()) ::
           {:ok, BeaconState.t()} | {:error, String.t()}
-  def process_execution_payload(
-        state,
-        %BeaconBlockBody{execution_payload: payload}
-      ) do
+  def process_execution_payload(state, %BeaconBlockBody{execution_payload: payload}) do
     cond do
       # Verify consistency of the parent hash with respect to the previous execution payload header
       BeaconState.merge_transition_complete?(state) and
@@ -235,6 +232,10 @@ defmodule LambdaEthereumConsensus.StateTransition.Operations do
       # Verify timestamp
       payload.timestamp != Misc.compute_timestamp_at_slot(state, state.slot) ->
         {:error, "Timestamp verification failed"}
+
+      HardForkAliasInjection.deneb?() and
+          length(body.blob_kzg_commitments) > ChainSpec.get("MAX_BLOBS_PER_BLOCK") ->
+        {:error, "Too many commitments"}
 
       # Cache execution payload header
       true ->

--- a/lib/lambda_ethereum_consensus/state_transition/operations.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/operations.ex
@@ -217,7 +217,7 @@ defmodule LambdaEthereumConsensus.StateTransition.Operations do
   """
   @spec process_execution_payload(BeaconState.t(), BeaconBlockBody.t()) ::
           {:ok, BeaconState.t()} | {:error, String.t()}
-  def process_execution_payload(state, %BeaconBlockBody{execution_payload: payload}) do
+  def process_execution_payload(state, %BeaconBlockBody{execution_payload: payload} = body) do
     cond do
       # Verify consistency of the parent hash with respect to the previous execution payload header
       BeaconState.merge_transition_complete?(state) and

--- a/lib/types/beacon_chain/new_payload_request.ex
+++ b/lib/types/beacon_chain/new_payload_request.ex
@@ -2,11 +2,14 @@ defmodule NewPayloadRequest do
   @moduledoc """
   Struct received by `ExecutionClient.verify_and_notify_new_payload`.
   """
-  fields = [:execution_payload]
-  @enforce_keys fields
-  defstruct fields
+  @enforce_keys [:execution_payload]
+  defstruct [:execution_payload, :versioned_hashes, :parent_beacon_block_root]
 
   @type t :: %__MODULE__{
-          execution_payload: ExecutionPayload.t()
+          execution_payload: ExecutionPayload.t(),
+
+          # Deneb-only
+          versioned_hashes: list(Types.bytes32()),
+          parent_beacon_block_root: Types.root()
         }
 end

--- a/lib/types/beacon_chain/new_payload_request.ex
+++ b/lib/types/beacon_chain/new_payload_request.ex
@@ -1,0 +1,12 @@
+defmodule NewPayloadRequest do
+  @moduledoc """
+  Struct received by `ExecutionClient.verify_and_notify_new_payload`.
+  """
+  fields = [:execution_payload]
+  @enforce_keys fields
+  defstruct fields
+
+  @type t :: %__MODULE__{
+          execution_payload: ExecutionPayload.t()
+        }
+end

--- a/native/ssz_nif/src/elx_types/beacon_chain.rs
+++ b/native/ssz_nif/src/elx_types/beacon_chain.rs
@@ -444,6 +444,54 @@ gen_struct_with_config!(
 
 gen_struct_with_config!(
     #[derive(NifStruct)]
+    #[module = "Types.BeaconStateDeneb"]
+    pub(crate) struct BeaconStateDeneb<'a> {
+        // Versioning
+        genesis_time: u64,
+        genesis_validators_root: Root<'a>,
+        slot: Slot,
+        fork: Fork<'a>,
+        // History
+        latest_block_header: BeaconBlockHeader<'a>,
+        block_roots: Vec<Root<'a>>,
+        state_roots: Vec<Root<'a>>,
+        historical_roots: Vec<Root<'a>>, // Frozen in Capella, replaced by historical_summaries
+        // Eth1
+        eth1_data: Eth1Data<'a>,
+        eth1_data_votes: Vec<Eth1Data<'a>>,
+        eth1_deposit_index: u64,
+        // Registry
+        validators: Vec<Validator<'a>>,
+        balances: Vec<Gwei>,
+        // Randomness
+        randao_mixes: Vec<Bytes32<'a>>,
+        // Slashings
+        slashings: Vec<Gwei>, // Per-epoch sums of slashed effective balances
+        // Participation
+        previous_epoch_participation: Vec<ParticipationFlags>,
+        current_epoch_participation: Vec<ParticipationFlags>,
+        // Finality
+        justification_bits: Binary<'a>, // Bit set for every recent justified epoch
+        previous_justified_checkpoint: Checkpoint<'a>,
+        current_justified_checkpoint: Checkpoint<'a>,
+        finalized_checkpoint: Checkpoint<'a>,
+        // Inactivity
+        inactivity_scores: Vec<u64>,
+        // Sync
+        current_sync_committee: SyncCommittee<'a>,
+        next_sync_committee: SyncCommittee<'a>,
+        // Execution
+        latest_execution_payload_header: ExecutionPayloadHeaderDeneb<'a>, // [Modified in Capella]
+        // Withdrawals
+        next_withdrawal_index: WithdrawalIndex, // [New in Capella]
+        next_withdrawal_validator_index: ValidatorIndex, // [New in Capella]
+        // Deep history valid from Capella onwards
+        historical_summaries: Vec<HistoricalSummary<'a>>, // [New in Capella]
+    }
+);
+
+gen_struct_with_config!(
+    #[derive(NifStruct)]
     #[module = "Types.BeaconBlockBody"]
     pub(crate) struct BeaconBlockBody<'a> {
         randao_reveal: BLSSignature<'a>,

--- a/native/ssz_nif/src/ssz_types/beacon_chain.rs
+++ b/native/ssz_nif/src/ssz_types/beacon_chain.rs
@@ -373,3 +373,50 @@ pub(crate) struct BeaconState<C: Config> {
     // Deep history valid from Capella onwards
     pub(crate) historical_summaries: VariableList<HistoricalSummary, C::HistoricalRootsLimit>, // [New in Capella]
 }
+
+#[derive(Encode, Decode, TreeHash)]
+pub(crate) struct BeaconStateDeneb<C: Config> {
+    // Versioning
+    pub(crate) genesis_time: u64,
+    pub(crate) genesis_validators_root: Root,
+    pub(crate) slot: Slot,
+    pub(crate) fork: Fork,
+    // History
+    pub(crate) latest_block_header: BeaconBlockHeader,
+    pub(crate) block_roots: FixedVector<Root, C::SlotsPerHistoricalRoot>,
+    pub(crate) state_roots: FixedVector<Root, C::SlotsPerHistoricalRoot>,
+    pub(crate) historical_roots: VariableList<Root, C::HistoricalRootsLimit>, // Frozen in Capella, replaced by historical_summaries
+    // Eth1
+    pub(crate) eth1_data: Eth1Data,
+    pub(crate) eth1_data_votes: VariableList<Eth1Data, C::SlotsPerEth1VotingPeriod>,
+    pub(crate) eth1_deposit_index: u64,
+    // Registry
+    pub(crate) validators: VariableList<Validator, C::ValidatorRegistryLimit>,
+    pub(crate) balances: VariableList<Gwei, C::ValidatorRegistryLimit>,
+    // Randomness
+    pub(crate) randao_mixes: FixedVector<Bytes32, C::EpochsPerHistoricalVector>,
+    // Slashings
+    pub(crate) slashings: FixedVector<Gwei, C::EpochsPerSlashingsVector>, // Per-epoch sums of slashed effective balances
+    // Participation
+    pub(crate) previous_epoch_participation:
+        VariableList<ParticipationFlags, C::ValidatorRegistryLimit>,
+    pub(crate) current_epoch_participation:
+        VariableList<ParticipationFlags, C::ValidatorRegistryLimit>,
+    // Finality
+    pub(crate) justification_bits: BitVector<C::JustificationBitsLength>, // Bit set for every recent justified epoch
+    pub(crate) previous_justified_checkpoint: Checkpoint,
+    pub(crate) current_justified_checkpoint: Checkpoint,
+    pub(crate) finalized_checkpoint: Checkpoint,
+    // Inactivity
+    pub(crate) inactivity_scores: VariableList<u64, C::ValidatorRegistryLimit>,
+    // Sync
+    pub(crate) current_sync_committee: SyncCommittee<C>,
+    pub(crate) next_sync_committee: SyncCommittee<C>,
+    // Execution
+    pub(crate) latest_execution_payload_header: ExecutionPayloadHeaderDeneb<C>, // [Modified in Capella]
+    // Withdrawals
+    pub(crate) next_withdrawal_index: WithdrawalIndex, // [New in Capella]
+    pub(crate) next_withdrawal_validator_index: ValidatorIndex, // [New in Capella]
+    // Deep history valid from Capella onwards
+    pub(crate) historical_summaries: VariableList<HistoricalSummary, C::HistoricalRootsLimit>, // [New in Capella]
+}

--- a/native/ssz_nif/src/utils/mod.rs
+++ b/native/ssz_nif/src/utils/mod.rs
@@ -42,6 +42,7 @@ macro_rules! schema_match {
                 SyncAggregate<C>,
                 SyncCommittee<C>,
                 BeaconState<C>,
+                BeaconStateDeneb<C>,
                 BeaconBlockBody<C>,
                 BeaconBlockBodyDeneb<C>,
                 StatusMessage,

--- a/test/spec/runners/rewards.ex
+++ b/test/spec/runners/rewards.ex
@@ -6,6 +6,8 @@ defmodule RewardsTestRunner do
   use TestRunner
   alias Types.BeaconState
 
+  use HardForkAliasInjection
+
   @disabled [
     # "basic",
     # "leak",

--- a/test/spec/utils.ex
+++ b/test/spec/utils.ex
@@ -107,8 +107,8 @@ defmodule SpecTestUtils do
   @spec resolve_type_from_handler(String.t(), map()) :: module()
   def resolve_type_from_handler(handler, map) do
     case Map.get(map, handler) do
-      nil -> raise "Unknown case #{handler}"
-      type -> Module.concat(Types, type)
+      nil -> raise "Unknown case \"#{handler}\""
+      type -> type
     end
   end
 

--- a/test/unit/mainnet_config_test.exs
+++ b/test/unit/mainnet_config_test.exs
@@ -1,6 +1,8 @@
 defmodule Unit.MainnetConfigSmokeTest do
   use ExUnit.Case
 
+  doctest HardForkAliasInjection
+
   setup_all do
     Application.fetch_env!(:lambda_ethereum_consensus, ChainSpec)
     |> Keyword.put(:config, MainnetConfig)


### PR DESCRIPTION
Closes #758

This PR adds new checks in `process_execution_payload`, and updates the `ExecutionClient` integration in `compute_post_state`. It also added some stubs in `ExecutionClient` that should be resolved in #860.