### PR TITLE
feat: construct and publish aggregated attestations

### DIFF
--- a/lib/lambda_ethereum_consensus/p2p/gossip/attestation.ex
+++ b/lib/lambda_ethereum_consensus/p2p/gossip/attestation.ex
@@ -35,7 +35,7 @@ defmodule LambdaEthereumConsensus.P2P.Gossip.Attestation do
     update_enr()
   end
 
-  @spec publish(non_neg_integer(), Types.Attestation) :: :ok
+  @spec publish(non_neg_integer(), Types.Attestation.t()) :: :ok
   def publish(subnet_id, %Types.Attestation{} = attestation) do
     topic = get_topic_name(subnet_id)
     {:ok, encoded} = SszEx.encode(attestation, Types.Attestation)
@@ -51,14 +51,14 @@ defmodule LambdaEthereumConsensus.P2P.Gossip.Attestation do
     Libp2pPort.publish(topic, message)
   end
 
-  @spec collect(non_neg_integer(), Types.AttestationData) :: :ok
+  @spec collect(non_neg_integer(), Types.AttestationData.t()) :: :ok
   def collect(subnet_id, attestation_data) do
     GenServer.call(__MODULE__, {:collect, subnet_id, attestation_data})
     join(subnet_id)
   end
 
   @spec stop_collecting(non_neg_integer()) ::
-          {:ok, list(Types.Attestation)} | {:error, String.t()}
+          {:ok, list(Types.Attestation.t())} | {:error, String.t()}
   def stop_collecting(subnet_id) do
     leave(subnet_id)
     GenServer.call(__MODULE__, {:stop_collecting, subnet_id})

--- a/lib/lambda_ethereum_consensus/p2p/gossip/attestation.ex
+++ b/lib/lambda_ethereum_consensus/p2p/gossip/attestation.ex
@@ -116,12 +116,13 @@ defmodule LambdaEthereumConsensus.P2P.Gossip.Attestation do
   end
 
   defp store_attestation(subnet_id, %{attestations: attestations} = state, attestation) do
-    # TODO: compare attestation with attestation_data
-    if Map.has_key?(attestation, subnet_id) do
-      attestations = Map.update(attestations, subnet_id, [], &[attestation | &1])
-      %{state | attestations: attestations}
-    else
-      state
+    case Map.get(attestation, subnet_id) do
+      data when data !== attestation.data ->
+        state
+
+      _ ->
+        attestations = Map.update(attestations, subnet_id, [], &[attestation | &1])
+        %{state | attestations: attestations}
     end
   end
 end

--- a/lib/lambda_ethereum_consensus/validator/validator.ex
+++ b/lib/lambda_ethereum_consensus/validator/validator.ex
@@ -5,13 +5,13 @@ defmodule LambdaEthereumConsensus.Validator do
   use GenServer
   require Logger
 
-  alias LambdaEthereumConsensus.Utils.BitField
   alias LambdaEthereumConsensus.ForkChoice.Handlers
   alias LambdaEthereumConsensus.P2P.Gossip
   alias LambdaEthereumConsensus.StateTransition
   alias LambdaEthereumConsensus.StateTransition.Accessors
   alias LambdaEthereumConsensus.StateTransition.Misc
   alias LambdaEthereumConsensus.Store.BlockStates
+  alias LambdaEthereumConsensus.Utils.BitField
   alias LambdaEthereumConsensus.Utils.BitList
   alias LambdaEthereumConsensus.Validator.Utils
   alias Types.Attestation
@@ -177,7 +177,7 @@ defmodule LambdaEthereumConsensus.Validator do
 
     if current_duty.is_aggregator do
       Logger.info("[Validator] Collecting messages for future aggregation...")
-      Gossip.Attestation.collect(subnet_id, attestation)
+      Gossip.Attestation.collect(subnet_id, attestation.data)
     end
   end
 

--- a/lib/utils/bit_field.ex
+++ b/lib/utils/bit_field.ex
@@ -82,4 +82,10 @@ defmodule LambdaEthereumConsensus.Utils.BitField do
   """
   @spec count(t) :: non_neg_integer()
   def count(bit_field), do: for(<<bit::1 <- bit_field>>, do: bit) |> Enum.sum()
+
+  @doc """
+  Receives two bitfields and returns the OR of both.
+  """
+  @spec bitwise_or(t, t) :: t
+  def bitwise_or(left, right) when bit_size(left) == bit_size(right), do: Bitwise.bor(left, right)
 end

--- a/lib/utils/bit_field.ex
+++ b/lib/utils/bit_field.ex
@@ -87,5 +87,10 @@ defmodule LambdaEthereumConsensus.Utils.BitField do
   Receives two bitfields and returns the OR of both.
   """
   @spec bitwise_or(t, t) :: t
-  def bitwise_or(left, right) when bit_size(left) == bit_size(right), do: Bitwise.bor(left, right)
+  def bitwise_or(left, right) when bit_size(left) == bit_size(right) do
+    size = bit_size(left)
+    left_int = :binary.decode_unsigned(left)
+    right_int = :binary.decode_unsigned(right)
+    <<Bitwise.bor(left_int, right_int)::size(size)>>
+  end
 end


### PR DESCRIPTION
Depends on #890
Closes #839
Closes #840

This PR adds the logic of `SignedAggregateAndProof` creation and broadcasting. Also: it adds some typespecs that were missing, and filters incoming attestations leaving only those matching our vision.