### PR TITLE
feat: add `engine_newPayloadV3` to `EngineApi`

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -99,6 +99,9 @@ mock_execution = Keyword.get(args, :mock_execution, mode == :db or is_nil(jwt_pa
 implementation = if mock_execution, do: EngineApi.Mocked, else: EngineApi.Api
 jwt_secret = if jwt_path, do: File.read!(jwt_path)
 
+# Check that jwt secret is valid
+LambdaEthereumConsensus.Execution.Auth.generate_token(jwt_secret)
+
 config :lambda_ethereum_consensus, EngineApi,
   endpoint: execution_endpoint,
   jwt_secret: jwt_secret,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -100,7 +100,7 @@ implementation = if mock_execution, do: EngineApi.Mocked, else: EngineApi.Api
 jwt_secret = if jwt_path, do: File.read!(jwt_path)
 
 # Check that jwt secret is valid
-LambdaEthereumConsensus.Execution.Auth.generate_token(jwt_secret)
+if jwt_secret, do: LambdaEthereumConsensus.Execution.Auth.generate_token(jwt_secret)
 
 config :lambda_ethereum_consensus, EngineApi,
   endpoint: execution_endpoint,

--- a/lib/lambda_ethereum_consensus/execution/auth.ex
+++ b/lib/lambda_ethereum_consensus/execution/auth.ex
@@ -27,7 +27,6 @@ defmodule LambdaEthereumConsensus.Execution.Auth do
       |> Base.decode16!(case: :mixed)
 
     signer = Joken.Signer.create("HS256", jwt_secret)
-    claim = %{"iat" => Joken.current_time()}
-    generate_and_sign!(claim, signer)
+    generate_and_sign!(%{}, signer)
   end
 end

--- a/lib/lambda_ethereum_consensus/execution/auth.ex
+++ b/lib/lambda_ethereum_consensus/execution/auth.ex
@@ -4,6 +4,9 @@ defmodule LambdaEthereumConsensus.Execution.Auth do
   """
   use Joken.Config
 
+  # Set default expiry to 60s
+  def token_config, do: default_claims(default_exp: 60)
+
   # JWT Authentication is necessary for the EL <> CL communication through Engine API
   # Following the specs here: https://github.com/ethereum/execution-apis/blob/main/src/engine/authentication.md
   # 3 properties are required for the JWT to be valid:
@@ -16,22 +19,15 @@ defmodule LambdaEthereumConsensus.Execution.Auth do
   @doc """
   Generates a JWT token using HS256 algo and provided secret, additionaly adds an iat claim at current time.
   """
-  @spec generate_token(binary) ::
-          {:error, atom | keyword} | {:ok, binary, %{optional(binary) => any}}
-  def generate_token("0x" <> jwt_secret) do
-    claim = %{"iat" => Joken.current_time()}
-
+  @spec generate_token(String.t()) :: Joken.bearer_token()
+  def generate_token(hex_encoded_secret) do
     jwt_secret =
-      jwt_secret
-      |> String.upcase()
-      |> Base.decode16!()
+      hex_encoded_secret
+      |> String.trim_leading("0x")
+      |> Base.decode16!(case: :mixed)
 
-    signer =
-      Joken.Signer.create(
-        "HS256",
-        jwt_secret
-      )
-
-    generate_and_sign(claim, signer)
+    signer = Joken.Signer.create("HS256", jwt_secret)
+    claim = %{"iat" => Joken.current_time()}
+    generate_and_sign!(claim, signer)
   end
 end

--- a/lib/lambda_ethereum_consensus/execution/engine_api.ex
+++ b/lib/lambda_ethereum_consensus/execution/engine_api.ex
@@ -3,8 +3,7 @@ defmodule LambdaEthereumConsensus.Execution.EngineApi do
   Execution Layer Engine API methods with routing
   """
   alias Types.ExecutionPayload
-
-  use HardForkAliasInjection
+  alias Types.ExecutionPayloadDeneb
 
   @doc """
   Using this method Execution and consensus layer client software may
@@ -15,6 +14,11 @@ defmodule LambdaEthereumConsensus.Execution.EngineApi do
 
   @spec new_payload(ExecutionPayload.t()) :: {:ok, any} | {:error, any}
   def new_payload(execution_payload), do: impl().new_payload(execution_payload)
+
+  @spec new_payload(ExecutionPayloadDeneb.t(), [list(Types.root())], Types.root()) ::
+          {:ok, any} | {:error, any}
+  def new_payload(execution_payload, versioned_hashes, parent_beacon_block_root),
+    do: impl().new_payload(execution_payload, versioned_hashes, parent_beacon_block_root)
 
   @spec forkchoice_updated(map, map | any) :: {:ok, any} | {:error, any}
   def forkchoice_updated(forkchoice_state, payload_attributes),

--- a/lib/lambda_ethereum_consensus/execution/engine_api/api.ex
+++ b/lib/lambda_ethereum_consensus/execution/engine_api/api.ex
@@ -9,7 +9,7 @@ defmodule LambdaEthereumConsensus.Execution.EngineApi.Api do
   alias Types.ExecutionPayload
   alias Types.ExecutionPayloadDeneb
 
-  @supported_methods ["engine_newPayloadV2"]
+  @supported_methods ["engine_newPayloadV2", "engine_newPayloadV2"]
 
   @doc """
   Using this method Execution and consensus layer client software may
@@ -29,16 +29,16 @@ defmodule LambdaEthereumConsensus.Execution.EngineApi.Api do
   @spec new_payload(ExecutionPayloadDeneb.t(), [list(Types.root())], Types.root()) ::
           {:ok, any} | {:error, any}
   # DENEB
-  def new_payload(_execution_payload, _versioned_hashes, _parent_beacon_block_root) do
-    {:ok, %{"status" => "VALID"}}
+  def new_payload(execution_payload, versioned_hashes, parent_beacon_block_root) do
+    call(
+      "engine_newPayloadV3",
+      RPC.normalize([execution_payload, versioned_hashes, parent_beacon_block_root])
+    )
   end
 
   @spec forkchoice_updated(map, map | any) :: {:ok, any} | {:error, any}
   def forkchoice_updated(forkchoice_state, payload_attributes) do
-    call("engine_forkchoiceUpdatedV2", [
-      RPC.normalize(forkchoice_state),
-      RPC.normalize(payload_attributes)
-    ])
+    call("engine_forkchoiceUpdatedV2", RPC.normalize([forkchoice_state, payload_attributes]))
   end
 
   defp call(method, params) do

--- a/lib/lambda_ethereum_consensus/execution/engine_api/api.ex
+++ b/lib/lambda_ethereum_consensus/execution/engine_api/api.ex
@@ -3,9 +3,11 @@ defmodule LambdaEthereumConsensus.Execution.EngineApi.Api do
   Execution Layer Engine API methods
   """
 
+  alias LambdaEthereumConsensus.Execution.EngineApi
   alias LambdaEthereumConsensus.Execution.Auth
   alias LambdaEthereumConsensus.Execution.RPC
   alias Types.ExecutionPayload
+  alias Types.ExecutionPayloadDeneb
 
   @supported_methods ["engine_newPayloadV2"]
 
@@ -18,10 +20,17 @@ defmodule LambdaEthereumConsensus.Execution.EngineApi.Api do
     call("engine_exchangeCapabilities", [@supported_methods])
   end
 
-  @spec new_payload(ExecutionPayload.t()) ::
-          {:ok, any} | {:error, any}
+  @spec new_payload(ExecutionPayload.t()) :: {:ok, any} | {:error, any}
+  # CAPELLA
   def new_payload(execution_payload) do
     call("engine_newPayloadV2", [RPC.normalize(execution_payload)])
+  end
+
+  @spec new_payload(ExecutionPayloadDeneb.t(), [list(Types.root())], Types.root()) ::
+          {:ok, any} | {:error, any}
+  # DENEB
+  def new_payload(_execution_payload, _versioned_hashes, _parent_beacon_block_root) do
+    {:ok, %{"status" => "VALID"}}
   end
 
   @spec forkchoice_updated(map, map | any) :: {:ok, any} | {:error, any}
@@ -33,11 +42,7 @@ defmodule LambdaEthereumConsensus.Execution.EngineApi.Api do
   end
 
   defp call(method, params) do
-    config =
-      Application.fetch_env!(
-        :lambda_ethereum_consensus,
-        LambdaEthereumConsensus.Execution.EngineApi
-      )
+    config = Application.fetch_env!(:lambda_ethereum_consensus, EngineApi)
 
     endpoint = Keyword.fetch!(config, :endpoint)
     version = Keyword.fetch!(config, :version)

--- a/lib/lambda_ethereum_consensus/execution/engine_api/api.ex
+++ b/lib/lambda_ethereum_consensus/execution/engine_api/api.ex
@@ -3,8 +3,8 @@ defmodule LambdaEthereumConsensus.Execution.EngineApi.Api do
   Execution Layer Engine API methods
   """
 
-  alias LambdaEthereumConsensus.Execution.EngineApi
   alias LambdaEthereumConsensus.Execution.Auth
+  alias LambdaEthereumConsensus.Execution.EngineApi
   alias LambdaEthereumConsensus.Execution.RPC
   alias Types.ExecutionPayload
   alias Types.ExecutionPayloadDeneb

--- a/lib/lambda_ethereum_consensus/execution/engine_api/api.ex
+++ b/lib/lambda_ethereum_consensus/execution/engine_api/api.ex
@@ -48,7 +48,7 @@ defmodule LambdaEthereumConsensus.Execution.EngineApi.Api do
     version = Keyword.fetch!(config, :version)
     jwt_secret = Keyword.fetch!(config, :jwt_secret)
 
-    {:ok, jwt, _} = Auth.generate_token(jwt_secret)
+    jwt = Auth.generate_token(jwt_secret)
     RPC.rpc_call(endpoint, jwt, version, method, params)
   end
 end

--- a/lib/lambda_ethereum_consensus/execution/engine_api/api.ex
+++ b/lib/lambda_ethereum_consensus/execution/engine_api/api.ex
@@ -9,7 +9,7 @@ defmodule LambdaEthereumConsensus.Execution.EngineApi.Api do
   alias Types.ExecutionPayload
   alias Types.ExecutionPayloadDeneb
 
-  @supported_methods ["engine_newPayloadV2", "engine_newPayloadV2"]
+  @supported_methods ["engine_newPayloadV2", "engine_newPayloadV3"]
 
   @doc """
   Using this method Execution and consensus layer client software may

--- a/lib/lambda_ethereum_consensus/execution/engine_api/mocked.ex
+++ b/lib/lambda_ethereum_consensus/execution/engine_api/mocked.ex
@@ -1,11 +1,9 @@
 defmodule LambdaEthereumConsensus.Execution.EngineApi.Mocked do
   @moduledoc """
-  Mock Execution Layer Engine API methods
+  Mocked Execution Layer Engine API methods
   """
-
   alias Types.ExecutionPayload
-
-  use HardForkAliasInjection
+  alias Types.ExecutionPayloadDeneb
 
   @doc """
   Using this method Execution and consensus layer client software may
@@ -13,12 +11,19 @@ defmodule LambdaEthereumConsensus.Execution.EngineApi.Mocked do
   """
   @spec exchange_capabilities() :: {:ok, any} | {:error, any}
   def exchange_capabilities do
-    {:ok, ["engine_newPayloadV2"]}
+    {:ok, ["engine_newPayloadV2", "engine_newPayloadV3"]}
   end
 
-  @spec new_payload(ExecutionPayload.t()) ::
-          {:ok, any} | {:error, any}
+  @spec new_payload(ExecutionPayload.t()) :: {:ok, any} | {:error, any}
+  # CAPELLA
   def new_payload(_execution_payload) do
+    {:ok, %{"status" => "VALID"}}
+  end
+
+  @spec new_payload(ExecutionPayloadDeneb.t(), [list(Types.root())], Types.root()) ::
+          {:ok, any} | {:error, any}
+  # DENEB
+  def new_payload(_execution_payload, _versioned_hashes, _parent_beacon_block_root) do
     {:ok, %{"status" => "VALID"}}
   end
 

--- a/lib/lambda_ethereum_consensus/execution/execution_client.ex
+++ b/lib/lambda_ethereum_consensus/execution/execution_client.ex
@@ -83,13 +83,15 @@ defmodule LambdaEthereumConsensus.Execution.ExecutionClient do
   Same as `notify_new_payload`, but with additional checks.
   """
   # CAPELLA
-  def verify_and_notify_new_payload(%NewPayloadRequest{
-        execution_payload: execution_payload,
-        parent_beacon_block_root: nil,
-        versioned_hashes: nil
-      }) do
+  def verify_and_notify_new_payload(
+        %NewPayloadRequest{
+          execution_payload: execution_payload,
+          parent_beacon_block_root: nil,
+          versioned_hashes: nil
+        } = request
+      ) do
     with {:ok, :valid} <- valid_block_hash?(execution_payload) do
-      notify_new_payload(execution_payload)
+      notify_new_payload(request)
     end
   end
 


### PR DESCRIPTION
Closes #756

This PR adds a new RPC call to the Engine API, and integrates it with the existing `ExecutionClient` module. It also simplifies the `Auth` module a bit.