### PR TITLE
fix: handle shorter byte lengths than expected

### DIFF
--- a/lib/ssz_ex/decode.ex
+++ b/lib/ssz_ex/decode.ex
@@ -241,10 +241,13 @@ defmodule SszEx.Decode do
     schemas = module.schema()
     fixed_length = get_fixed_length(schemas)
 
-    with {:ok, fixed_parts, _offsets, items_index} <-
-           decode_fixed_section(binary, schemas, fixed_length),
-         :ok <- check_byte_len(items_index, byte_size(binary)) do
-      {:ok, struct!(module, fixed_parts)}
+    if fixed_length != byte_size(binary) do
+      {:error, "InvalidByteLength"}
+    else
+      with {:ok, fixed_parts, _offsets, _items_index} <-
+             decode_fixed_section(binary, schemas, fixed_length) do
+        {:ok, struct!(module, fixed_parts)}
+      end
     end
   end
 
@@ -255,13 +258,6 @@ defmodule SszEx.Decode do
       true -> :ok
     end
   end
-
-  defp check_byte_len(items_index, binary_size)
-       when items_index == binary_size,
-       do: :ok
-
-  defp check_byte_len(_items_index, _binary_size),
-    do: {:error, "InvalidByteLength"}
 
   defp decode_variable_section(full_binary, binary, offsets) do
     offsets

--- a/test/unit/ssz_ex_test.exs
+++ b/test/unit/ssz_ex_test.exs
@@ -703,7 +703,7 @@ defmodule Unit.SSZExTest do
   end
 
   test "decode longer IndexedAttestation" do
-    encoded_indexed_attestation = <<0::size(10000)>>
+    encoded_indexed_attestation = <<0::size(10_000)>>
 
     assert SszEx.decode(encoded_indexed_attestation, IndexedAttestation) ==
              {:error, "OffsetIntoFixedPortion (0)"}

--- a/test/unit/ssz_ex_test.exs
+++ b/test/unit/ssz_ex_test.exs
@@ -1,4 +1,5 @@
 defmodule Unit.SSZExTest do
+  alias Types.IndexedAttestation
   alias LambdaEthereumConsensus.Utils.Diff
   alias SszEx.Merkleization
 
@@ -678,5 +679,33 @@ defmodule Unit.SSZExTest do
     assert Merkleization.get_zero_hash(1) == chunk1
     assert Merkleization.get_zero_hash(2) == chunk2
     assert Merkleization.get_zero_hash(3) == chunk3
+  end
+
+  test "decode shorter checkpoint" do
+    encoded_checkpoint =
+      <<0,0,0>>
+
+    assert SszEx.decode(encoded_checkpoint, Checkpoint) == {:error, "InvalidByteLength"}
+  end
+
+  test "decode longer checkpoint" do
+    encoded_checkpoint =
+      <<0::size(41)>>
+
+    assert SszEx.decode(encoded_checkpoint, Checkpoint) == {:error, "InvalidByteLength"}
+  end
+
+  test "decode shorter IndexedAttestation" do
+    encoded_indexed_attestation = <<0, 0, 0>>
+
+    assert SszEx.decode(encoded_indexed_attestation, IndexedAttestation) ==
+             {:error, "OffsetOutOfBounds"}
+  end
+
+  test "decode longer IndexedAttestation" do
+    encoded_indexed_attestation = <<0::size(10000)>>
+
+    assert SszEx.decode(encoded_indexed_attestation, IndexedAttestation) ==
+             {:error, "OffsetIntoFixedPortion (0)"}
   end
 end

--- a/test/unit/ssz_ex_test.exs
+++ b/test/unit/ssz_ex_test.exs
@@ -1,7 +1,7 @@
 defmodule Unit.SSZExTest do
-  alias Types.IndexedAttestation
   alias LambdaEthereumConsensus.Utils.Diff
   alias SszEx.Merkleization
+  alias Types.IndexedAttestation
 
   alias Types.BeaconBlock
   alias Types.BeaconBlockBody
@@ -683,7 +683,7 @@ defmodule Unit.SSZExTest do
 
   test "decode shorter checkpoint" do
     encoded_checkpoint =
-      <<0,0,0>>
+      <<0, 0, 0>>
 
     assert SszEx.decode(encoded_checkpoint, Checkpoint) == {:error, "InvalidByteLength"}
   end


### PR DESCRIPTION
This PR fixes a bug when trying to decode a container and the received binary is shorter than expected.
Will handle error messages on a different PR.

Closes #896 

