### PR TITLE
feat: add blob availability check (stubbed)

### DIFF
--- a/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
@@ -80,7 +80,8 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
         {:error, "block isn't descendant of latest finalized block"}
 
       # Check blob data is available
-      not (Ssz.hash_tree_root!(block) |> data_available?(block.body.blob_kzg_commitments)) ->
+      HardForkAliasInjection.deneb?() and
+          not (Ssz.hash_tree_root!(block) |> data_available?(block.body.blob_kzg_commitments)) ->
         {:error, "blob data not available"}
 
       true ->

--- a/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
@@ -93,6 +93,8 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
   Equivalent to `is_data_available` from the spec.
   Returns true if the blob's data is available from the network.
   """
+  # TODO: remove when implemented
+  @dialyzer {:no_match, on_block: 2}
   @spec data_available?(Types.root(), [Types.kzg_commitment()]) :: boolean()
   def data_available?(_beacon_block_root, _blob_kzg_commitments) do
     # TODO: the p2p network does not guarantee sidecar retrieval


### PR DESCRIPTION
Related to #765

This PR adds the blob availability check of the `on_block` handler, but with a stubbed implementation, that should be added in a following PR.