### PR TITLE
refactor: normalize SSZ error messages

### DIFF
--- a/lib/ssz_ex/merkleization.ex
+++ b/lib/ssz_ex/merkleization.ex
@@ -64,28 +64,28 @@ defmodule SszEx.Merkleization do
 
   @spec hash_tree_root(list(), {:list, any, non_neg_integer}) ::
           {:ok, Types.root()} | {:error, String.t()}
-  def hash_tree_root(list, {:list, type, _size} = schema) do
-    limit = chunk_count(schema)
+  def hash_tree_root(list, {:list, type, max_size} = schema) do
     len = Enum.count(list)
 
-    value =
-      if Utils.basic_type?(type) do
-        pack(list, schema)
-      else
-        list_hash_tree_root(list, type)
-      end
+    cond do
+      len > max_size ->
+        {:error,
+         "Invalid binary length while encoding list of #{inspect(type)}.\nExpected max_size: #{max_size}.\nFound: #{len}\n"}
 
-    case value do
-      {:ok, chunks} -> chunks |> hash_tree_root_list(limit, len)
-      {:error, reason} -> {:error, reason}
-      chunks -> chunks |> hash_tree_root_list(limit, len)
+      Utils.basic_type?(type) ->
+        list_hash_tree_root_basic(list, schema, len)
+
+      true ->
+        list_hash_tree_root_complex(list, schema, type, len)
     end
   end
 
   @spec hash_tree_root(list(), {:vector, any, non_neg_integer}) ::
           {:ok, Types.root()} | {:error, String.t()}
-  def hash_tree_root(vector, {:vector, _type, size}) when length(vector) != size,
-    do: {:error, "invalid size"}
+  def hash_tree_root(vector, {:vector, inner_type, size}) when length(vector) != size,
+    do:
+      {:error,
+       "Invalid binary length while merkleizing vector of #{inspect(inner_type)}.\nExpected size: #{size}.\nFound: #{length(vector)}\n"}
 
   def hash_tree_root(vector, {:vector, type, _size} = schema) do
     value =
@@ -128,6 +128,20 @@ defmodule SszEx.Merkleization do
     end
   end
 
+  defp list_hash_tree_root_basic(list, schema, len) do
+    limit = chunk_count(schema)
+    pack(list, schema) |> hash_tree_root_list(limit, len)
+  end
+
+  defp list_hash_tree_root_complex(list, schema, type, len) do
+    limit = chunk_count(schema)
+
+    with {:ok, chunks} <- list_hash_tree_root(list, type),
+         result <- hash_tree_root_list(chunks, limit, len) do
+      result
+    end
+  end
+
   defp hash_tree_root_vector(chunks) do
     leaf_count = chunks |> get_chunks_len() |> next_pow_of_two()
     root = merkleize_chunks_with_virtual_padding(chunks, leaf_count)
@@ -135,14 +149,8 @@ defmodule SszEx.Merkleization do
   end
 
   defp hash_tree_root_list(chunks, limit, len) do
-    chunks_len = chunks |> get_chunks_len()
-
-    if chunks_len > limit do
-      {:error, "chunk size exceeds limit"}
-    else
-      root = merkleize_chunks_with_virtual_padding(chunks, limit) |> mix_in_length(len)
-      {:ok, root}
-    end
+    root = merkleize_chunks_with_virtual_padding(chunks, limit) |> mix_in_length(len)
+    {:ok, root}
   end
 
   defp list_hash_tree_root(list, inner_schema) do

--- a/test/unit/ssz_ex_test.exs
+++ b/test/unit/ssz_ex_test.exs
@@ -431,7 +431,8 @@ defmodule Unit.SSZExTest do
   end
 
   test "serialize out bounded list" do
-    error_message = "invalid max_size of list"
+    error_message =
+      "Invalid binary length while encoding list of {:int, 32}.\nExpected max_size: 3.\nFound: 4\n"
 
     assert {:error, ^error_message} =
              SszEx.encode([230, 380, 523, 23_423], {:list, {:int, 32}, 3})
@@ -738,5 +739,14 @@ defmodule Unit.SSZExTest do
     assert SszEx.decode(encoded_checkpoint, Checkpoint) ==
              {:error,
               "Invalid binary length while decoding Elixir.Types.Checkpoint. \nExpected 40. \nFound 41.\n"}
+  end
+
+  test "hash tree root of list exceeding max size" do
+    initial_list = [5, 5, 5, 5]
+
+    error =
+      "Invalid binary length while encoding list of {:int, 8}.\nExpected max_size: 2.\nFound: 4\n"
+
+    assert {:error, ^error} = SszEx.hash_tree_root(initial_list, {:list, {:int, 8}, 2})
   end
 end


### PR DESCRIPTION
This PR normalizes the rest of the error messages in our SSZ module.
Closes https://github.com/lambdaclass/lambda_ethereum_consensus/issues/986

