### PR TITLE
chore: add parentheses to zero-arity functions

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -93,7 +93,7 @@
           {Credo.Check.Readability.ModuleDoc, []},
           {Credo.Check.Readability.ModuleNames, []},
           {Credo.Check.Readability.ParenthesesInCondition, []},
-          {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
+          {Credo.Check.Readability.ParenthesesOnZeroArityDefs, [parens: true]},
           {Credo.Check.Readability.PipeIntoAnonymousFunctions, []},
           {Credo.Check.Readability.PredicateFunctionNames, []},
           {Credo.Check.Readability.PreferImplicitTry, []},

--- a/lib/beacon_api/api_spec.ex
+++ b/lib/beacon_api/api_spec.ex
@@ -10,5 +10,5 @@ defmodule BeaconApi.ApiSpec do
            |> OpenApiSpex.OpenApi.Decode.decode()
 
   @impl OpenApi
-  def spec, do: @ethspec
+  def spec(), do: @ethspec
 end

--- a/lib/beacon_api/beacon_api.ex
+++ b/lib/beacon_api/beacon_api.ex
@@ -17,7 +17,7 @@ defmodule BeaconApi do
   those modules here.
   """
 
-  def router do
+  def router() do
     quote do
       use Phoenix.Router, helpers: false
 
@@ -27,7 +27,7 @@ defmodule BeaconApi do
     end
   end
 
-  def controller do
+  def controller() do
     quote do
       use Phoenix.Controller,
         formats: [:json]

--- a/lib/chain_spec/chain_spec.ex
+++ b/lib/chain_spec/chain_spec.ex
@@ -3,10 +3,10 @@ defmodule ChainSpec do
   Single entrypoint for fetching chain-specific constants.
   """
 
-  def get_config,
+  def get_config(),
     do: Application.fetch_env!(:lambda_ethereum_consensus, __MODULE__) |> Keyword.fetch!(:config)
 
-  def get_preset, do: get_config().get("PRESET_BASE") |> String.to_atom()
+  def get_preset(), do: get_config().get("PRESET_BASE") |> String.to_atom()
 
   def get_fork_version_for_epoch(epoch) do
     if epoch >= get("DENEB_FORK_EPOCH") do
@@ -19,7 +19,7 @@ defmodule ChainSpec do
   # NOTE: this only works correctly for Capella
   def get(name), do: get_config().get(name)
 
-  def get_genesis_validators_root do
+  def get_genesis_validators_root() do
     Application.fetch_env!(:lambda_ethereum_consensus, __MODULE__)
     |> Keyword.fetch!(:genesis_validators_root)
   end

--- a/lib/chain_spec/configs/custom.ex
+++ b/lib/chain_spec/configs/custom.ex
@@ -19,7 +19,7 @@ defmodule CustomConfig do
   end
 
   @impl GenConfig
-  def get_all do
+  def get_all() do
     Application.get_env(:lambda_ethereum_consensus, __MODULE__)
     |> Keyword.fetch!(:merged)
     |> Map.new(fn {k, v} -> {k, parse_int(v)} end)

--- a/lib/chain_spec/configs/gen_config.ex
+++ b/lib/chain_spec/configs/gen_config.ex
@@ -23,7 +23,7 @@ defmodule ChainSpec.GenConfig do
       def get(key), do: Map.fetch!(@__unified, key)
 
       @impl unquote(__MODULE__)
-      def get_all, do: @__unified
+      def get_all(), do: @__unified
     end
   end
 

--- a/lib/chain_spec/configs/gnosis.ex
+++ b/lib/chain_spec/configs/gnosis.ex
@@ -7,5 +7,5 @@ defmodule GnosisConfig do
   genesis_validators_root =
     Base.decode16!("F5DCB5564E829AAB27264B9BECD5DFAA017085611224CB3036F573368DBB9D47")
 
-  def genesis_validators_root, do: unquote(genesis_validators_root)
+  def genesis_validators_root(), do: unquote(genesis_validators_root)
 end

--- a/lib/chain_spec/configs/holesky.ex
+++ b/lib/chain_spec/configs/holesky.ex
@@ -7,5 +7,5 @@ defmodule HoleskyConfig do
   genesis_validators_root =
     Base.decode16!("9143AA7C615A7F7115E2B6AAC319C03529DF8242AE705FBA9DF39B79C59FA8B1")
 
-  def genesis_validators_root, do: unquote(genesis_validators_root)
+  def genesis_validators_root(), do: unquote(genesis_validators_root)
 end

--- a/lib/chain_spec/configs/mainnet.ex
+++ b/lib/chain_spec/configs/mainnet.ex
@@ -7,5 +7,5 @@ defmodule MainnetConfig do
   genesis_validators_root =
     Base.decode16!("4B363DB94E286120D76EB905340FDD4E54BFE9F06BF33FF6CF5AD27F511BFE95")
 
-  def genesis_validators_root, do: unquote(genesis_validators_root)
+  def genesis_validators_root(), do: unquote(genesis_validators_root)
 end

--- a/lib/chain_spec/configs/minimal.ex
+++ b/lib/chain_spec/configs/minimal.ex
@@ -4,5 +4,5 @@ defmodule MinimalConfig do
   """
   use ChainSpec.GenConfig, file: "config/networks/minimal/config.yaml"
 
-  def genesis_validators_root, do: <<0::256>>
+  def genesis_validators_root(), do: <<0::256>>
 end

--- a/lib/chain_spec/configs/sepolia.ex
+++ b/lib/chain_spec/configs/sepolia.ex
@@ -7,5 +7,5 @@ defmodule SepoliaConfig do
   genesis_validators_root =
     Base.decode16!("D8EA171F3C94AEA21EBC42A1ED61052ACF3F9209C00E4EFBAADDAC09ED9B8078")
 
-  def genesis_validators_root, do: unquote(genesis_validators_root)
+  def genesis_validators_root(), do: unquote(genesis_validators_root)
 end

--- a/lib/chain_spec/presets/gen_preset.ex
+++ b/lib/chain_spec/presets/gen_preset.ex
@@ -16,7 +16,7 @@ defmodule ChainSpec.GenPreset do
       @behaviour unquote(__MODULE__)
 
       @impl unquote(__MODULE__)
-      def get_preset, do: @__parsed_preset
+      def get_preset(), do: @__parsed_preset
     end
   end
 

--- a/lib/constants.ex
+++ b/lib/constants.ex
@@ -7,126 +7,126 @@ defmodule Constants do
   ### Misc
 
   @spec genesis_epoch() :: Types.slot()
-  def genesis_epoch, do: 0
+  def genesis_epoch(), do: 0
 
   @spec genesis_slot() :: Types.slot()
-  def genesis_slot, do: 0
+  def genesis_slot(), do: 0
 
   @far_future_epoch 2 ** 64 - 1
 
   @spec far_future_epoch() :: non_neg_integer()
-  def far_future_epoch, do: @far_future_epoch
+  def far_future_epoch(), do: @far_future_epoch
 
   @spec base_rewards_per_epoch() :: non_neg_integer()
-  def base_rewards_per_epoch, do: 4
+  def base_rewards_per_epoch(), do: 4
 
   @spec deposit_contract_tree_depth() :: non_neg_integer()
-  def deposit_contract_tree_depth, do: 32
+  def deposit_contract_tree_depth(), do: 32
 
   @spec justification_bits_length() :: non_neg_integer()
-  def justification_bits_length, do: 4
+  def justification_bits_length(), do: 4
 
   @spec endianness() :: atom()
-  def endianness, do: :little
+  def endianness(), do: :little
 
   @spec participation_flag_weights() :: list(non_neg_integer())
-  def participation_flag_weights,
+  def participation_flag_weights(),
     do: [timely_source_weight(), timely_target_weight(), timely_head_weight()]
 
   @spec target_aggregators_per_committee() :: non_neg_integer()
-  def target_aggregators_per_committee, do: 16
+  def target_aggregators_per_committee(), do: 16
 
   ### Withdrawal prefixes
 
   @spec bls_withdrawal_prefix() :: Types.bytes1()
-  def bls_withdrawal_prefix, do: <<0>>
+  def bls_withdrawal_prefix(), do: <<0>>
 
   @spec eth1_address_withdrawal_prefix() :: Types.bytes1()
-  def eth1_address_withdrawal_prefix, do: <<1>>
+  def eth1_address_withdrawal_prefix(), do: <<1>>
 
   ### Domain types
 
   @spec domain_beacon_proposer() :: Types.domain_type()
-  def domain_beacon_proposer, do: <<0, 0, 0, 0>>
+  def domain_beacon_proposer(), do: <<0, 0, 0, 0>>
 
   @spec domain_beacon_attester() :: Types.domain_type()
-  def domain_beacon_attester, do: <<1, 0, 0, 0>>
+  def domain_beacon_attester(), do: <<1, 0, 0, 0>>
 
   @spec domain_randao() :: Types.domain_type()
-  def domain_randao, do: <<2, 0, 0, 0>>
+  def domain_randao(), do: <<2, 0, 0, 0>>
 
   @spec domain_deposit() :: Types.domain_type()
-  def domain_deposit, do: <<3, 0, 0, 0>>
+  def domain_deposit(), do: <<3, 0, 0, 0>>
 
   @spec domain_voluntary_exit() :: Types.domain_type()
-  def domain_voluntary_exit, do: <<4, 0, 0, 0>>
+  def domain_voluntary_exit(), do: <<4, 0, 0, 0>>
 
   @spec domain_selection_proof() :: Types.domain_type()
-  def domain_selection_proof, do: <<5, 0, 0, 0>>
+  def domain_selection_proof(), do: <<5, 0, 0, 0>>
 
   @spec domain_aggregate_and_proof() :: Types.domain_type()
-  def domain_aggregate_and_proof, do: <<6, 0, 0, 0>>
+  def domain_aggregate_and_proof(), do: <<6, 0, 0, 0>>
 
   @spec domain_application_mask() :: Types.domain_type()
-  def domain_application_mask, do: <<0, 0, 0, 1>>
+  def domain_application_mask(), do: <<0, 0, 0, 1>>
 
   @spec domain_sync_committee() :: Types.domain_type()
-  def domain_sync_committee, do: <<7, 0, 0, 0>>
+  def domain_sync_committee(), do: <<7, 0, 0, 0>>
 
   @spec domain_sync_committee_selection_proof() :: Types.domain_type()
-  def domain_sync_committee_selection_proof, do: <<8, 0, 0, 0>>
+  def domain_sync_committee_selection_proof(), do: <<8, 0, 0, 0>>
 
   @spec domain_contribution_and_proof() :: Types.domain_type()
-  def domain_contribution_and_proof, do: <<9, 0, 0, 0>>
+  def domain_contribution_and_proof(), do: <<9, 0, 0, 0>>
 
   @spec domain_bls_to_execution_change() :: Types.domain_type()
-  def domain_bls_to_execution_change, do: <<10, 0, 0, 0>>
+  def domain_bls_to_execution_change(), do: <<10, 0, 0, 0>>
 
   ### Participation flag indices
 
   @spec timely_source_flag_index() :: non_neg_integer()
-  def timely_source_flag_index, do: 0
+  def timely_source_flag_index(), do: 0
 
   @spec timely_target_flag_index() :: non_neg_integer()
-  def timely_target_flag_index, do: 1
+  def timely_target_flag_index(), do: 1
 
   @spec timely_head_flag_index() :: non_neg_integer()
-  def timely_head_flag_index, do: 2
+  def timely_head_flag_index(), do: 2
 
   ### Incentivization weights
 
   @spec timely_source_weight() :: non_neg_integer()
-  def timely_source_weight, do: 14
+  def timely_source_weight(), do: 14
 
   @spec timely_target_weight() :: non_neg_integer()
-  def timely_target_weight, do: 26
+  def timely_target_weight(), do: 26
 
   @spec timely_head_weight() :: non_neg_integer()
-  def timely_head_weight, do: 14
+  def timely_head_weight(), do: 14
 
   @spec sync_reward_weight() :: non_neg_integer()
-  def sync_reward_weight, do: 2
+  def sync_reward_weight(), do: 2
 
   @spec proposer_weight() :: non_neg_integer()
-  def proposer_weight, do: 8
+  def proposer_weight(), do: 8
 
   @spec weight_denominator() :: non_neg_integer()
-  def weight_denominator, do: 64
+  def weight_denominator(), do: 64
 
   ## Fork choice
 
   @spec intervals_per_slot() :: non_neg_integer()
-  def intervals_per_slot, do: 3
+  def intervals_per_slot(), do: 3
 
   @spec proposer_score_boost() :: non_neg_integer()
-  def proposer_score_boost, do: 3
+  def proposer_score_boost(), do: 3
 
   @spec sync_committee_subnet_count() :: non_neg_integer()
-  def sync_committee_subnet_count, do: 4
+  def sync_committee_subnet_count(), do: 4
 
   @spec bytes_per_field_element() :: Types.uint64()
-  def bytes_per_field_element, do: 32
+  def bytes_per_field_element(), do: 32
 
   @spec versioned_hash_version_kzg() :: <<_::8>>
-  def versioned_hash_version_kzg, do: <<1>>
+  def versioned_hash_version_kzg(), do: <<1>>
 end

--- a/lib/lambda_ethereum_consensus/application.ex
+++ b/lib/lambda_ethereum_consensus/application.ex
@@ -50,7 +50,7 @@ defmodule LambdaEthereumConsensus.Application do
       ]
   end
 
-  defp get_operation_mode do
+  defp get_operation_mode() do
     Application.fetch_env!(:lambda_ethereum_consensus, LambdaEthereumConsensus)
     |> Keyword.fetch!(:mode)
   end

--- a/lib/lambda_ethereum_consensus/beacon/beacon_chain.ex
+++ b/lib/lambda_ethereum_consensus/beacon/beacon_chain.ex
@@ -44,10 +44,10 @@ defmodule LambdaEthereumConsensus.Beacon.BeaconChain do
   end
 
   @spec get_current_slot() :: Types.slot()
-  def get_current_slot, do: GenServer.call(__MODULE__, :get_current_slot)
+  def get_current_slot(), do: GenServer.call(__MODULE__, :get_current_slot)
 
   @spec get_genesis_time() :: Types.uint64()
-  def get_genesis_time, do: GenServer.call(__MODULE__, :get_genesis_time)
+  def get_genesis_time(), do: GenServer.call(__MODULE__, :get_genesis_time)
 
   @spec update_fork_choice_cache(Types.root(), Types.slot(), Checkpoint.t(), Checkpoint.t()) ::
           :ok
@@ -59,24 +59,24 @@ defmodule LambdaEthereumConsensus.Beacon.BeaconChain do
   end
 
   @spec get_finalized_checkpoint() :: Types.Checkpoint.t()
-  def get_finalized_checkpoint do
+  def get_finalized_checkpoint() do
     %{finalized: finalized} = GenServer.call(__MODULE__, :get_fork_choice_cache)
     finalized
   end
 
   @spec get_justified_checkpoint() :: Types.Checkpoint.t()
-  def get_justified_checkpoint do
+  def get_justified_checkpoint() do
     %{justified: justified} = GenServer.call(__MODULE__, :get_fork_choice_cache)
     justified
   end
 
   @spec get_current_epoch() :: integer()
-  def get_current_epoch do
+  def get_current_epoch() do
     Misc.compute_epoch_at_slot(get_current_slot())
   end
 
   @spec get_fork_digest() :: Types.fork_digest()
-  def get_fork_digest do
+  def get_fork_digest() do
     GenServer.call(__MODULE__, :get_fork_digest)
   end
 
@@ -86,10 +86,10 @@ defmodule LambdaEthereumConsensus.Beacon.BeaconChain do
   end
 
   @spec get_fork_version() :: Types.version()
-  def get_fork_version, do: GenServer.call(__MODULE__, :get_fork_version)
+  def get_fork_version(), do: GenServer.call(__MODULE__, :get_fork_version)
 
   @spec get_current_status_message() :: {:ok, Types.StatusMessage.t()} | {:error, any}
-  def get_current_status_message, do: GenServer.call(__MODULE__, :get_current_status_message)
+  def get_current_status_message(), do: GenServer.call(__MODULE__, :get_current_status_message)
 
   ##########################
   ### GenServer Callbacks
@@ -202,7 +202,7 @@ defmodule LambdaEthereumConsensus.Beacon.BeaconChain do
     end
   end
 
-  def schedule_next_tick do
+  def schedule_next_tick() do
     # For millisecond precision
     time_to_next_tick = 1000 - rem(:os.system_time(:millisecond), 1000)
     Process.send_after(__MODULE__, :on_tick, time_to_next_tick)

--- a/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
+++ b/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
@@ -215,15 +215,15 @@ defmodule LambdaEthereumConsensus.Beacon.PendingBlocks do
     end
   end
 
-  def schedule_blocks_processing do
+  def schedule_blocks_processing() do
     Process.send_after(__MODULE__, :process_blocks, 500)
   end
 
-  def schedule_blobs_download do
+  def schedule_blobs_download() do
     Process.send_after(__MODULE__, :download_blobs, 500)
   end
 
-  def schedule_blocks_download do
+  def schedule_blocks_download() do
     Process.send_after(__MODULE__, :download_blocks, 1000)
   end
 end

--- a/lib/lambda_ethereum_consensus/beacon/store_setup.ex
+++ b/lib/lambda_ethereum_consensus/beacon/store_setup.ex
@@ -40,7 +40,7 @@ defmodule LambdaEthereumConsensus.Beacon.StoreSetup do
   Gets a {store, genesis_validators_root} tuple with the configured strategy.
   """
   @spec setup!() :: {Store.t(), binary}
-  def setup!, do: setup!(get_strategy!())
+  def setup!(), do: setup!(get_strategy!())
 
   @spec setup!(store_setup_strategy()) :: {Store.t(), binary}
   def setup!({:file, anchor_state}) do
@@ -83,7 +83,7 @@ defmodule LambdaEthereumConsensus.Beacon.StoreSetup do
   Gets the deposit tree snapshot. Will return nil unless the strategy is checkpoint sync.
   """
   @spec get_deposit_snapshot!() :: DepositTreeSnapshot.t() | nil
-  def get_deposit_snapshot!, do: get_deposit_snapshot!(get_strategy!())
+  def get_deposit_snapshot!(), do: get_deposit_snapshot!(get_strategy!())
 
   @spec get_deposit_snapshot!(store_setup_strategy()) :: DepositTreeSnapshot.t() | nil
   def get_deposit_snapshot!({:file, _}), do: nil
@@ -91,12 +91,12 @@ defmodule LambdaEthereumConsensus.Beacon.StoreSetup do
   def get_deposit_snapshot!(:db), do: nil
 
   @spec get_strategy!() :: store_setup_strategy
-  defp get_strategy! do
+  defp get_strategy!() do
     Application.get_env(:lambda_ethereum_consensus, __MODULE__)
     |> Keyword.fetch!(:strategy)
   end
 
-  defp restore_state_from_db do
+  defp restore_state_from_db() do
     # Try to fetch the old store from the database
     case StoreDb.fetch_store() do
       {:ok, %Store{finalized_checkpoint: %{epoch: finalized_epoch}} = store} ->

--- a/lib/lambda_ethereum_consensus/execution/auth.ex
+++ b/lib/lambda_ethereum_consensus/execution/auth.ex
@@ -5,7 +5,7 @@ defmodule LambdaEthereumConsensus.Execution.Auth do
   use Joken.Config
 
   # Set default expiry to 60s
-  def token_config, do: default_claims(default_exp: 60)
+  def token_config(), do: default_claims(default_exp: 60)
 
   # JWT Authentication is necessary for the EL <> CL communication through Engine API
   # Following the specs here: https://github.com/ethereum/execution-apis/blob/main/src/engine/authentication.md

--- a/lib/lambda_ethereum_consensus/execution/engine_api.ex
+++ b/lib/lambda_ethereum_consensus/execution/engine_api.ex
@@ -4,7 +4,7 @@ defmodule LambdaEthereumConsensus.Execution.EngineApi do
   """
   @behaviour LambdaEthereumConsensus.Execution.EngineApi.Behaviour
 
-  def exchange_capabilities, do: impl().exchange_capabilities()
+  def exchange_capabilities(), do: impl().exchange_capabilities()
 
   def new_payload(execution_payload, versioned_hashes, parent_beacon_block_root),
     do: impl().new_payload(execution_payload, versioned_hashes, parent_beacon_block_root)
@@ -18,5 +18,5 @@ defmodule LambdaEthereumConsensus.Execution.EngineApi do
 
   def get_deposit_logs(block_number_range), do: impl().get_deposit_logs(block_number_range)
 
-  defp impl, do: Application.fetch_env!(:lambda_ethereum_consensus, __MODULE__)[:implementation]
+  defp impl(), do: Application.fetch_env!(:lambda_ethereum_consensus, __MODULE__)[:implementation]
 end

--- a/lib/lambda_ethereum_consensus/execution/engine_api/api.ex
+++ b/lib/lambda_ethereum_consensus/execution/engine_api/api.ex
@@ -14,7 +14,7 @@ defmodule LambdaEthereumConsensus.Execution.EngineApi.Api do
   Using this method Execution and consensus layer client software may
   exchange with a list of supported Engine API methods.
   """
-  def exchange_capabilities do
+  def exchange_capabilities() do
     call("engine_exchangeCapabilities", [@supported_methods])
   end
 

--- a/lib/lambda_ethereum_consensus/execution/engine_api/mocked.ex
+++ b/lib/lambda_ethereum_consensus/execution/engine_api/mocked.ex
@@ -8,7 +8,7 @@ defmodule LambdaEthereumConsensus.Execution.EngineApi.Mocked do
   Using this method Execution and consensus layer client software may
   exchange with a list of supported Engine API methods.
   """
-  def exchange_capabilities do
+  def exchange_capabilities() do
     {:ok, ["engine_newPayloadV2", "engine_newPayloadV3"]}
   end
 

--- a/lib/lambda_ethereum_consensus/execution/execution_chain.ex
+++ b/lib/lambda_ethereum_consensus/execution/execution_chain.ex
@@ -251,6 +251,6 @@ defmodule LambdaEthereumConsensus.Execution.ExecutionChain do
 
   defp compute_period(slot), do: slot |> div(slots_per_eth1_voting_period())
 
-  defp slots_per_eth1_voting_period,
+  defp slots_per_eth1_voting_period(),
     do: ChainSpec.get("EPOCHS_PER_ETH1_VOTING_PERIOD") * ChainSpec.get("SLOTS_PER_EPOCH")
 end

--- a/lib/lambda_ethereum_consensus/fork_choice/old_tree.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/old_tree.ex
@@ -60,7 +60,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Tree do
   so this operation is O(1).
   """
   @spec get_head() :: Node.t()
-  def get_head, do: GenServer.call(__MODULE__, :get_head)
+  def get_head(), do: GenServer.call(__MODULE__, :get_head)
 
   ##########################
   ### GenServer Callbacks

--- a/lib/lambda_ethereum_consensus/hard_fork_alias_injection.ex
+++ b/lib/lambda_ethereum_consensus/hard_fork_alias_injection.ex
@@ -3,7 +3,7 @@ defmodule HardForkAliasInjection do
   is_deneb = Application.compile_env!(:lambda_ethereum_consensus, :fork) == :deneb
 
   @compile {:inline, deneb?: 0}
-  def deneb?, do: unquote(is_deneb)
+  def deneb?(), do: unquote(is_deneb)
 
   @doc """
   Compiles to the first argument if on deneb, otherwise to the second argument.

--- a/lib/lambda_ethereum_consensus/p2p/blob_downloader.ex
+++ b/lib/lambda_ethereum_consensus/p2p/blob_downloader.ex
@@ -90,7 +90,7 @@ defmodule LambdaEthereumConsensus.P2P.BlobDownloader do
     end
   end
 
-  defp get_some_peer do
+  defp get_some_peer() do
     case P2P.Peerbook.get_some_peer() do
       nil ->
         Process.sleep(100)

--- a/lib/lambda_ethereum_consensus/p2p/block_downloader.ex
+++ b/lib/lambda_ethereum_consensus/p2p/block_downloader.ex
@@ -100,7 +100,7 @@ defmodule LambdaEthereumConsensus.P2P.BlockDownloader do
     end
   end
 
-  defp get_some_peer do
+  defp get_some_peer() do
     case P2P.Peerbook.get_some_peer() do
       nil ->
         Process.sleep(100)

--- a/lib/lambda_ethereum_consensus/p2p/gossip/attestation.ex
+++ b/lib/lambda_ethereum_consensus/p2p/gossip/attestation.ex
@@ -69,13 +69,13 @@ defmodule LambdaEthereumConsensus.P2P.Gossip.Attestation do
     "/eth2/#{fork_context}/beacon_attestation_#{subnet_id}/ssz_snappy"
   end
 
-  defp update_enr do
+  defp update_enr() do
     enr_fork_id = compute_enr_fork_id()
     %{attnets: attnets, syncnets: syncnets} = P2P.Metadata.get_metadata()
     Libp2pPort.update_enr(enr_fork_id, attnets, syncnets)
   end
 
-  defp compute_enr_fork_id do
+  defp compute_enr_fork_id() do
     current_version = BeaconChain.get_fork_version()
 
     fork_digest =

--- a/lib/lambda_ethereum_consensus/p2p/metadata.ex
+++ b/lib/lambda_ethereum_consensus/p2p/metadata.ex
@@ -17,12 +17,12 @@ defmodule LambdaEthereumConsensus.P2P.Metadata do
   end
 
   @spec get_seq_number() :: Types.uint64()
-  def get_seq_number do
+  def get_seq_number() do
     GenServer.call(__MODULE__, :get_seq_number)
   end
 
   @spec get_metadata() :: Metadata.t()
-  def get_metadata do
+  def get_metadata() do
     GenServer.call(__MODULE__, :get_metadata)
   end
 

--- a/lib/lambda_ethereum_consensus/p2p/peerbook.ex
+++ b/lib/lambda_ethereum_consensus/p2p/peerbook.ex
@@ -20,7 +20,7 @@ defmodule LambdaEthereumConsensus.P2P.Peerbook do
   @doc """
   Get some peer from the peerbook.
   """
-  def get_some_peer do
+  def get_some_peer() do
     GenServer.call(__MODULE__, :get_some_peer)
   end
 

--- a/lib/lambda_ethereum_consensus/state_transition/cache.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/cache.ex
@@ -44,10 +44,10 @@ defmodule LambdaEthereumConsensus.StateTransition.Cache do
   defp generate_cleanup_spec(:active_validator_indices, key), do: cleanup_epoch_ms(key)
 
   @spec initialize_cache() :: :ok
-  def initialize_cache, do: @tables |> Enum.each(&init_table/1)
+  def initialize_cache(), do: @tables |> Enum.each(&init_table/1)
 
   @spec clear_cache() :: :ok
-  def clear_cache, do: @tables |> Enum.each(&:ets.delete_all_objects/1)
+  def clear_cache(), do: @tables |> Enum.each(&:ets.delete_all_objects/1)
 
   @spec init_table(:ets.table()) :: :ok
   def init_table(table) do

--- a/lib/lambda_ethereum_consensus/store/block_db.ex
+++ b/lib/lambda_ethereum_consensus/store/block_db.ex
@@ -58,7 +58,7 @@ defmodule LambdaEthereumConsensus.Store.BlockDb do
     end
   end
 
-  def stream_missing_blocks_desc do
+  def stream_missing_blocks_desc() do
     Stream.resource(
       fn -> 0xFFFFFFFFFFFFFFFF |> block_root_by_slot_key() |> init_keycursor() end,
       &next_slot(&1, :prev),
@@ -119,7 +119,7 @@ defmodule LambdaEthereumConsensus.Store.BlockDb do
   defp block_key(root), do: Utils.get_key(@block_prefix, root)
   defp block_root_by_slot_key(slot), do: Utils.get_key(@blockslot_prefix, slot)
 
-  def stream_blocks do
+  def stream_blocks() do
     Stream.resource(
       fn -> <<0::256>> |> block_key() |> init_cursor() end,
       &next_block/1,

--- a/lib/lambda_ethereum_consensus/store/db.ex
+++ b/lib/lambda_ethereum_consensus/store/db.ex
@@ -25,14 +25,14 @@ defmodule LambdaEthereumConsensus.Store.Db do
   end
 
   @spec iterate() :: {:ok, :eleveldb.itr_ref()} | {:error, any()}
-  def iterate do
+  def iterate() do
     ref = GenServer.call(@registered_name, :get_ref)
     # TODO: wrap cursor to make it DB-agnostic
     Exleveldb.iterator(ref, [])
   end
 
   @spec iterate_keys() :: {:ok, :eleveldb.itr_ref()} | {:error, any()}
-  def iterate_keys do
+  def iterate_keys() do
     ref = GenServer.call(@registered_name, :get_ref)
     # TODO: wrap cursor to make it DB-agnostic
     Exleveldb.iterator(ref, [], :keys_only)
@@ -57,7 +57,7 @@ defmodule LambdaEthereumConsensus.Store.Db do
   @impl true
   def handle_call(:get_ref, _from, %{ref: ref} = state), do: {:reply, ref, state}
 
-  defp get_dir do
+  defp get_dir() do
     Application.fetch_env!(:lambda_ethereum_consensus, __MODULE__)
     |> Keyword.fetch!(:dir)
   end

--- a/lib/lambda_ethereum_consensus/store/state_db.ex
+++ b/lib/lambda_ethereum_consensus/store/state_db.ex
@@ -52,7 +52,7 @@ defmodule LambdaEthereumConsensus.Store.StateDb do
 
   @spec get_latest_state() ::
           {:ok, BeaconState.t()} | {:error, String.t()} | :not_found
-  def get_latest_state do
+  def get_latest_state() do
     last_key = root_by_slot_key(0xFFFFFFFFFFFFFFFF)
 
     with {:ok, it} <- Db.iterate(),

--- a/lib/lambda_ethereum_consensus/store/store_db.ex
+++ b/lib/lambda_ethereum_consensus/store/store_db.ex
@@ -7,7 +7,7 @@ defmodule LambdaEthereumConsensus.Store.StoreDb do
   @store_prefix "store"
 
   @spec fetch_store() :: {:ok, Types.Store.t()} | :not_found
-  def fetch_store do
+  def fetch_store() do
     with {:ok, encoded_store} <- Db.get(@store_prefix) do
       {:ok, :erlang.binary_to_term(encoded_store)}
     end

--- a/lib/lambda_ethereum_consensus/telemetry.ex
+++ b/lib/lambda_ethereum_consensus/telemetry.ex
@@ -122,7 +122,7 @@ defmodule LambdaEthereumConsensus.Telemetry do
     ]
   end
 
-  defp periodic_measurements do
+  defp periodic_measurements() do
     [
       # A module, function and arguments to be invoked periodically.
       # This function must call :telemetry.execute/3 and a metric must be added above.
@@ -131,7 +131,7 @@ defmodule LambdaEthereumConsensus.Telemetry do
     ]
   end
 
-  def uptime do
+  def uptime() do
     {uptime, _} = :erlang.statistics(:wall_clock)
     :telemetry.execute([:vm, :uptime], %{total: uptime})
   end
@@ -140,7 +140,7 @@ defmodule LambdaEthereumConsensus.Telemetry do
     :telemetry.execute([:vm, :message_queue], %{length: len}, %{process: inspect(name)})
   end
 
-  def message_queue_lengths do
+  def message_queue_lengths() do
     Process.list()
     |> Enum.each(fn pid ->
       case Process.info(pid, [:message_queue_len, :registered_name]) do

--- a/lib/lambda_ethereum_consensus/validator/block_builder.ex
+++ b/lib/lambda_ethereum_consensus/validator/block_builder.ex
@@ -146,7 +146,7 @@ defmodule LambdaEthereumConsensus.Validator.BlockBuilder do
           voluntary_exits: [Types.VoluntaryExit.t()],
           bls_to_execution_changes: [Types.SignedBLSToExecutionChange.t()]
         }
-  defp fetch_operations_for_block do
+  defp fetch_operations_for_block() do
     %{
       proposer_slashings:
         ChainSpec.get("MAX_PROPOSER_SLASHINGS") |> OperationsCollector.get_proposer_slashings(),
@@ -194,7 +194,7 @@ defmodule LambdaEthereumConsensus.Validator.BlockBuilder do
     signature
   end
 
-  defp get_sync_aggregate do
+  defp get_sync_aggregate() do
     %Types.SyncAggregate{
       sync_committee_bits: ChainSpec.get("SYNC_COMMITTEE_SIZE") |> BitVector.new(),
       sync_committee_signature: <<192, 0::760>>

--- a/lib/lambda_ethereum_consensus/validator/validator.ex
+++ b/lib/lambda_ethereum_consensus/validator/validator.ex
@@ -113,7 +113,7 @@ defmodule LambdaEthereumConsensus.Validator do
   ### Private Functions
   ##########################
 
-  defp empty_duties do
+  defp empty_duties() do
     %{
       # Order is: previous epoch, current epoch, next epoch
       attester: [:not_computed, :not_computed, :not_computed],

--- a/lib/libp2p/libp2p.ex
+++ b/lib/libp2p/libp2p.ex
@@ -5,7 +5,7 @@ defmodule Libp2p do
 
   @on_load :load_nifs
 
-  def load_nifs do
+  def load_nifs() do
     dir = :code.priv_dir(:lambda_ethereum_consensus)
     :erlang.load_nif(dir ++ ~c"/native/libp2p_nif", 0)
   end
@@ -89,7 +89,7 @@ defmodule Libp2p do
   The ttl for a "permanent address" (e.g. bootstrap nodes).
   """
   @spec ttl_permanent_addr :: integer
-  def ttl_permanent_addr, do: 2 ** 63 - 1
+  def ttl_permanent_addr(), do: 2 ** 63 - 1
 
   @doc """
   Gets next subscription message.

--- a/lib/libp2p_port.ex
+++ b/lib/libp2p_port.ex
@@ -130,7 +130,7 @@ defmodule LambdaEthereumConsensus.Libp2pPort do
   on the current process. If there are no requests, it waits for one.
   """
   @spec handle_request() :: {String.t(), String.t(), binary()}
-  def handle_request do
+  def handle_request() do
     receive do
       {:request, {_protocol_id, _message_id, _message} = request} -> request
     end
@@ -189,7 +189,7 @@ defmodule LambdaEthereumConsensus.Libp2pPort do
   on the current process. If there are none, it waits for one.
   """
   @spec receive_gossip() :: {String.t(), binary(), binary()}
-  def receive_gossip do
+  def receive_gossip() do
     receive do
       {:gossipsub, {_topic_name, _msg_id, _message} = m} -> m
     end
@@ -427,7 +427,7 @@ defmodule LambdaEthereumConsensus.Libp2pPort do
     receive_response()
   end
 
-  defp receive_response do
+  defp receive_response() do
     receive do
       {:response, {res, %ResultMessage{message: []}}} -> res
       {:response, {res, %ResultMessage{message: message}}} -> [res | message] |> List.to_tuple()

--- a/lib/ssz.ex
+++ b/lib/ssz.ex
@@ -123,7 +123,7 @@ defmodule Ssz do
     do: error()
 
   ##### Utils
-  defp error, do: :erlang.nif_error(:nif_not_loaded)
+  defp error(), do: :erlang.nif_error(:nif_not_loaded)
 
   # Ssz types can have special decoding rules defined in their optional encode/1 function,
   defp encode(%name{} = struct) do

--- a/lib/ssz_ex/hash.ex
+++ b/lib/ssz_ex/hash.ex
@@ -10,7 +10,7 @@ defmodule SszEx.Hash do
   @doc """
   Compute the roots of Merkle trees with all zero leaves and lengths from 0 to 64.
   """
-  def compute_zero_hashes do
+  def compute_zero_hashes() do
     Stream.iterate(<<0::size(8 * @bytes_per_chunk)>>, &hash_nodes(&1, &1))
     |> Stream.take(@max_merkle_tree_depth + 1)
     |> Enum.join()

--- a/lib/types/beacon_chain/attestation.ex
+++ b/lib/types/beacon_chain/attestation.ex
@@ -24,7 +24,7 @@ defmodule Types.Attestation do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:aggregation_bits, {:bitlist, ChainSpec.get("MAX_VALIDATORS_PER_COMMITTEE")}},
       {:data, Types.AttestationData},

--- a/lib/types/beacon_chain/attestation_data.ex
+++ b/lib/types/beacon_chain/attestation_data.ex
@@ -26,7 +26,7 @@ defmodule Types.AttestationData do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:slot, TypeAliases.slot()},
       {:index, TypeAliases.commitee_index()},

--- a/lib/types/beacon_chain/attester_slashing.ex
+++ b/lib/types/beacon_chain/attester_slashing.ex
@@ -19,7 +19,7 @@ defmodule Types.AttesterSlashing do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:attestation_1, Types.IndexedAttestation},
       {:attestation_2, Types.IndexedAttestation}

--- a/lib/types/beacon_chain/beacon_block.ex
+++ b/lib/types/beacon_chain/beacon_block.ex
@@ -25,7 +25,7 @@ defmodule Types.BeaconBlock do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:slot, TypeAliases.slot()},
       {:proposer_index, TypeAliases.validator_index()},

--- a/lib/types/beacon_chain/beacon_block_body.ex
+++ b/lib/types/beacon_chain/beacon_block_body.ex
@@ -46,7 +46,7 @@ defmodule Types.BeaconBlockBody do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       randao_reveal: TypeAliases.bls_signature(),
       eth1_data: Types.Eth1Data,

--- a/lib/types/beacon_chain/beacon_block_header.ex
+++ b/lib/types/beacon_chain/beacon_block_header.ex
@@ -25,7 +25,7 @@ defmodule Types.BeaconBlockHeader do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:slot, TypeAliases.slot()},
       {:proposer_index, TypeAliases.validator_index()},

--- a/lib/types/beacon_chain/beacon_state.ex
+++ b/lib/types/beacon_chain/beacon_state.ex
@@ -109,7 +109,7 @@ defmodule Types.BeaconState do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:genesis_time, TypeAliases.uint64()},
       {:genesis_validators_root, TypeAliases.root()},

--- a/lib/types/beacon_chain/blob_identifier.ex
+++ b/lib/types/beacon_chain/blob_identifier.ex
@@ -19,7 +19,7 @@ defmodule Types.BlobIdentifier do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:block_root, TypeAliases.root()},
       {:index, TypeAliases.blob_index()}

--- a/lib/types/beacon_chain/blob_sidecar.ex
+++ b/lib/types/beacon_chain/blob_sidecar.ex
@@ -28,7 +28,7 @@ defmodule Types.BlobSidecar do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       index: TypeAliases.blob_index(),
       blob: TypeAliases.blob(),

--- a/lib/types/beacon_chain/bls_to_execution_change.ex
+++ b/lib/types/beacon_chain/bls_to_execution_change.ex
@@ -21,7 +21,7 @@ defmodule Types.BLSToExecutionChange do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:validator_index, TypeAliases.validator_index()},
       {:from_bls_pubkey, TypeAliases.bls_pubkey()},

--- a/lib/types/beacon_chain/checkpoint.ex
+++ b/lib/types/beacon_chain/checkpoint.ex
@@ -20,7 +20,7 @@ defmodule Types.Checkpoint do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:epoch, TypeAliases.epoch()},
       {:root, TypeAliases.root()}

--- a/lib/types/beacon_chain/deposit.ex
+++ b/lib/types/beacon_chain/deposit.ex
@@ -43,7 +43,7 @@ defmodule Types.Deposit do
   end
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:proof, {:vector, TypeAliases.bytes32(), 33}},
       {:data, Types.DepositData}

--- a/lib/types/beacon_chain/deposit_data.ex
+++ b/lib/types/beacon_chain/deposit_data.ex
@@ -24,7 +24,7 @@ defmodule Types.DepositData do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:pubkey, TypeAliases.bls_pubkey()},
       {:withdrawal_credentials, TypeAliases.bytes32()},

--- a/lib/types/beacon_chain/deposit_message.ex
+++ b/lib/types/beacon_chain/deposit_message.ex
@@ -21,7 +21,7 @@ defmodule Types.DepositMessage do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:pubkey, TypeAliases.bls_pubkey()},
       {:withdrawal_credentials, TypeAliases.bytes32()},

--- a/lib/types/beacon_chain/eth1_block.ex
+++ b/lib/types/beacon_chain/eth1_block.ex
@@ -20,7 +20,7 @@ defmodule Types.Eth1Block do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       timestamp: TypeAliases.uint64(),
       deposit_root: TypeAliases.root(),

--- a/lib/types/beacon_chain/eth1_data.ex
+++ b/lib/types/beacon_chain/eth1_data.ex
@@ -21,7 +21,7 @@ defmodule Types.Eth1Data do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       deposit_root: TypeAliases.root(),
       deposit_count: TypeAliases.uint64(),

--- a/lib/types/beacon_chain/execution_payload.ex
+++ b/lib/types/beacon_chain/execution_payload.ex
@@ -61,7 +61,7 @@ defmodule Types.ExecutionPayload do
   end
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:parent_hash, TypeAliases.hash32()},
       {:fee_recipient, TypeAliases.execution_address()},

--- a/lib/types/beacon_chain/execution_payload_header.ex
+++ b/lib/types/beacon_chain/execution_payload_header.ex
@@ -78,10 +78,10 @@ defmodule Types.ExecutionPayloadHeader do
     Map.update!(map, :base_fee_per_gas, &Ssz.decode_u256/1)
   end
 
-  def default, do: @default_execution_payload_header
+  def default(), do: @default_execution_payload_header
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:parent_hash, TypeAliases.hash32()},
       {:fee_recipient, TypeAliases.execution_address()},

--- a/lib/types/beacon_chain/fork.ex
+++ b/lib/types/beacon_chain/fork.ex
@@ -22,7 +22,7 @@ defmodule Types.Fork do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:previous_version, TypeAliases.version()},
       {:current_version, TypeAliases.version()},

--- a/lib/types/beacon_chain/fork_data.ex
+++ b/lib/types/beacon_chain/fork_data.ex
@@ -20,7 +20,7 @@ defmodule Types.ForkData do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:current_version, TypeAliases.version()},
       {:genesis_validators_root, TypeAliases.root()}

--- a/lib/types/beacon_chain/historical_batch.ex
+++ b/lib/types/beacon_chain/historical_batch.ex
@@ -20,7 +20,7 @@ defmodule Types.HistoricalBatch do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:block_roots, {:vector, TypeAliases.root(), ChainSpec.get("SLOTS_PER_HISTORICAL_ROOT")}},
       {:state_roots, {:vector, TypeAliases.root(), ChainSpec.get("SLOTS_PER_HISTORICAL_ROOT")}}

--- a/lib/types/beacon_chain/historical_summary.ex
+++ b/lib/types/beacon_chain/historical_summary.ex
@@ -21,7 +21,7 @@ defmodule Types.HistoricalSummary do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:block_summary_root, TypeAliases.root()},
       {:state_summary_root, TypeAliases.root()}

--- a/lib/types/beacon_chain/indexed_attestation.ex
+++ b/lib/types/beacon_chain/indexed_attestation.ex
@@ -22,7 +22,7 @@ defmodule Types.IndexedAttestation do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:attesting_indices,
        {:list, TypeAliases.validator_index(), ChainSpec.get("MAX_VALIDATORS_PER_COMMITTEE")}},

--- a/lib/types/beacon_chain/pending_attestation.ex
+++ b/lib/types/beacon_chain/pending_attestation.ex
@@ -26,7 +26,7 @@ defmodule Types.PendingAttestation do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:aggregation_bits, {:bitlist, ChainSpec.get("MAX_VALIDATORS_PER_COMMITTEE")}},
       {:data, Types.AttestationData},

--- a/lib/types/beacon_chain/proposer_slashing.ex
+++ b/lib/types/beacon_chain/proposer_slashing.ex
@@ -19,7 +19,7 @@ defmodule Types.ProposerSlashing do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:signed_header_1, Types.SignedBeaconBlockHeader},
       {:signed_header_2, Types.SignedBeaconBlockHeader}

--- a/lib/types/beacon_chain/signed_beacon_block.ex
+++ b/lib/types/beacon_chain/signed_beacon_block.ex
@@ -19,7 +19,7 @@ defmodule Types.SignedBeaconBlock do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:message, Types.BeaconBlock},
       {:signature, TypeAliases.bls_signature()}

--- a/lib/types/beacon_chain/signed_beacon_block_header.ex
+++ b/lib/types/beacon_chain/signed_beacon_block_header.ex
@@ -19,7 +19,7 @@ defmodule Types.SignedBeaconBlockHeader do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:message, Types.BeaconBlockHeader},
       {:signature, TypeAliases.bls_signature()}

--- a/lib/types/beacon_chain/signed_bls_to_execution_change.ex
+++ b/lib/types/beacon_chain/signed_bls_to_execution_change.ex
@@ -19,7 +19,7 @@ defmodule Types.SignedBLSToExecutionChange do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:message, Types.BLSToExecutionChange},
       {:signature, TypeAliases.bls_signature()}

--- a/lib/types/beacon_chain/signed_voluntary_exit.ex
+++ b/lib/types/beacon_chain/signed_voluntary_exit.ex
@@ -19,7 +19,7 @@ defmodule Types.SignedVoluntaryExit do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:message, Types.VoluntaryExit},
       {:signature, TypeAliases.bls_signature()}

--- a/lib/types/beacon_chain/signing_data.ex
+++ b/lib/types/beacon_chain/signing_data.ex
@@ -19,7 +19,7 @@ defmodule Types.SigningData do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:object_root, TypeAliases.root()},
       {:domain, TypeAliases.domain()}

--- a/lib/types/beacon_chain/sync_aggregate.ex
+++ b/lib/types/beacon_chain/sync_aggregate.ex
@@ -31,7 +31,7 @@ defmodule Types.SyncAggregate do
   end
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:sync_committee_bits, {:bitvector, ChainSpec.get("SYNC_COMMITTEE_SIZE")}},
       {:sync_committee_signature, TypeAliases.bls_signature()}

--- a/lib/types/beacon_chain/sync_aggregator_selection_data.ex
+++ b/lib/types/beacon_chain/sync_aggregator_selection_data.ex
@@ -15,7 +15,7 @@ defmodule Types.SyncAggregatorSelectionData do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       slot: TypeAliases.slot(),
       subcommittee_index: TypeAliases.uint64()

--- a/lib/types/beacon_chain/sync_committee.ex
+++ b/lib/types/beacon_chain/sync_committee.ex
@@ -21,7 +21,7 @@ defmodule Types.SyncCommittee do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:pubkeys, {:vector, TypeAliases.bls_pubkey(), ChainSpec.get("SYNC_COMMITTEE_SIZE")}},
       {:aggregate_pubkey, TypeAliases.bls_pubkey()}

--- a/lib/types/beacon_chain/validator.ex
+++ b/lib/types/beacon_chain/validator.ex
@@ -69,7 +69,7 @@ defmodule Types.Validator do
   end
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:pubkey, TypeAliases.bls_pubkey()},
       {:withdrawal_credentials, TypeAliases.bytes32()},

--- a/lib/types/beacon_chain/voluntary_exit.ex
+++ b/lib/types/beacon_chain/voluntary_exit.ex
@@ -19,7 +19,7 @@ defmodule Types.VoluntaryExit do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:epoch, TypeAliases.epoch()},
       {:validator_index, TypeAliases.validator_index()}

--- a/lib/types/beacon_chain/withdrawal.ex
+++ b/lib/types/beacon_chain/withdrawal.ex
@@ -23,7 +23,7 @@ defmodule Types.Withdrawal do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:index, TypeAliases.withdrawal_index()},
       {:validator_index, TypeAliases.validator_index()},

--- a/lib/types/blobdata.ex
+++ b/lib/types/blobdata.ex
@@ -13,7 +13,7 @@ defmodule Types.Blobdata do
   @type t :: %__MODULE__{blob: Types.blob(), proof: Types.kzg_proof()}
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       blob: TypeAliases.blob(),
       proof: TypeAliases.kzg_proof()

--- a/lib/types/deposit_tree.ex
+++ b/lib/types/deposit_tree.ex
@@ -31,7 +31,7 @@ defmodule Types.DepositTree do
   ################
 
   @spec new() :: t()
-  def new, do: %__MODULE__{}
+  def new(), do: %__MODULE__{}
 
   @spec from_snapshot(DepositTreeSnapshot.t()) :: t()
   def from_snapshot(%DepositTreeSnapshot{} = snapshot) do

--- a/lib/types/p2p/beacon_blocks_by_range_request.ex
+++ b/lib/types/p2p/beacon_blocks_by_range_request.ex
@@ -20,7 +20,7 @@ defmodule Types.BeaconBlocksByRangeRequest do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       start_slot: TypeAliases.slot(),
       count: TypeAliases.uint64(),

--- a/lib/types/p2p/enr_fork_id.ex
+++ b/lib/types/p2p/enr_fork_id.ex
@@ -21,7 +21,7 @@ defmodule Types.EnrForkId do
         }
 
   @impl Container
-  def schema do
+  def schema() do
     [
       fork_digest: TypeAliases.fork_digest(),
       next_fork_version: TypeAliases.version(),

--- a/lib/types/p2p/metadata.ex
+++ b/lib/types/p2p/metadata.ex
@@ -20,14 +20,14 @@ defmodule Types.Metadata do
           syncnets: Types.bitvector()
         }
 
-  def schema,
+  def schema(),
     do: [
       seq_number: TypeAliases.uint64(),
       attnets: {:bitvector, ChainSpec.get("ATTESTATION_SUBNET_COUNT")},
       syncnets: {:bitvector, Constants.sync_committee_subnet_count()}
     ]
 
-  def empty do
+  def empty() do
     attnets = ChainSpec.get("ATTESTATION_SUBNET_COUNT") |> BitVector.new()
     syncnets = Constants.sync_committee_subnet_count() |> BitVector.new()
     %__MODULE__{seq_number: 0, attnets: attnets, syncnets: syncnets}

--- a/lib/types/p2p/status_message.ex
+++ b/lib/types/p2p/status_message.ex
@@ -25,7 +25,7 @@ defmodule Types.StatusMessage do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       fork_digest: TypeAliases.fork_digest(),
       finalized_root: TypeAliases.root(),

--- a/lib/types/type_aliases.ex
+++ b/lib/types/type_aliases.ex
@@ -3,46 +3,46 @@ defmodule TypeAliases do
   Type aliases for ssz schemas
   """
 
-  def root, do: {:byte_vector, 32}
-  def epoch, do: {:int, 64}
-  def bls_signature, do: {:byte_vector, 96}
-  def slot, do: {:int, 64}
-  def commitee_index, do: {:int, 64}
-  def validator_index, do: {:int, 64}
-  def gwei, do: {:int, 64}
-  def participation_flags, do: {:int, 8}
-  def withdrawal_index, do: {:int, 64}
-  def bls_pubkey, do: {:byte_vector, 48}
-  def execution_address, do: {:byte_vector, 20}
-  def version, do: {:byte_vector, 4}
-  def domain, do: {:byte_vector, 32}
-  def domain_type, do: {:byte_vector, 4}
-  def fork_digest, do: {:byte_vector, 4}
-  def blob_index, do: uint64()
+  def root(), do: {:byte_vector, 32}
+  def epoch(), do: {:int, 64}
+  def bls_signature(), do: {:byte_vector, 96}
+  def slot(), do: {:int, 64}
+  def commitee_index(), do: {:int, 64}
+  def validator_index(), do: {:int, 64}
+  def gwei(), do: {:int, 64}
+  def participation_flags(), do: {:int, 8}
+  def withdrawal_index(), do: {:int, 64}
+  def bls_pubkey(), do: {:byte_vector, 48}
+  def execution_address(), do: {:byte_vector, 20}
+  def version(), do: {:byte_vector, 4}
+  def domain(), do: {:byte_vector, 32}
+  def domain_type(), do: {:byte_vector, 4}
+  def fork_digest(), do: {:byte_vector, 4}
+  def blob_index(), do: uint64()
 
-  def blob,
+  def blob(),
     do:
       {:byte_vector,
        Constants.bytes_per_field_element() * ChainSpec.get("FIELD_ELEMENTS_PER_BLOB")}
 
-  def kzg_commitment, do: {:byte_vector, 48}
-  def kzg_proof, do: {:byte_vector, 48}
+  def kzg_commitment(), do: {:byte_vector, 48}
+  def kzg_proof(), do: {:byte_vector, 48}
 
-  def bytes32, do: {:byte_vector, 32}
-  def uint64, do: {:int, 64}
-  def hash32, do: {:byte_vector, 32}
-  def uint256, do: {:int, 256}
+  def bytes32(), do: {:byte_vector, 32}
+  def uint64(), do: {:int, 64}
+  def hash32(), do: {:byte_vector, 32}
+  def uint256(), do: {:int, 256}
 
-  def transactions do
+  def transactions() do
     transaction = {:byte_list, ChainSpec.get("MAX_BYTES_PER_TRANSACTION")}
     {:list, transaction, ChainSpec.get("MAX_TRANSACTIONS_PER_PAYLOAD")}
   end
 
-  def beacon_blocks_by_root_request,
+  def beacon_blocks_by_root_request(),
     do: {:list, TypeAliases.root(), ChainSpec.get("MAX_REQUEST_BLOCKS")}
 
-  def blob_sidecars_by_root_request,
+  def blob_sidecars_by_root_request(),
     do: {:list, Types.BlobIdentifier, ChainSpec.get("MAX_REQUEST_BLOB_SIDECARS")}
 
-  def error_message, do: {:byte_list, 256}
+  def error_message(), do: {:byte_list, 256}
 end

--- a/lib/types/validator/aggregate_and_proof.ex
+++ b/lib/types/validator/aggregate_and_proof.ex
@@ -21,7 +21,7 @@ defmodule Types.AggregateAndProof do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:aggregator_index, TypeAliases.validator_index()},
       {:aggregate, Types.Attestation},

--- a/lib/types/validator/contribution_and_proof.ex
+++ b/lib/types/validator/contribution_and_proof.ex
@@ -21,7 +21,7 @@ defmodule Types.ContributionAndProof do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:aggregator_index, TypeAliases.validator_index()},
       {:contribution, Types.SyncCommitteeContribution},

--- a/lib/types/validator/signed_aggregate_and_proof.ex
+++ b/lib/types/validator/signed_aggregate_and_proof.ex
@@ -19,7 +19,7 @@ defmodule Types.SignedAggregateAndProof do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:message, Types.AggregateAndProof},
       {:signature, TypeAliases.bls_signature()}

--- a/lib/types/validator/signed_contribution_and_proof.ex
+++ b/lib/types/validator/signed_contribution_and_proof.ex
@@ -19,7 +19,7 @@ defmodule Types.SignedContributionAndProof do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:message, Types.ContributionAndProof},
       {:signature, TypeAliases.bls_signature()}

--- a/lib/types/validator/sync_committee_contribution.ex
+++ b/lib/types/validator/sync_committee_contribution.ex
@@ -26,7 +26,7 @@ defmodule Types.SyncCommitteeContribution do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:slot, TypeAliases.slot()},
       {:beacon_block_root, TypeAliases.root()},

--- a/lib/types/validator/sync_committee_message.ex
+++ b/lib/types/validator/sync_committee_message.ex
@@ -23,7 +23,7 @@ defmodule Types.SyncCommitteeMessage do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:slot, TypeAliases.slot()},
       {:beacon_block_root, TypeAliases.root()},

--- a/lib/utils/bit_list.ex
+++ b/lib/utils/bit_list.ex
@@ -18,7 +18,7 @@ defmodule LambdaEthereumConsensus.Utils.BitList do
   Creates a default (empty/size 0) bit list.
   """
   @spec default :: t
-  def default, do: <<>>
+  def default(), do: <<>>
 
   @doc """
   Creates a new bit_list from bitstring.

--- a/lib/utils/profile.ex
+++ b/lib/utils/profile.ex
@@ -31,7 +31,7 @@ defmodule LambdaEthereumConsensus.Profile do
     :ok
   end
 
-  defp now_str do
+  defp now_str() do
     DateTime.utc_now()
     |> Formatter.format!("{YYYY}_{0M}_{0D}__{h24}_{m}_{s}_{ss}")
     |> String.replace(".", "")

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule LambdaEthereumConsensus.MixProject do
   use Mix.Project
 
-  def project do
+  def project() do
     [
       app: :lambda_ethereum_consensus,
       version: "0.1.0",
@@ -20,7 +20,7 @@ defmodule LambdaEthereumConsensus.MixProject do
   end
 
   # Run "mix help compile.app" to learn about applications.
-  def application do
+  def application() do
     [
       extra_applications: [:logger, :observer, :prometheus_ex],
       mod: {LambdaEthereumConsensus.Application, []}
@@ -28,7 +28,7 @@ defmodule LambdaEthereumConsensus.MixProject do
   end
 
   # Run "mix help deps" to learn about dependencies.
-  defp deps do
+  defp deps() do
     [
       {:phoenix, "~> 1.7.7"},
       {:plug_cowboy, "~> 2.5"},
@@ -71,7 +71,7 @@ defmodule LambdaEthereumConsensus.MixProject do
     ]
   end
 
-  defp dialyzer do
+  defp dialyzer() do
     [
       # https://elixirforum.com/t/help-with-dialyzer-output/15202/5
       plt_add_apps: [:ex_unit, :mix],

--- a/test/fixtures/block.ex
+++ b/test/fixtures/block.ex
@@ -14,7 +14,7 @@ defmodule Fixtures.Block do
   alias Types.SignedBeaconBlock
 
   @spec signed_beacon_block :: SignedBeaconBlock.t()
-  def signed_beacon_block do
+  def signed_beacon_block() do
     %SignedBeaconBlock{
       message: beacon_block(),
       signature: Random.bls_signature()
@@ -22,7 +22,7 @@ defmodule Fixtures.Block do
   end
 
   @spec beacon_block :: BeaconBlock.t()
-  def beacon_block do
+  def beacon_block() do
     %BeaconBlock{
       parent_root: Random.root(),
       slot: Random.uint64(),
@@ -33,7 +33,7 @@ defmodule Fixtures.Block do
   end
 
   @spec beacon_block_body :: BeaconBlockBody.t()
-  def beacon_block_body do
+  def beacon_block_body() do
     fields =
       [
         randao_reveal: Random.bls_signature(),
@@ -54,7 +54,7 @@ defmodule Fixtures.Block do
   end
 
   @spec eth1_data :: Types.Eth1Data.t()
-  def eth1_data do
+  def eth1_data() do
     %Types.Eth1Data{
       deposit_root: Random.root(),
       deposit_count: Random.uint64(),
@@ -63,7 +63,7 @@ defmodule Fixtures.Block do
   end
 
   @spec sync_aggregate :: Types.SyncAggregate.t()
-  def sync_aggregate do
+  def sync_aggregate() do
     %Types.SyncAggregate{
       sync_committee_bits: Random.sync_committee_bits(),
       sync_committee_signature: Random.bls_signature()
@@ -71,7 +71,7 @@ defmodule Fixtures.Block do
   end
 
   @spec execution_payload :: ExecutionPayload.t()
-  def execution_payload do
+  def execution_payload() do
     fields =
       [
         parent_hash: Random.hash32(),
@@ -97,7 +97,7 @@ defmodule Fixtures.Block do
   end
 
   @spec fork :: Types.Fork.t()
-  def fork do
+  def fork() do
     %Types.Fork{
       previous_version: Random.binary(4),
       current_version: Random.binary(4),
@@ -106,7 +106,7 @@ defmodule Fixtures.Block do
   end
 
   @spec beacon_block_header :: Types.BeaconBlockHeader.t()
-  def signed_beacon_block_header do
+  def signed_beacon_block_header() do
     %Types.SignedBeaconBlockHeader{
       message: beacon_block_header(),
       signature: Random.bls_signature()
@@ -114,7 +114,7 @@ defmodule Fixtures.Block do
   end
 
   @spec beacon_block_header :: Types.BeaconBlockHeader.t()
-  def beacon_block_header do
+  def beacon_block_header() do
     %Types.BeaconBlockHeader{
       slot: Random.uint64(),
       proposer_index: Random.uint64(),
@@ -125,7 +125,7 @@ defmodule Fixtures.Block do
   end
 
   @spec checkpoint :: Types.Checkpoint.t()
-  def checkpoint do
+  def checkpoint() do
     %Types.Checkpoint{
       epoch: Random.uint64(),
       root: Random.root()
@@ -133,7 +133,7 @@ defmodule Fixtures.Block do
   end
 
   @spec sync_committee :: Types.SyncCommittee.t()
-  def sync_committee do
+  def sync_committee() do
     %Types.SyncCommittee{
       pubkeys: [],
       aggregate_pubkey: Random.binary(48)
@@ -141,7 +141,7 @@ defmodule Fixtures.Block do
   end
 
   @spec execution_payload_header :: ExecutionPayloadHeader.t()
-  def execution_payload_header do
+  def execution_payload_header() do
     fields =
       [
         parent_hash: Random.binary(32),
@@ -167,7 +167,7 @@ defmodule Fixtures.Block do
   end
 
   @spec beacon_state :: BeaconState.t()
-  def beacon_state do
+  def beacon_state() do
     %BeaconState{
       genesis_time: Random.uint64(),
       genesis_validators_root: Random.root(),

--- a/test/fixtures/utils.ex
+++ b/test/fixtures/utils.ex
@@ -9,37 +9,37 @@ defmodule Fixtures.Random do
   end
 
   @spec hash32 :: binary
-  def hash32 do
+  def hash32() do
     binary(32)
   end
 
   @spec root :: binary
-  def root do
+  def root() do
     binary(32)
   end
 
   @spec bls_signature :: binary
-  def bls_signature do
+  def bls_signature() do
     binary(96)
   end
 
   @spec sync_committee_bits :: binary
-  def sync_committee_bits do
+  def sync_committee_bits() do
     binary(64)
   end
 
   @spec execution_address :: binary
-  def execution_address do
+  def execution_address() do
     binary(20)
   end
 
   @spec uint64 :: pos_integer
-  def uint64 do
+  def uint64() do
     :rand.uniform(2 ** 64 - 1)
   end
 
   @spec uint256 :: pos_integer
-  def uint256 do
+  def uint256() do
     :rand.uniform(2 ** 256 - 1)
   end
 end

--- a/test/spec/meta_utils.ex
+++ b/test/spec/meta_utils.ex
@@ -9,9 +9,9 @@ defmodule Spec.MetaUtils do
   @vector_sub_dirs ["config", "fork", "runner", "handler", "suite", "case"]
   @vector_dir_keys Enum.map(@vector_sub_dirs, &String.to_atom/1)
 
-  def vectors_dir, do: @vectors_dir
-  def runners_dir, do: @runners_dir
-  def generated_dir, do: @generated_dir
+  def vectors_dir(), do: @vectors_dir
+  def runners_dir(), do: @runners_dir
+  def generated_dir(), do: @generated_dir
 
   @doc """
   All SpecTestCases for a filter. The filter might have either of the following keys:
@@ -58,7 +58,7 @@ defmodule Spec.MetaUtils do
   details, only the number of tests that are run or skipped. Partial directories are more
   interesting, as they might have unimplemented cases by oversight.
   """
-  def check_enabled do
+  def check_enabled() do
     {_status, "tests", res} = check_enabled(@vectors_dir, ["root" | @vector_sub_dirs])
     res
   end

--- a/test/spec/runners/helpers/ssz_static_containers/bits_struct.ex
+++ b/test/spec/runners/helpers/ssz_static_containers/bits_struct.ex
@@ -24,7 +24,7 @@ defmodule Helpers.SszStaticContainers.BitsStruct do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:A, {:bitlist, 5}},
       {:B, {:bitvector, 2}},

--- a/test/spec/runners/helpers/ssz_static_containers/complex_test_struct.ex
+++ b/test/spec/runners/helpers/ssz_static_containers/complex_test_struct.ex
@@ -30,7 +30,7 @@ defmodule Helpers.SszStaticContainers.ComplexTestStruct do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:A, {:int, 16}},
       {:B, {:list, {:int, 16}, 128}},

--- a/test/spec/runners/helpers/ssz_static_containers/fixed_test_struct.ex
+++ b/test/spec/runners/helpers/ssz_static_containers/fixed_test_struct.ex
@@ -22,7 +22,7 @@ defmodule Helpers.SszStaticContainers.FixedTestStruct do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:A, {:int, 8}},
       {:B, {:int, 64}},

--- a/test/spec/runners/helpers/ssz_static_containers/single_field_test_struct.ex
+++ b/test/spec/runners/helpers/ssz_static_containers/single_field_test_struct.ex
@@ -16,7 +16,7 @@ defmodule Helpers.SszStaticContainers.SingleFieldTestStruct do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:A, {:int, 8}}
     ]

--- a/test/spec/runners/helpers/ssz_static_containers/small_test_struct.ex
+++ b/test/spec/runners/helpers/ssz_static_containers/small_test_struct.ex
@@ -18,7 +18,7 @@ defmodule Helpers.SszStaticContainers.SmallTestStruct do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:A, {:int, 16}},
       {:B, {:int, 16}}

--- a/test/spec/runners/helpers/ssz_static_containers/var_test_struct.ex
+++ b/test/spec/runners/helpers/ssz_static_containers/var_test_struct.ex
@@ -20,7 +20,7 @@ defmodule Helpers.SszStaticContainers.VarTestStruct do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:A, {:int, 16}},
       {:B, {:list, {:int, 16}, 1024}},

--- a/test/spec/runners/rewards.ex
+++ b/test/spec/runners/rewards.ex
@@ -101,7 +101,7 @@ defmodule Deltas do
         }
 
   @impl LambdaEthereumConsensus.Container
-  def schema do
+  def schema() do
     [
       {:rewards, {:list, {:int, 64}, 1_099_511_627_776}},
       {:penalties, {:list, {:int, 64}, 1_099_511_627_776}}

--- a/test/spec/runners/sync.ex
+++ b/test/spec/runners/sync.ex
@@ -100,7 +100,7 @@ defmodule SyncTestRunner.EngineApiMock do
   end
 
   def get_payload(_payload_id), do: raise("Not implemented")
-  def exchange_capabilities, do: raise("Not implemented")
+  def exchange_capabilities(), do: raise("Not implemented")
   def get_block_header(_block_id), do: raise("Not implemented")
   def get_deposit_logs(_range), do: raise("Not implemented")
 end

--- a/test/spec/utils.ex
+++ b/test/spec/utils.ex
@@ -15,7 +15,7 @@ defmodule SpecTestUtils do
     "current_epoch_participation"
   ]
 
-  def vectors_dir, do: @vectors_dir
+  def vectors_dir(), do: @vectors_dir
 
   @spec sanitize_yaml(any()) :: any()
   def sanitize_yaml(map) when is_map(map) do

--- a/test/unit/libp2p_port_test.exs
+++ b/test/unit/libp2p_port_test.exs
@@ -81,7 +81,7 @@ defmodule Unit.Libp2pPortTest do
     assert_receive {:new_peer, _peer_id}, 10_000
   end
 
-  defp two_hosts_gossip do
+  defp two_hosts_gossip() do
     gossiper_addr = ["/ip4/127.0.0.1/tcp/48766"]
     start_port(:publisher)
     start_port(:gossiper, listen_addr: gossiper_addr)


### PR DESCRIPTION
This PR modifies the credo configuration to make parentheses on 0-arity functions mandatory, and adds them in all cases.