### PR TITLE
feat: make `BeaconChain` send ticks to `Validator`

### DIFF
--- a/lib/lambda_ethereum_consensus/beacon/beacon_chain.ex
+++ b/lib/lambda_ethereum_consensus/beacon/beacon_chain.ex
@@ -5,6 +5,7 @@ defmodule LambdaEthereumConsensus.Beacon.BeaconChain do
 
   alias LambdaEthereumConsensus.ForkChoice
   alias LambdaEthereumConsensus.StateTransition.Misc
+  alias LambdaEthereumConsensus.Validator
   alias Types.BeaconState
   alias Types.Checkpoint
 
@@ -229,6 +230,7 @@ defmodule LambdaEthereumConsensus.Beacon.BeaconChain do
 
   defp notify_subscribers(logical_time) do
     log_new_slot(logical_time)
+    Validator.notify_tick(logical_time)
   end
 
   defp log_new_slot({slot, :first_third}) do

--- a/lib/lambda_ethereum_consensus/validator/validator.ex
+++ b/lib/lambda_ethereum_consensus/validator/validator.ex
@@ -209,10 +209,16 @@ defmodule LambdaEthereumConsensus.Validator do
     # Can't fail
     {:ok, duty} = Utils.get_committee_assignment(beacon_state, epoch, validator.index)
 
-    duty
-    |> Map.put(:attested?, false)
-    |> update_with_aggregation_duty(beacon_state, validator.privkey)
-    |> update_with_subnet_id(beacon_state, epoch)
+    case duty do
+      nil ->
+        nil
+
+      duty ->
+        duty
+        |> Map.put(:attested?, false)
+        |> update_with_aggregation_duty(beacon_state, validator.privkey)
+        |> update_with_subnet_id(beacon_state, epoch)
+    end
   end
 
   defp get_subnet_ids(duties),
@@ -407,8 +413,6 @@ defmodule LambdaEthereumConsensus.Validator do
   defp go_to_slot(%{latest_block_header: %{parent_root: parent_root}}, slot) do
     BlockStates.get_state!(parent_root) |> go_to_slot(slot)
   end
-
-  defp update_with_aggregation_duty(nil, _beacon_state, _privkey), do: nil
 
   defp update_with_aggregation_duty(duty, beacon_state, privkey) do
     proof = Utils.get_slot_signature(beacon_state, duty.slot, privkey)

--- a/lib/lambda_ethereum_consensus/validator/validator.ex
+++ b/lib/lambda_ethereum_consensus/validator/validator.ex
@@ -113,8 +113,29 @@ defmodule LambdaEthereumConsensus.Validator do
     {:noreply, new_state}
   end
 
-  def handle_cast({:on_tick, logical_time}, state) do
-    # TODO: implement
+  def handle_cast({:on_tick, _}, %{validator: %{index: nil}} = state), do: {:noreply, state}
+
+  def handle_cast({:on_tick, logical_time}, state),
+    do: {:noreply, handle_tick(logical_time, state)}
+
+  defp handle_tick({_slot, :first_third}, state) do
+    # Here we may:
+    # 1. propose our blocks
+    # 2. start collecting attestations for aggregation
+    state
+  end
+
+  defp handle_tick({_slot, :second_third}, state) do
+    # Here we may:
+    # 1. send our attestation for an empty slot (if so)
+    # 2. start building a payload
+    state
+  end
+
+  defp handle_tick({_slot, :last_third}, state) do
+    # Here we may:
+    # 1. publish our aggregate
+    state
   end
 
   defp update_state(%{slot: last_slot, root: last_root} = state, slot, head_root) do

--- a/lib/lambda_ethereum_consensus/validator/validator.ex
+++ b/lib/lambda_ethereum_consensus/validator/validator.ex
@@ -27,6 +27,9 @@ defmodule LambdaEthereumConsensus.Validator do
   def notify_new_block(slot, head_root),
     do: GenServer.cast(__MODULE__, {:new_block, slot, head_root})
 
+  def notify_tick(logical_time),
+    do: GenServer.cast(__MODULE__, {:on_tick, logical_time})
+
   @impl true
   def init({slot, head_root}) do
     config = Application.get_env(:lambda_ethereum_consensus, __MODULE__, [])
@@ -108,6 +111,10 @@ defmodule LambdaEthereumConsensus.Validator do
     if should_propose?(new_state, slot + 1), do: propose(new_state, slot + 1)
 
     {:noreply, new_state}
+  end
+
+  def handle_cast({:on_tick, logical_time}, state) do
+    # TODO: implement
   end
 
   defp update_state(%{slot: last_slot, root: last_root} = state, slot, head_root) do


### PR DESCRIPTION
Closes #926

This PR adds a static pub-sub to `BeaconChain`, that notifies the `Validator` whenever a third of a slot starts. That way we can send attestations, aggregates, and blocks when they _should_ be published, instead of when a new block happens to arrive.