### PR TITLE
fix: attesting on empty slots with the wrong state

### DIFF
--- a/lib/lambda_ethereum_consensus/validator/validator.ex
+++ b/lib/lambda_ethereum_consensus/validator/validator.ex
@@ -121,7 +121,7 @@ defmodule LambdaEthereumConsensus.Validator do
       target_root = if slot == start_slot, do: head_root, else: last_root
 
       # Process the start of the new epoch
-      new_beacon = fetch_target_state(epoch, target_root) |> process_slots(start_slot)
+      new_beacon = fetch_target_state(epoch, target_root) |> go_to_slot(start_slot)
 
       new_duties =
         shift_duties(state.duties, epoch, last_epoch)
@@ -320,7 +320,7 @@ defmodule LambdaEthereumConsensus.Validator do
       slot: slot
     } = duty
 
-    head_state = BlockStates.get_state!(head_root) |> process_slots(slot)
+    head_state = BlockStates.get_state!(head_root) |> go_to_slot(slot)
     head_epoch = Misc.compute_epoch_at_slot(slot)
 
     epoch_boundary_block_root =
@@ -356,11 +356,15 @@ defmodule LambdaEthereumConsensus.Validator do
     {duty.subnet_id, attestation}
   end
 
-  defp process_slots(%{slot: old_slot} = state, slot) when old_slot == slot, do: state
+  defp go_to_slot(%{slot: old_slot} = state, slot) when old_slot == slot, do: state
 
-  defp process_slots(state, slot) do
+  defp go_to_slot(%{slot: old_slot} = state, slot) when old_slot < slot do
     {:ok, st} = StateTransition.process_slots(state, slot)
     st
+  end
+
+  defp go_to_slot(%{latest_block_header: %{parent_root: parent_root}}, slot) do
+    BlockStates.get_state!(parent_root) |> go_to_slot(slot)
   end
 
   defp update_with_aggregation_duty(nil, _beacon_state, _privkey), do: nil


### PR DESCRIPTION
This fixes a bug we were having when attesting on empty slots:

```
no match of right hand side value: {:error, "slot is older than state"}
```

Since we process duties each time a block arrives, we don't notice the empty slot and try to attest with the state from the next slot, which triggers the error.