### PR TITLE
refactor: change SSZ errors to structs

### DIFF
--- a/lib/ssz_ex/decode.ex
+++ b/lib/ssz_ex/decode.ex
@@ -5,13 +5,14 @@ defmodule SszEx.Decode do
 
   alias LambdaEthereumConsensus.Utils.BitList
   alias LambdaEthereumConsensus.Utils.BitVector
+  alias SszEx.Error
   alias SszEx.Utils
 
   @bytes_per_length_offset 4
   @offset_bits 32
 
   @spec decode(binary(), SszEx.schema()) ::
-          {:ok, any()} | {:error, String.t()}
+          {:ok, any()} | Error.t()
   def decode(binary, :bool), do: decode_bool(binary)
   def decode(binary, {:int, size}), do: decode_uint(binary, size)
   def decode(value, {:byte_list, _}), do: {:ok, value}
@@ -50,9 +51,10 @@ defmodule SszEx.Decode do
   end
 
   defp decode_uint(binary, size) when bit_size(binary) != size,
-    do:
-      {:error,
-       "Invalid binary length while decoding uint.\nExpected size: #{size}.\nFound:#{bit_size(binary)}\n"}
+    do: %Error{
+      message:
+        "Invalid binary length while decoding uint.\nExpected size: #{size}.\nFound:#{bit_size(binary)}\n"
+    }
 
   defp decode_uint(binary, size) do
     <<element::integer-size(size)-little, _rest::bitstring>> = binary
@@ -60,20 +62,24 @@ defmodule SszEx.Decode do
   end
 
   defp decode_bool(binary) when byte_size(binary) != 1,
-    do:
-      {:error,
-       "Invalid binary length while decoding bool.\nExpected size: 1.\nFound:#{byte_size(binary)}\n"}
+    do: %Error{
+      message:
+        "Invalid binary length while decoding bool.\nExpected size: 1.\nFound:#{byte_size(binary)}\n"
+    }
 
   defp decode_bool("\x01"), do: {:ok, true}
   defp decode_bool("\x00"), do: {:ok, false}
 
   defp decode_bool(binary),
-    do:
-      {:error,
-       "Invalid binary value while decoding bool.\nExpected value: x01/x00.\nFound: x#{Base.encode16(binary)}."}
+    do: %Error{
+      message:
+        "Invalid binary value while decoding bool.\nExpected value: x01/x00.\nFound: x#{Base.encode16(binary)}."
+    }
 
   defp decode_bitlist("", _max_size),
-    do: {:error, "Invalid binary value while decoding BitList.\nEmpty binary found.\n"}
+    do: %Error{
+      message: "Invalid binary value while decoding BitList.\nEmpty binary found.\n"
+    }
 
   defp decode_bitlist(bit_list, max_size) do
     num_bytes = byte_size(bit_list)
@@ -82,11 +88,15 @@ defmodule SszEx.Decode do
 
     cond do
       match?(<<_::binary-size(num_bytes - 1), 0>>, bit_list) ->
-        {:error, "Invalid binary value while decoding BitList.\nMissing sentinel bit.\n"}
+        %Error{
+          message: "Invalid binary value while decoding BitList.\nMissing sentinel bit.\n"
+        }
 
       len > max_size ->
-        {:error,
-         "Invalid binary length while decoding BitList. \nExpected max_size: #{max_size}. Found: #{len}.\n"}
+        %Error{
+          message:
+            "Invalid binary length while decoding BitList. \nExpected max_size: #{max_size}. Found: #{len}.\n"
+        }
 
       true ->
         {:ok, decoded}
@@ -103,7 +113,9 @@ defmodule SszEx.Decode do
         {:ok, BitVector.new(bit_vector, size)}
 
       _ ->
-        {:error, "Invalid binary length while decoding BitVector. \nExpected size: #{size}.\n"}
+        %Error{
+          message: "Invalid binary length while decoding BitVector. \nExpected size: #{size}.\n"
+        }
     end
   end
 
@@ -135,18 +147,20 @@ defmodule SszEx.Decode do
 
   defp check_valid_fixed_list_size(byte_length, inner_type, inner_type_size, max_size)
        when byte_length > inner_type_size * max_size,
-       do:
-         {:error,
-          "Invalid binary length while decoding list of #{inspect(inner_type)}.\nExpected max_size: #{max_size}.\nFound: #{byte_length}\n"}
+       do: %Error{
+         message:
+           "Invalid binary length while decoding list of #{inspect(inner_type)}.\nExpected max_size: #{max_size}.\nFound: #{byte_length}\n"
+       }
 
   defp check_valid_fixed_list_size(_byte_length, _inner_type, _inner_type_size, _max_size),
     do: :ok
 
   defp check_valid_vector_size(byte_length, inner_type, inner_type_size, size)
        when byte_length != inner_type_size * size,
-       do:
-         {:error,
-          "Invalid binary length while decoding vector of #{inspect(inner_type)}.\nExpected size #{inner_type_size * size} bytes.\nFound: #{byte_length}.\n"}
+       do: %Error{
+         message:
+           "Invalid binary length while decoding vector of #{inspect(inner_type)}.\nExpected size #{inner_type_size * size} bytes.\nFound: #{byte_length}.\n"
+       }
 
   defp check_valid_vector_size(_byte_length, _inner_type, _inner_type_size, _size),
     do: :ok
@@ -156,9 +170,10 @@ defmodule SszEx.Decode do
        do: :ok
 
   defp check_valid_vector_size_after_decode(size, decoded_size),
-    do:
-      {:error,
-       "Invalid vector decoded size.\nExpected size: #{size}. Decoded vector size: #{decoded_size} "}
+    do: %Error{
+      message:
+        "Invalid vector decoded size.\nExpected size: #{size}. Decoded vector size: #{decoded_size} "
+    }
 
   defp decode_variable_list("", _, _) do
     {:ok, []}
@@ -170,9 +185,10 @@ defmodule SszEx.Decode do
          size
        )
        when div(first_offset, @bytes_per_length_offset) > size,
-       do:
-         {:error,
-          "Invalid binary while decoding list of #{inspect(inner_type)}.\nExpected max_size: #{size}.\n First offset points to: #{first_offset}."}
+       do: %Error{
+         message:
+           "Invalid binary while decoding list of #{inspect(inner_type)}.\nExpected max_size: #{size}.\n First offset points to: #{first_offset}."
+       }
 
   defp decode_variable_list(binary, inner_type, _size) do
     <<first_offset::integer-32-little, rest_bytes::bitstring>> = binary
@@ -180,8 +196,10 @@ defmodule SszEx.Decode do
 
     if Integer.mod(first_offset, @bytes_per_length_offset) != 0 ||
          first_offset < @bytes_per_length_offset do
-      {:error,
-       "Invalid binary while decoding list of #{inspect(inner_type)}.\nFirst offset points to: #{first_offset}."}
+      %Error{
+        message:
+          "Invalid binary while decoding list of #{inspect(inner_type)}.\nFirst offset points to: #{first_offset}."
+      }
     else
       with :ok <-
              sanitize_offset(first_offset, nil, byte_size(binary), first_offset) do
@@ -268,18 +286,20 @@ defmodule SszEx.Decode do
 
   defp check_fixed_container_size(module, expected_length, size)
        when expected_length != size,
-       do:
-         {:error,
-          "Invalid binary length while decoding #{module}. \nExpected #{expected_length}. \nFound #{size}.\n"}
+       do: %Error{
+         message:
+           "Invalid binary length while decoding #{module}. \nExpected #{expected_length}. \nFound #{size}.\n"
+       }
 
   defp check_fixed_container_size(_module, _expected_length, _size),
     do: :ok
 
   defp check_first_offset([{offset, _} | _rest], items_index, _binary_size)
        when offset != items_index,
-       do:
-         {:error,
-          "First offset does not point to the first variable byte.\nExpected index: #{items_index}.\nOffset: #{offset}. "}
+       do: %Error{
+         message:
+           "First offset does not point to the first variable byte.\nExpected index: #{items_index}.\nOffset: #{offset}. "
+       }
 
   defp check_first_offset(_offsets, _items_index, _binary_size),
     do: :ok
@@ -344,12 +364,16 @@ defmodule SszEx.Decode do
   defp sanitize_offset(offset, previous_offset, num_bytes, nil) do
     cond do
       offset > num_bytes ->
-        {:error,
-         "Offset points outside the binary. \nBinary length: #{num_bytes}.\nOffset: #{offset}"}
+        %Error{
+          message:
+            "Offset points outside the binary. \nBinary length: #{num_bytes}.\nOffset: #{offset}"
+        }
 
       previous_offset != nil && previous_offset > offset ->
-        {:error,
-         "Offset points to bytes prior to the previous offset.\nPrevious offset: #{previous_offset}.\nOffset: #{offset}"}
+        %Error{
+          message:
+            "Offset points to bytes prior to the previous offset.\nPrevious offset: #{previous_offset}.\nOffset: #{offset}"
+        }
 
       true ->
         :ok
@@ -359,12 +383,16 @@ defmodule SszEx.Decode do
   defp sanitize_offset(offset, previous_offset, _num_bytes, num_fixed_bytes) do
     cond do
       offset < num_fixed_bytes ->
-        {:error,
-         "Offset points “backwards” into the fixed-bytes portion. \nFirst variable byte index: #{num_fixed_bytes}.\nOffset: #{offset}."}
+        %Error{
+          message:
+            "Offset points “backwards” into the fixed-bytes portion. \nFirst variable byte index: #{num_fixed_bytes}.\nOffset: #{offset}."
+        }
 
       previous_offset == nil && offset != num_fixed_bytes ->
-        {:error,
-         "Offset does not point to the first variable byte.\nExpected index: #{num_fixed_bytes}.\nOffset: #{offset}."}
+        %Error{
+          message:
+            "Offset does not point to the first variable byte.\nExpected index: #{num_fixed_bytes}.\nOffset: #{offset}."
+        }
 
       true ->
         :ok
@@ -382,8 +410,10 @@ defmodule SszEx.Decode do
   defp decode_fixed_collection(binary, chunk_size, _inner_type, results)
        when byte_size(binary) < chunk_size,
        do: [
-         {:error,
-          "Invalid binary length while decoding collection. \nInner type size: #{chunk_size} bytes. Binary length: #{byte_size(binary)} bytes.\n"}
+         %Error{
+           message:
+             "Invalid binary length while decoding collection. \nInner type size: #{chunk_size} bytes. Binary length: #{byte_size(binary)} bytes.\n"
+         }
          | results
        ]
 
@@ -396,7 +426,7 @@ defmodule SszEx.Decode do
     case Enum.group_by(results, fn {_, {type, _}} -> type end, fn {key, {_, result}} ->
            {key, result}
          end) do
-      %{error: errors} -> {:error, errors}
+      %Error{} = error -> error
       summary -> {:ok, Map.get(summary, :ok, [])}
     end
   end

--- a/lib/ssz_ex/encode.ex
+++ b/lib/ssz_ex/encode.ex
@@ -130,8 +130,8 @@ defmodule SszEx.Encode do
                  size = byte_size(encoded)
                  {:cont, {:ok, {[encoded | res_encoded], [size | res_size], size + acc}}}
 
-               error ->
-                 {:halt, {:error, %Error{message: error}}}
+               {:error, %Error{}} = error ->
+                 {:halt, error}
              end
            end) do
       {:ok, {Enum.reverse(encoded_list), Enum.reverse(byte_size_list), total_byte_size}}

--- a/lib/ssz_ex/encode.ex
+++ b/lib/ssz_ex/encode.ex
@@ -5,6 +5,7 @@ defmodule SszEx.Encode do
 
   alias LambdaEthereumConsensus.Utils.BitList
   alias LambdaEthereumConsensus.Utils.BitVector
+  alias SszEx.Error
   alias SszEx.Utils
 
   import BitVector
@@ -13,7 +14,7 @@ defmodule SszEx.Encode do
   @bits_per_byte 8
 
   @spec encode(any(), SszEx.schema()) ::
-          {:ok, binary()} | {:error, String.t()}
+          {:ok, binary()} | Error.t()
   def encode(value, {:int, size}), do: encode_int(value, size)
   def encode(value, :bool), do: encode_bool(value)
   def encode(value, {:byte_list, _}), do: {:ok, value}
@@ -51,8 +52,10 @@ defmodule SszEx.Encode do
     size = Enum.count(list)
 
     if size > max_size do
-      {:error,
-       "Invalid binary length while encoding list of #{inspect(inner_type)}.\nExpected max_size: #{max_size}.\nFound: #{size}\n"}
+      %Error{
+        message:
+          "Invalid binary length while encoding list of #{inspect(inner_type)}.\nExpected max_size: #{max_size}.\nFound: #{size}\n"
+      }
     else
       list
       |> Enum.map(&encode(&1, inner_type))
@@ -64,17 +67,20 @@ defmodule SszEx.Encode do
     len = bit_size(bit_list)
 
     if len > max_size do
-      {:error,
-       "Invalid binary length while encoding BitList.\nExpected max_size: #{max_size}. Found: #{len}.\n"}
+      %Error{
+        message:
+          "Invalid binary length while encoding BitList.\nExpected max_size: #{max_size}. Found: #{len}.\n"
+      }
     else
       {:ok, BitList.to_bytes(bit_list)}
     end
   end
 
   defp encode_bitvector(bit_vector, size) when bit_vector_size(bit_vector) != size,
-    do:
-      {:error,
-       "Invalid binary length while encoding BitVector. \nExpected: #{size}.\nFound: #{bit_vector_size(bit_vector)}."}
+    do: %Error{
+      message:
+        "Invalid binary length while encoding BitVector. \nExpected: #{size}.\nFound: #{bit_vector_size(bit_vector)}."
+    }
 
   defp encode_bitvector(bit_vector, _size),
     do: {:ok, BitVector.to_bytes(bit_vector)}
@@ -83,8 +89,10 @@ defmodule SszEx.Encode do
     size = Enum.count(list)
 
     if size > max_size do
-      {:error,
-       "Invalid binary length while encoding list of #{inspect(inner_type)}.\nExpected max_size: #{max_size}.\nFound: #{size}\n"}
+      %Error{
+        message:
+          "Invalid binary length while encoding list of #{inspect(inner_type)}.\nExpected max_size: #{max_size}.\nFound: #{size}\n"
+      }
     else
       fixed_lengths = @bytes_per_length_offset * length(list)
 
@@ -118,7 +126,7 @@ defmodule SszEx.Encode do
                  {:cont, {:ok, {[encoded | res_encoded], [size | res_size], size + acc}}}
 
                error ->
-                 {:halt, {:error, error}}
+                 {:halt, %Error{message: error}}
              end
            end) do
       {:ok, {Enum.reverse(encoded_list), Enum.reverse(byte_size_list), total_byte_size}}
@@ -190,8 +198,10 @@ defmodule SszEx.Encode do
          2 ** (@bytes_per_length_offset * @bits_per_byte) do
       :ok
     else
-      {:error,
-       "Invalid binary size after encoding. Size out of offset range. Size: #{fixed_lengths + total_byte_size}"}
+      %Error{
+        message:
+          "Invalid binary size after encoding. Size out of offset range. Size: #{fixed_lengths + total_byte_size}"
+      }
     end
   end
 end

--- a/lib/ssz_ex/encode.ex
+++ b/lib/ssz_ex/encode.ex
@@ -14,7 +14,7 @@ defmodule SszEx.Encode do
   @bits_per_byte 8
 
   @spec encode(any(), SszEx.schema()) ::
-          {:ok, binary()} | Error.t()
+          {:ok, binary()} | {:error, Error.t()}
   def encode(value, {:int, size}), do: encode_int(value, size)
   def encode(value, :bool), do: encode_bool(value)
   def encode(value, {:byte_list, _}), do: {:ok, value}
@@ -52,10 +52,11 @@ defmodule SszEx.Encode do
     size = Enum.count(list)
 
     if size > max_size do
-      %Error{
-        message:
-          "Invalid binary length while encoding list of #{inspect(inner_type)}.\nExpected max_size: #{max_size}.\nFound: #{size}\n"
-      }
+      {:error,
+       %Error{
+         message:
+           "Invalid binary length while encoding list of #{inspect(inner_type)}.\nExpected max_size: #{max_size}.\nFound: #{size}\n"
+       }}
     else
       list
       |> Enum.map(&encode(&1, inner_type))
@@ -67,20 +68,23 @@ defmodule SszEx.Encode do
     len = bit_size(bit_list)
 
     if len > max_size do
-      %Error{
-        message:
-          "Invalid binary length while encoding BitList.\nExpected max_size: #{max_size}. Found: #{len}.\n"
-      }
+      {:error,
+       %Error{
+         message:
+           "Invalid binary length while encoding BitList.\nExpected max_size: #{max_size}. Found: #{len}.\n"
+       }}
     else
       {:ok, BitList.to_bytes(bit_list)}
     end
   end
 
   defp encode_bitvector(bit_vector, size) when bit_vector_size(bit_vector) != size,
-    do: %Error{
-      message:
-        "Invalid binary length while encoding BitVector. \nExpected: #{size}.\nFound: #{bit_vector_size(bit_vector)}."
-    }
+    do:
+      {:error,
+       %Error{
+         message:
+           "Invalid binary length while encoding BitVector. \nExpected: #{size}.\nFound: #{bit_vector_size(bit_vector)}."
+       }}
 
   defp encode_bitvector(bit_vector, _size),
     do: {:ok, BitVector.to_bytes(bit_vector)}
@@ -89,10 +93,11 @@ defmodule SszEx.Encode do
     size = Enum.count(list)
 
     if size > max_size do
-      %Error{
-        message:
-          "Invalid binary length while encoding list of #{inspect(inner_type)}.\nExpected max_size: #{max_size}.\nFound: #{size}\n"
-      }
+      {:error,
+       %Error{
+         message:
+           "Invalid binary length while encoding list of #{inspect(inner_type)}.\nExpected max_size: #{max_size}.\nFound: #{size}\n"
+       }}
     else
       fixed_lengths = @bytes_per_length_offset * length(list)
 
@@ -126,7 +131,7 @@ defmodule SszEx.Encode do
                  {:cont, {:ok, {[encoded | res_encoded], [size | res_size], size + acc}}}
 
                error ->
-                 {:halt, %Error{message: error}}
+                 {:halt, {:error, %Error{message: error}}}
              end
            end) do
       {:ok, {Enum.reverse(encoded_list), Enum.reverse(byte_size_list), total_byte_size}}
@@ -198,10 +203,11 @@ defmodule SszEx.Encode do
          2 ** (@bytes_per_length_offset * @bits_per_byte) do
       :ok
     else
-      %Error{
-        message:
-          "Invalid binary size after encoding. Size out of offset range. Size: #{fixed_lengths + total_byte_size}"
-      }
+      {:error,
+       %Error{
+         message:
+           "Invalid binary size after encoding. Size out of offset range. Size: #{fixed_lengths + total_byte_size}"
+       }}
     end
   end
 end

--- a/lib/ssz_ex/error.ex
+++ b/lib/ssz_ex/error.ex
@@ -1,0 +1,16 @@
+defmodule SszEx.Error do
+  @moduledoc """
+  Error messages for SszEx domain.
+  """
+  alias SszEx.Error
+  defstruct [:message]
+  @type t :: %__MODULE__{message: binary()}
+
+  def format(%Error{message: message}) do
+    "#{message}"
+  end
+
+  defimpl String.Chars, for: __MODULE__ do
+    def to_string(error), do: Error.format(error)
+  end
+end

--- a/lib/ssz_ex/error.ex
+++ b/lib/ssz_ex/error.ex
@@ -4,7 +4,7 @@ defmodule SszEx.Error do
   """
   alias SszEx.Error
   defstruct [:message]
-  @type t :: %__MODULE__{message: binary()}
+  @type t :: %__MODULE__{message: String.t()}
 
   def format(%Error{message: message}) do
     "#{message}"

--- a/lib/ssz_ex/merkleization.ex
+++ b/lib/ssz_ex/merkleization.ex
@@ -6,6 +6,7 @@ defmodule SszEx.Merkleization do
   alias LambdaEthereumConsensus.Utils.BitList
   alias LambdaEthereumConsensus.Utils.BitVector
   alias SszEx.Encode
+  alias SszEx.Error
   alias SszEx.Hash
   alias SszEx.Utils
 
@@ -63,14 +64,16 @@ defmodule SszEx.Merkleization do
   end
 
   @spec hash_tree_root(list(), {:list, any, non_neg_integer}) ::
-          {:ok, Types.root()} | {:error, String.t()}
+          {:ok, Types.root()} | Error.t()
   def hash_tree_root(list, {:list, type, max_size} = schema) do
     len = Enum.count(list)
 
     cond do
       len > max_size ->
-        {:error,
-         "Invalid binary length while encoding list of #{inspect(type)}.\nExpected max_size: #{max_size}.\nFound: #{len}\n"}
+        %Error{
+          message:
+            "Invalid binary length while merkleizing list of #{inspect(type)}.\nExpected max_size: #{max_size}.\nFound: #{len}\n"
+        }
 
       Utils.basic_type?(type) ->
         list_hash_tree_root_basic(list, schema, len)
@@ -81,11 +84,12 @@ defmodule SszEx.Merkleization do
   end
 
   @spec hash_tree_root(list(), {:vector, any, non_neg_integer}) ::
-          {:ok, Types.root()} | {:error, String.t()}
+          {:ok, Types.root()} | Error.t()
   def hash_tree_root(vector, {:vector, inner_type, size}) when length(vector) != size,
-    do:
-      {:error,
-       "Invalid binary length while merkleizing vector of #{inspect(inner_type)}.\nExpected size: #{size}.\nFound: #{length(vector)}\n"}
+    do: %Error{
+      message:
+        "Invalid binary length while merkleizing vector of #{inspect(inner_type)}.\nExpected size: #{size}.\nFound: #{length(vector)}\n"
+    }
 
   def hash_tree_root(vector, {:vector, type, _size} = schema) do
     value =
@@ -97,7 +101,7 @@ defmodule SszEx.Merkleization do
 
     case value do
       {:ok, chunks} -> chunks |> hash_tree_root_vector()
-      {:error, reason} -> {:error, reason}
+      %Error{} -> value
       chunks -> chunks |> hash_tree_root_vector()
     end
   end
@@ -111,7 +115,7 @@ defmodule SszEx.Merkleization do
 
         case hash_tree_root(value, schema) do
           {:ok, root} -> {:cont, {:ok, acc_root <> root}}
-          {:error, reason} -> {:halt, {:error, reason}}
+          %Error{} = error -> {:halt, error}
         end
       end)
 
@@ -123,8 +127,8 @@ defmodule SszEx.Merkleization do
         root = chunks |> merkleize_chunks_with_virtual_padding(leaf_count)
         {:ok, root}
 
-      {:error, reason} ->
-        {:error, reason}
+      %Error{} ->
+        value
     end
   end
 
@@ -182,7 +186,7 @@ defmodule SszEx.Merkleization do
     |> Enum.reduce_while({:ok, <<>>}, fn value, {_, acc_roots} ->
       case hash_tree_root(value, inner_schema) do
         {:ok, root} -> {:cont, {:ok, acc_roots <> root}}
-        {:error, reason} -> {:halt, {:error, reason}}
+        %Error{} = error -> {:halt, error}
       end
     end)
   end
@@ -256,7 +260,7 @@ defmodule SszEx.Merkleization do
     <<value::size(size)-little>> |> pack_bytes()
   end
 
-  @spec pack(list(), {:list | :vector, any, non_neg_integer}) :: binary() | :error
+  @spec pack(list(), {:list | :vector, any, non_neg_integer}) :: binary() | Error.t()
   def pack(list, {type, schema, _}) when type in [:vector, :list] do
     list
     |> Enum.reduce(<<>>, fn x, acc ->

--- a/lib/ssz_ex/ssz_ex.ex
+++ b/lib/ssz_ex/ssz_ex.ex
@@ -35,6 +35,7 @@ defmodule SszEx do
   """
   alias SszEx.Decode
   alias SszEx.Encode
+  alias SszEx.Error
   alias SszEx.Hash
   alias SszEx.Merkleization
   alias SszEx.Utils
@@ -60,15 +61,15 @@ defmodule SszEx do
   @type container_schema() :: module()
 
   @spec encode(struct()) ::
-          {:ok, binary()} | {:error, String.t()}
+          {:ok, binary()} | {:error, Error.t()}
   def encode(%name{} = value), do: encode(value, name)
 
   @spec encode(any(), schema()) ::
-          {:ok, binary()} | {:error, String.t()}
+          {:ok, binary()} | {:error, Error.t()}
   def encode(value, schema), do: Encode.encode(value, schema)
 
   @spec decode(binary(), schema()) ::
-          {:ok, any()} | {:error, String.t()}
+          {:ok, any()} | {:error, Error.t()}
   def decode(value, schema), do: Decode.decode(value, schema)
 
   @spec hash_tree_root!(struct()) :: Types.root()
@@ -77,7 +78,7 @@ defmodule SszEx do
   @spec hash_tree_root!(any, any) :: Types.root()
   def hash_tree_root!(value, schema), do: Merkleization.hash_tree_root!(value, schema)
 
-  @spec hash_tree_root(any, any) :: {:ok, Types.root()} | {:error, String.t()}
+  @spec hash_tree_root(any, any) :: {:ok, Types.root()} | {:error, Error.t()}
   def hash_tree_root(value, schema), do: Merkleization.hash_tree_root(value, schema)
 
   @spec validate_schema!(any) :: :ok

--- a/lib/ssz_ex/utils.ex
+++ b/lib/ssz_ex/utils.ex
@@ -68,7 +68,7 @@ defmodule SszEx.Utils do
 
   def flatten_results_by(results, fun) do
     case Enum.group_by(results, fn {type, _} -> type end, fn {_, result} -> result end) do
-      %Error{} = error -> error
+      %{error: errors} -> {:error, errors}
       summary -> {:ok, fun.(Map.get(summary, :ok, []))}
     end
   end

--- a/lib/ssz_ex/utils.ex
+++ b/lib/ssz_ex/utils.ex
@@ -5,6 +5,7 @@ defmodule SszEx.Utils do
 
   alias LambdaEthereumConsensus.Utils.BitList
   alias LambdaEthereumConsensus.Utils.BitVector
+  alias SszEx.Error
 
   @allowed_uints [8, 16, 32, 64, 128, 256]
   @bits_per_byte 8
@@ -67,7 +68,7 @@ defmodule SszEx.Utils do
 
   def flatten_results_by(results, fun) do
     case Enum.group_by(results, fn {type, _} -> type end, fn {_, result} -> result end) do
-      %{error: errors} -> {:error, errors}
+      %Error{} = error -> error
       summary -> {:ok, fun.(Map.get(summary, :ok, []))}
     end
   end

--- a/lib/ssz_ex/utils.ex
+++ b/lib/ssz_ex/utils.ex
@@ -5,7 +5,6 @@ defmodule SszEx.Utils do
 
   alias LambdaEthereumConsensus.Utils.BitList
   alias LambdaEthereumConsensus.Utils.BitVector
-  alias SszEx.Error
 
   @allowed_uints [8, 16, 32, 64, 128, 256]
   @bits_per_byte 8

--- a/test/unit/ssz_ex_test.exs
+++ b/test/unit/ssz_ex_test.exs
@@ -434,8 +434,9 @@ defmodule Unit.SSZExTest do
     error_message =
       "Invalid binary length while encoding list of {:int, 32}.\nExpected max_size: 3.\nFound: 4\n"
 
-    assert {:error, ^error_message} =
-             SszEx.encode([230, 380, 523, 23_423], {:list, {:int, 32}, 3})
+    result = SszEx.encode([230, 380, 523, 23_423], {:list, {:int, 32}, 3})
+
+    assert error_message == "#{result}"
   end
 
   test "deserialize out bounded list" do

--- a/test/unit/ssz_ex_test.exs
+++ b/test/unit/ssz_ex_test.exs
@@ -1,5 +1,6 @@
 defmodule Unit.SSZExTest do
   alias LambdaEthereumConsensus.Utils.Diff
+  alias SszEx.Error
   alias SszEx.Merkleization
 
   alias Types.BeaconBlock
@@ -443,44 +444,52 @@ defmodule Unit.SSZExTest do
     error_message =
       "Invalid binary length while decoding list of {:int, 32}.\nExpected max_size: 3.\nFound: 16\n"
 
-    assert {:error, ^error_message} =
-             SszEx.decode(
-               <<230, 0, 0, 0, 124, 1, 0, 0, 11, 2, 0, 0, 127, 91, 0, 0>>,
-               {:list, {:int, 32}, 3}
-             )
+    result =
+      SszEx.decode(
+        <<230, 0, 0, 0, 124, 1, 0, 0, 11, 2, 0, 0, 127, 91, 0, 0>>,
+        {:list, {:int, 32}, 3}
+      )
+
+    assert error_message == "#{result}"
   end
 
   test "deserialize shorter vector" do
     error_message =
       "Invalid binary length while decoding vector of {:int, 32}.\nExpected size 12 bytes.\nFound: 6.\n"
 
-    assert {:error, ^error_message} =
-             SszEx.decode(
-               <<230, 0, 0, 0, 124, 1>>,
-               {:vector, {:int, 32}, 3}
-             )
+    result =
+      SszEx.decode(
+        <<230, 0, 0, 0, 124, 1>>,
+        {:vector, {:int, 32}, 3}
+      )
+
+    assert error_message == "#{result}"
   end
 
   test "deserialize outbounded vector" do
     error_message =
       "Invalid binary length while decoding vector of {:int, 32}.\nExpected size 12 bytes.\nFound: 13.\n"
 
-    assert {:error, ^error_message} =
-             SszEx.decode(
-               <<230, 0, 0, 0, 124, 1, 230, 0, 0, 0, 124, 1, 2>>,
-               {:vector, {:int, 32}, 3}
-             )
+    result =
+      SszEx.decode(
+        <<230, 0, 0, 0, 124, 1, 230, 0, 0, 0, 124, 1, 2>>,
+        {:vector, {:int, 32}, 3}
+      )
+
+    assert error_message == "#{result}"
   end
 
   test "deserialize invalid vector" do
     error_message =
       "Invalid binary length while decoding vector of {:int, 32}.\nExpected size 12 bytes.\nFound: 13.\n"
 
-    assert {:error, ^error_message} =
-             SszEx.decode(
-               <<230, 0, 0, 0, 124, 1, 230, 0, 0, 0, 124, 1, 1::1>>,
-               {:vector, {:int, 32}, 3}
-             )
+    result =
+      SszEx.decode(
+        <<230, 0, 0, 0, 124, 1, 230, 0, 0, 0, 124, 1, 1::1>>,
+        {:vector, {:int, 32}, 3}
+      )
+
+    assert error_message == "#{result}"
   end
 
   test "serialize and deserialize container only with fixed parts" do
@@ -592,14 +601,14 @@ defmodule Unit.SSZExTest do
     assert {:ok, ^encoded_bytes} = SszEx.encode(decoded_bytes, {:bitlist, 31})
 
     encoded_bytes = <<7>>
-    assert {:error, _msg} = SszEx.decode(encoded_bytes, {:bitlist, 1})
+    assert %Error{} = SszEx.decode(encoded_bytes, {:bitlist, 1})
 
     encoded_bytes = <<124, 3>>
-    assert {:error, _msg} = SszEx.decode(encoded_bytes, {:bitlist, 1})
+    assert %Error{} = SszEx.decode(encoded_bytes, {:bitlist, 1})
 
     encoded_bytes = <<0>>
-    assert {:error, _msg} = SszEx.decode(encoded_bytes, {:bitlist, 1})
-    assert {:error, _msg} = SszEx.decode(encoded_bytes, {:bitlist, 16})
+    assert %Error{} = SszEx.decode(encoded_bytes, {:bitlist, 1})
+    assert %Error{} = SszEx.decode(encoded_bytes, {:bitlist, 16})
   end
 
   test "serialize and deserialize bitvector" do
@@ -612,13 +621,13 @@ defmodule Unit.SSZExTest do
     assert {:ok, ^encoded_bytes} = SszEx.encode(decoded_bytes, {:bitvector, 16})
 
     encoded_bytes = <<255, 255, 255, 255, 255, 1>>
-    assert {:error, _msg} = SszEx.decode(encoded_bytes, {:bitvector, 33})
+    assert %Error{} = SszEx.decode(encoded_bytes, {:bitvector, 33})
 
     encoded_bytes = <<255, 255, 255, 255, 255, 1::1>>
-    assert {:error, _msg} = SszEx.decode(encoded_bytes, {:bitvector, 41})
+    assert %Error{} = SszEx.decode(encoded_bytes, {:bitvector, 41})
 
     encoded_bytes = <<0>>
-    assert {:error, _msg} = SszEx.decode(encoded_bytes, {:bitvector, 9})
+    assert %Error{} = SszEx.decode(encoded_bytes, {:bitvector, 9})
   end
 
   test "hash tree root of byte list" do
@@ -729,8 +738,10 @@ defmodule Unit.SSZExTest do
       <<0, 0, 0>>
 
     assert SszEx.decode(encoded_checkpoint, Checkpoint) ==
-             {:error,
-              "Invalid binary length while decoding Elixir.Types.Checkpoint. \nExpected 40. \nFound 3.\n"}
+             %Error{
+               message:
+                 "Invalid binary length while decoding Elixir.Types.Checkpoint. \nExpected 40. \nFound 3.\n"
+             }
   end
 
   test "decode longer checkpoint" do
@@ -738,8 +749,10 @@ defmodule Unit.SSZExTest do
       <<0::size(41 * 8)>>
 
     assert SszEx.decode(encoded_checkpoint, Checkpoint) ==
-             {:error,
-              "Invalid binary length while decoding Elixir.Types.Checkpoint. \nExpected 40. \nFound 41.\n"}
+             %Error{
+               message:
+                 "Invalid binary length while decoding Elixir.Types.Checkpoint. \nExpected 40. \nFound 41.\n"
+             }
   end
 
   test "hash tree root of list exceeding max size" do

--- a/test/unit/ssz_ex_test.exs
+++ b/test/unit/ssz_ex_test.exs
@@ -746,8 +746,9 @@ defmodule Unit.SSZExTest do
     initial_list = [5, 5, 5, 5]
 
     error =
-      "Invalid binary length while encoding list of {:int, 8}.\nExpected max_size: 2.\nFound: 4\n"
+      "Invalid binary length while merkleizing list of {:int, 8}.\nExpected max_size: 2.\nFound: 4\n"
 
-    assert {:error, ^error} = SszEx.hash_tree_root(initial_list, {:list, {:int, 8}, 2})
+    result = SszEx.hash_tree_root(initial_list, {:list, {:int, 8}, 2})
+    assert error == "#{result}"
   end
 end

--- a/test/unit/ssz_ex_test.exs
+++ b/test/unit/ssz_ex_test.exs
@@ -435,7 +435,7 @@ defmodule Unit.SSZExTest do
     error_message =
       "Invalid binary length while encoding list of {:int, 32}.\nExpected max_size: 3.\nFound: 4\n"
 
-    result = SszEx.encode([230, 380, 523, 23_423], {:list, {:int, 32}, 3})
+    {:error, result} = SszEx.encode([230, 380, 523, 23_423], {:list, {:int, 32}, 3})
 
     assert error_message == "#{result}"
   end
@@ -444,7 +444,7 @@ defmodule Unit.SSZExTest do
     error_message =
       "Invalid binary length while decoding list of {:int, 32}.\nExpected max_size: 3.\nFound: 16\n"
 
-    result =
+    {:error, result} =
       SszEx.decode(
         <<230, 0, 0, 0, 124, 1, 0, 0, 11, 2, 0, 0, 127, 91, 0, 0>>,
         {:list, {:int, 32}, 3}
@@ -457,7 +457,7 @@ defmodule Unit.SSZExTest do
     error_message =
       "Invalid binary length while decoding vector of {:int, 32}.\nExpected size 12 bytes.\nFound: 6.\n"
 
-    result =
+    {:error, result} =
       SszEx.decode(
         <<230, 0, 0, 0, 124, 1>>,
         {:vector, {:int, 32}, 3}
@@ -470,7 +470,7 @@ defmodule Unit.SSZExTest do
     error_message =
       "Invalid binary length while decoding vector of {:int, 32}.\nExpected size 12 bytes.\nFound: 13.\n"
 
-    result =
+    {:error, result} =
       SszEx.decode(
         <<230, 0, 0, 0, 124, 1, 230, 0, 0, 0, 124, 1, 2>>,
         {:vector, {:int, 32}, 3}
@@ -483,7 +483,7 @@ defmodule Unit.SSZExTest do
     error_message =
       "Invalid binary length while decoding vector of {:int, 32}.\nExpected size 12 bytes.\nFound: 13.\n"
 
-    result =
+    {:error, result} =
       SszEx.decode(
         <<230, 0, 0, 0, 124, 1, 230, 0, 0, 0, 124, 1, 1::1>>,
         {:vector, {:int, 32}, 3}
@@ -601,14 +601,14 @@ defmodule Unit.SSZExTest do
     assert {:ok, ^encoded_bytes} = SszEx.encode(decoded_bytes, {:bitlist, 31})
 
     encoded_bytes = <<7>>
-    assert %Error{} = SszEx.decode(encoded_bytes, {:bitlist, 1})
+    assert {:error, %Error{}} = SszEx.decode(encoded_bytes, {:bitlist, 1})
 
     encoded_bytes = <<124, 3>>
-    assert %Error{} = SszEx.decode(encoded_bytes, {:bitlist, 1})
+    assert {:error, %Error{}} = SszEx.decode(encoded_bytes, {:bitlist, 1})
 
     encoded_bytes = <<0>>
-    assert %Error{} = SszEx.decode(encoded_bytes, {:bitlist, 1})
-    assert %Error{} = SszEx.decode(encoded_bytes, {:bitlist, 16})
+    assert {:error, %Error{}} = SszEx.decode(encoded_bytes, {:bitlist, 1})
+    assert {:error, %Error{}} = SszEx.decode(encoded_bytes, {:bitlist, 16})
   end
 
   test "serialize and deserialize bitvector" do
@@ -621,13 +621,13 @@ defmodule Unit.SSZExTest do
     assert {:ok, ^encoded_bytes} = SszEx.encode(decoded_bytes, {:bitvector, 16})
 
     encoded_bytes = <<255, 255, 255, 255, 255, 1>>
-    assert %Error{} = SszEx.decode(encoded_bytes, {:bitvector, 33})
+    assert {:error, %Error{}} = SszEx.decode(encoded_bytes, {:bitvector, 33})
 
     encoded_bytes = <<255, 255, 255, 255, 255, 1::1>>
-    assert %Error{} = SszEx.decode(encoded_bytes, {:bitvector, 41})
+    assert {:error, %Error{}} = SszEx.decode(encoded_bytes, {:bitvector, 41})
 
     encoded_bytes = <<0>>
-    assert %Error{} = SszEx.decode(encoded_bytes, {:bitvector, 9})
+    assert {:error, %Error{}} = SszEx.decode(encoded_bytes, {:bitvector, 9})
   end
 
   test "hash tree root of byte list" do
@@ -738,10 +738,11 @@ defmodule Unit.SSZExTest do
       <<0, 0, 0>>
 
     assert SszEx.decode(encoded_checkpoint, Checkpoint) ==
-             %Error{
-               message:
-                 "Invalid binary length while decoding Elixir.Types.Checkpoint. \nExpected 40. \nFound 3.\n"
-             }
+             {:error,
+              %Error{
+                message:
+                  "Invalid binary length while decoding Elixir.Types.Checkpoint. \nExpected 40. \nFound 3.\n"
+              }}
   end
 
   test "decode longer checkpoint" do
@@ -749,10 +750,11 @@ defmodule Unit.SSZExTest do
       <<0::size(41 * 8)>>
 
     assert SszEx.decode(encoded_checkpoint, Checkpoint) ==
-             %Error{
-               message:
-                 "Invalid binary length while decoding Elixir.Types.Checkpoint. \nExpected 40. \nFound 41.\n"
-             }
+             {:error,
+              %Error{
+                message:
+                  "Invalid binary length while decoding Elixir.Types.Checkpoint. \nExpected 40. \nFound 41.\n"
+              }}
   end
 
   test "hash tree root of list exceeding max size" do
@@ -761,7 +763,7 @@ defmodule Unit.SSZExTest do
     error =
       "Invalid binary length while merkleizing list of {:int, 8}.\nExpected max_size: 2.\nFound: 4\n"
 
-    result = SszEx.hash_tree_root(initial_list, {:list, {:int, 8}, 2})
+    {:error, result} = SszEx.hash_tree_root(initial_list, {:list, {:int, 8}, 2})
     assert error == "#{result}"
   end
 end


### PR DESCRIPTION
This PR changes SSZ errors from strings to structs in order to add a stack trace in a future refactor.

Closes #1003 

