### PR TITLE
feat: add health endpoint

### DIFF
--- a/lib/beacon_api/controllers/v1/node_controller.ex
+++ b/lib/beacon_api/controllers/v1/node_controller.ex
@@ -1,0 +1,18 @@
+defmodule BeaconApi.V1.NodeController do
+  use BeaconApi, :controller
+
+  alias BeaconApi.ApiSpec
+
+  plug(OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true)
+
+  # NOTE: this function is required by OpenApiSpex, and should return the information
+  #  of each specific endpoint. We just return the specific entry from the parsed spec.
+  def open_api_operation(:health),
+    do: ApiSpec.spec().paths["/eth/v1/node/health"].get
+
+  @spec health(Plug.Conn.t(), any) :: Plug.Conn.t()
+  def health(conn, _params) do
+    conn
+    |> send_resp(200, "")
+  end
+end

--- a/lib/beacon_api/controllers/v1/node_controller.ex
+++ b/lib/beacon_api/controllers/v1/node_controller.ex
@@ -11,8 +11,10 @@ defmodule BeaconApi.V1.NodeController do
     do: ApiSpec.spec().paths["/eth/v1/node/health"].get
 
   @spec health(Plug.Conn.t(), any) :: Plug.Conn.t()
-  def health(conn, _params) do
-    conn
-    |> send_resp(200, "")
+  def health(conn, params) do
+    # TODO: respond with syncing status if we're still syncing
+    _syncing_status = Map.get(params, :syncing_status, 206)
+
+    send_resp(conn, 200, "")
   end
 end

--- a/lib/beacon_api/router.ex
+++ b/lib/beacon_api/router.ex
@@ -16,6 +16,10 @@ defmodule BeaconApi.Router do
       get("/blocks/:block_id/root", BeaconController, :get_block_root)
       get("/states/:state_id/finality_checkpoints", BeaconController, :get_finality_checkpoints)
     end
+
+    scope "/node" do
+      get("/health", NodeController, :health)
+    end
   end
 
   # Ethereum API Version 2

--- a/test/unit/beacon_api/beacon_api_v1_test.exs
+++ b/test/unit/beacon_api/beacon_api_v1_test.exs
@@ -144,4 +144,11 @@ defmodule Unit.BeaconApiTest.V1 do
     assert conn.status == 200
     assert conn.resp_body == expected_body
   end
+
+  test "node health" do
+    conn = conn(:get, "/eth/v1/node/health", nil) |> Router.call(@opts)
+    assert conn.state == :sent
+    assert conn.status == 200
+    assert conn.resp_body == ""
+  end
 end


### PR DESCRIPTION
Adds the Beacon API `/eth/v1/node/health` endpoint. It will be used when integrating with kurtosis.