### PR TITLE
fix: switch order between metadata and beacon node processes

### DIFF
--- a/lib/lambda_ethereum_consensus/application.ex
+++ b/lib/lambda_ethereum_consensus/application.ex
@@ -44,8 +44,8 @@ defmodule LambdaEthereumConsensus.Application do
   defp get_children(:full) do
     get_children(:db) ++
       [
-        LambdaEthereumConsensus.Beacon.BeaconNode,
         LambdaEthereumConsensus.P2P.Metadata,
+        LambdaEthereumConsensus.Beacon.BeaconNode,
         BeaconApi.Endpoint
       ]
   end


### PR DESCRIPTION
**Description**

Fixes a race condition where metadata is requested immediately after p2p is initialized, but metadata genserver is not yet ready.