### PR TITLE
feat: add operations to block

### DIFF
--- a/lib/lambda_ethereum_consensus/validator/block_request.ex
+++ b/lib/lambda_ethereum_consensus/validator/block_request.ex
@@ -1,0 +1,32 @@
+defmodule LambdaEthereumConsensus.Validator.BlockRequest do
+  @moduledoc """
+  Struct that stores and validates data for block construction.
+  """
+  alias Types.BeaconState
+
+  enforced_keys = [:slot, :proposer_index]
+
+  optional_keys = [
+    graffiti_message: "",
+    proposer_slashings: [],
+    attester_slashings: [],
+    attestations: [],
+    voluntary_exits: [],
+    bls_to_execution_changes: []
+  ]
+
+  @enforce_keys enforced_keys
+  defstruct enforced_keys ++ optional_keys
+
+  @type t() :: %{
+          slot: Types.slot(),
+          proposer_index: Types.validator_index(),
+          graffiti_message: binary()
+        }
+
+  @spec validate(t(), BeaconState.t()) :: {:ok, t()} | {:error, String.t()}
+  def validate(%__MODULE__{slot: slot}, %BeaconState{slot: state_slot}) when slot <= state_slot,
+    do: {:error, "slot is older than the state"}
+
+  def validate(%__MODULE__{} = request, _), do: request
+end

--- a/lib/lambda_ethereum_consensus/validator/block_request.ex
+++ b/lib/lambda_ethereum_consensus/validator/block_request.ex
@@ -20,7 +20,7 @@ defmodule LambdaEthereumConsensus.Validator.BlockRequest do
   @enforce_keys enforced_keys
   defstruct enforced_keys ++ optional_keys
 
-  @type t() :: %{
+  @type t() :: %__MODULE__{
           slot: Types.slot(),
           proposer_index: Types.validator_index(),
           graffiti_message: binary()

--- a/lib/lambda_ethereum_consensus/validator/block_request.ex
+++ b/lib/lambda_ethereum_consensus/validator/block_request.ex
@@ -1,6 +1,8 @@
 defmodule LambdaEthereumConsensus.Validator.BlockRequest do
   @moduledoc """
   Struct that stores and validates data for block construction.
+  Most of the data is already validated when computing the state
+  transition, so this focuses on cheap validations.
   """
   alias Types.BeaconState
 
@@ -28,5 +30,5 @@ defmodule LambdaEthereumConsensus.Validator.BlockRequest do
   def validate(%__MODULE__{slot: slot}, %BeaconState{slot: state_slot}) when slot <= state_slot,
     do: {:error, "slot is older than the state"}
 
-  def validate(%__MODULE__{} = request, _), do: request
+  def validate(%__MODULE__{} = request, _), do: {:ok, request}
 end

--- a/lib/lambda_ethereum_consensus/validator/proposer.ex
+++ b/lib/lambda_ethereum_consensus/validator/proposer.ex
@@ -2,11 +2,11 @@ defmodule LambdaEthereumConsensus.Validator.Proposer do
   @moduledoc """
   Validator proposer duties.
   """
-  alias LambdaEthereumConsensus.Validator.BlockRequest
   alias LambdaEthereumConsensus.P2P.Gossip.OperationsCollector
   alias LambdaEthereumConsensus.StateTransition.Accessors
   alias LambdaEthereumConsensus.StateTransition.Misc
   alias LambdaEthereumConsensus.Utils.BitVector
+  alias LambdaEthereumConsensus.Validator.BlockRequest
 
   alias Types.BeaconState
 

--- a/lib/lambda_ethereum_consensus/validator/proposer.ex
+++ b/lib/lambda_ethereum_consensus/validator/proposer.ex
@@ -2,47 +2,75 @@ defmodule LambdaEthereumConsensus.Validator.Proposer do
   @moduledoc """
   Validator proposer duties.
   """
+  alias LambdaEthereumConsensus.Validator.BlockRequest
+  alias LambdaEthereumConsensus.P2P.Gossip.OperationsCollector
   alias LambdaEthereumConsensus.StateTransition.Accessors
   alias LambdaEthereumConsensus.StateTransition.Misc
   alias LambdaEthereumConsensus.Utils.BitVector
 
   alias Types.BeaconState
 
-  @spec construct_block(BeaconState.t(), Types.slot(), Types.validator_index(), Bls.privkey()) ::
-          {:ok, Types.SignedBeaconBlock.t()}
-  def construct_block(%BeaconState{} = state, slot, proposer_index, privkey) do
-    # NOTE: the state is at the start of the block's slot
-    block = %Types.BeaconBlock{
-      slot: slot,
-      proposer_index: proposer_index,
-      parent_root:
-        <<123, 234, 141, 179, 46, 87, 30, 35, 136, 140, 35, 5, 42, 50, 198, 192, 151, 177, 18,
-          239, 141, 142, 107, 105, 107, 140, 88, 112, 50, 69, 47, 228>>,
-      state_root:
-        <<173, 81, 100, 66, 197, 84, 137, 102, 200, 161, 182, 241, 222, 150, 201, 211, 80, 154,
-          64, 171, 115, 238, 58, 66, 103, 74, 220, 170, 8, 126, 22, 61>>,
-      body: %Types.BeaconBlockBody{
-        randao_reveal: get_epoch_signature(state, slot, privkey),
-        eth1_data: get_eth1_data(),
-        graffiti: pad_graffiti_message(""),
-        proposer_slashings: [],
-        attester_slashings: [],
-        attestations: [],
-        deposits: [],
-        voluntary_exits: [],
-        bls_to_execution_changes: [],
-        blob_kzg_commitments: [],
-        sync_aggregate: get_sync_aggregate(),
-        execution_payload: get_execution_payload()
+  @type block_request() :: %{
+          slot: Types.slot(),
+          proposer_index: Types.validator_index(),
+          graffiti_message: binary()
+        }
+
+  @spec construct_block(BeaconState.t(), block_request(), Bls.privkey()) ::
+          {:ok, Types.SignedBeaconBlock.t()} | {:error, String.t()}
+  def construct_block(%BeaconState{} = state, %BlockRequest{} = request, privkey) do
+    with {:ok, block_request} <- BlockRequest.validate(request, state) do
+      block = %Types.BeaconBlock{
+        slot: block_request.slot,
+        proposer_index: block_request.proposer_index,
+        parent_root:
+          <<123, 234, 141, 179, 46, 87, 30, 35, 136, 140, 35, 5, 42, 50, 198, 192, 151, 177, 18,
+            239, 141, 142, 107, 105, 107, 140, 88, 112, 50, 69, 47, 228>>,
+        state_root:
+          <<173, 81, 100, 66, 197, 84, 137, 102, 200, 161, 182, 241, 222, 150, 201, 211, 80, 154,
+            64, 171, 115, 238, 58, 66, 103, 74, 220, 170, 8, 126, 22, 61>>,
+        body: construct_block_body(state, block_request, privkey)
       }
-    }
 
-    signed_block = %Types.SignedBeaconBlock{
-      message: block,
-      signature: get_block_signature(state, block, privkey)
-    }
+      signed_block = %Types.SignedBeaconBlock{
+        message: block,
+        signature: get_block_signature(state, block, privkey)
+      }
 
-    {:ok, signed_block}
+      {:ok, signed_block}
+    end
+  end
+
+  def fetch_operations_for_block do
+    %{
+      proposer_slashings:
+        ChainSpec.get("MAX_PROPOSER_SLASHINGS") |> OperationsCollector.get_proposer_slashings(),
+      attester_slashings:
+        ChainSpec.get("MAX_ATTESTER_SLASHINGS") |> OperationsCollector.get_attester_slashings(),
+      attestations: ChainSpec.get("MAX_ATTESTATIONS") |> OperationsCollector.get_attestations(),
+      voluntary_exits:
+        ChainSpec.get("MAX_VOLUNTARY_EXITS") |> OperationsCollector.get_voluntary_exits(),
+      bls_to_execution_changes:
+        ChainSpec.get("MAX_BLS_TO_EXECUTION_CHANGES")
+        |> OperationsCollector.get_bls_to_execution_changes()
+    }
+  end
+
+  defp construct_block_body(state, request, privkey) do
+    %Types.BeaconBlockBody{
+      randao_reveal: get_epoch_signature(state, request.slot, privkey),
+      eth1_data: get_eth1_data(),
+      graffiti: pad_graffiti_message(request.graffiti_message),
+      proposer_slashings: request.proposer_slashings,
+      attester_slashings: request.attester_slashings,
+      attestations: request.attestations,
+      deposits: [],
+      voluntary_exits: request.voluntary_exits,
+      bls_to_execution_changes: request.bls_to_execution_changes,
+      blob_kzg_commitments: [],
+      sync_aggregate: get_sync_aggregate(),
+      execution_payload: get_execution_payload()
+    }
   end
 
   @spec get_epoch_signature(BeaconState.t(), Types.slot(), Bls.privkey()) ::

--- a/lib/lambda_ethereum_consensus/validator/proposer.ex
+++ b/lib/lambda_ethereum_consensus/validator/proposer.ex
@@ -10,13 +10,7 @@ defmodule LambdaEthereumConsensus.Validator.Proposer do
 
   alias Types.BeaconState
 
-  @type block_request() :: %{
-          slot: Types.slot(),
-          proposer_index: Types.validator_index(),
-          graffiti_message: binary()
-        }
-
-  @spec construct_block(BeaconState.t(), block_request(), Bls.privkey()) ::
+  @spec construct_block(BeaconState.t(), BlockRequest.t(), Bls.privkey()) ::
           {:ok, Types.SignedBeaconBlock.t()} | {:error, String.t()}
   def construct_block(%BeaconState{} = state, %BlockRequest{} = request, privkey) do
     with {:ok, block_request} <- BlockRequest.validate(request, state) do
@@ -41,6 +35,13 @@ defmodule LambdaEthereumConsensus.Validator.Proposer do
     end
   end
 
+  @spec fetch_operations_for_block() :: %{
+          proposer_slashings: [Types.ProposerSlashing.t()],
+          attester_slashings: [Types.AttesterSlashing.t()],
+          attestations: [Types.Attestation.t()],
+          voluntary_exits: [Types.VoluntaryExit.t()],
+          bls_to_execution_changes: [Types.SignedBLSToExecutionChange.t()]
+        }
   def fetch_operations_for_block do
     %{
       proposer_slashings:

--- a/lib/types/beacon_chain/beacon_block_body.ex
+++ b/lib/types/beacon_chain/beacon_block_body.ex
@@ -48,23 +48,22 @@ defmodule Types.BeaconBlockBody do
   @impl LambdaEthereumConsensus.Container
   def schema do
     [
-      {:randao_reveal, TypeAliases.bls_signature()},
-      {:eth1_data, Types.Eth1Data},
-      {:graffiti, TypeAliases.bytes32()},
-      {:proposer_slashings,
-       {:list, Types.ProposerSlashing, ChainSpec.get("MAX_PROPOSER_SLASHINGS")}},
-      {:attester_slashings,
-       {:list, Types.AttesterSlashing, ChainSpec.get("MAX_ATTESTER_SLASHINGS")}},
-      {:attestations, {:list, Types.Attestation, ChainSpec.get("MAX_ATTESTATIONS")}},
-      {:deposits, {:list, Types.Deposit, ChainSpec.get("MAX_DEPOSITS")}},
-      {:voluntary_exits,
-       {:list, Types.SignedVoluntaryExit, ChainSpec.get("MAX_VOLUNTARY_EXITS")}},
-      {:sync_aggregate, Types.SyncAggregate},
-      {:execution_payload, Types.ExecutionPayload},
-      {:bls_to_execution_changes,
-       {:list, Types.SignedBLSToExecutionChange, ChainSpec.get("MAX_BLS_TO_EXECUTION_CHANGES")}},
-      {:blob_kzg_commitments,
-       {:list, TypeAliases.kzg_commitment(), ChainSpec.get("MAX_BLOB_COMMITMENTS_PER_BLOCK")}}
+      randao_reveal: TypeAliases.bls_signature(),
+      eth1_data: Types.Eth1Data,
+      graffiti: TypeAliases.bytes32(),
+      proposer_slashings:
+        {:list, Types.ProposerSlashing, ChainSpec.get("MAX_PROPOSER_SLASHINGS")},
+      attester_slashings:
+        {:list, Types.AttesterSlashing, ChainSpec.get("MAX_ATTESTER_SLASHINGS")},
+      attestations: {:list, Types.Attestation, ChainSpec.get("MAX_ATTESTATIONS")},
+      deposits: {:list, Types.Deposit, ChainSpec.get("MAX_DEPOSITS")},
+      voluntary_exits: {:list, Types.SignedVoluntaryExit, ChainSpec.get("MAX_VOLUNTARY_EXITS")},
+      sync_aggregate: Types.SyncAggregate,
+      execution_payload: Types.ExecutionPayload,
+      bls_to_execution_changes:
+        {:list, Types.SignedBLSToExecutionChange, ChainSpec.get("MAX_BLS_TO_EXECUTION_CHANGES")},
+      blob_kzg_commitments:
+        {:list, TypeAliases.kzg_commitment(), ChainSpec.get("MAX_BLOB_COMMITMENTS_PER_BLOCK")}
     ]
   end
 end

--- a/test/unit/validator/proposer_test.exs
+++ b/test/unit/validator/proposer_test.exs
@@ -3,6 +3,7 @@ defmodule Unit.Validator.ProposerTests do
   use ExUnit.Case
 
   alias LambdaEthereumConsensus.StateTransition
+  alias LambdaEthereumConsensus.Validator.BlockRequest
   alias LambdaEthereumConsensus.Validator.Proposer
   alias Types.BeaconState
   alias Types.SignedBeaconBlock
@@ -27,14 +28,15 @@ defmodule Unit.Validator.ProposerTests do
       )
 
     # This private key is taken from the spec test vectors
-    privkey =
-      <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 64>>
+    privkey = <<0::248, 64>>
 
-    validator_index = 63
+    block_request = %BlockRequest{
+      slot: pre_state.slot + 1,
+      proposer_index: 63,
+      graffiti_message: ""
+    }
 
-    {:ok, signed_block} =
-      Proposer.construct_block(pre_state, pre_state.slot + 1, validator_index, privkey)
+    {:ok, signed_block} = Proposer.construct_block(pre_state, block_request, privkey)
 
     assert signed_block.message.body.randao_reveal == spec_block.message.body.randao_reveal
     assert signed_block.signature == spec_block.signature


### PR DESCRIPTION
Closes #912
Closes #913
Closes #914
Closes #916
Closes #918

This PR refactors the parameters of `Proposer.construct_block`, and allows passing arbitrary operations to add onto the block. It also updates the `Validator` and tests.