### PR TITLE
chore: reduce log level for gossipsub decode error

### DIFF
--- a/lib/lambda_ethereum_consensus/p2p/gossip/consumer.ex
+++ b/lib/lambda_ethereum_consensus/p2p/gossip/consumer.ex
@@ -42,7 +42,7 @@ defmodule LambdaEthereumConsensus.P2P.Gossip.Consumer do
         data
         |> Base.encode16()
         |> then(&"[#{topic}] (err: #{reason}) raw: '#{&1}'")
-        |> Logger.error()
+        |> Logger.warning()
 
         Broadway.Message.failed(message, reason)
     end


### PR DESCRIPTION
Since the error isn't on our side, we shouldn't be so noisy about it.