### PR TITLE
fix: add hexpm mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,15 +33,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Elixir
-        # NOTE: this is needed for the NIF header files
-        uses: erlef/setup-beam@v1
-        with:
-          version-type: strict
-          version-file: .tool-versions
-          hexpm-mirrors: |
-            https://builds.hex.pm
-            https://repo.hex.pm
       - name: Set up Go
         # NOTE: this action comes with caching by default
         uses: actions/setup-go@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,9 @@ jobs:
         with:
           version-type: strict
           version-file: .tool-versions
+          hexpm-mirrors: |
+            https://builds.hex.pm
+            https://repo.hex.pm
       - name: Fetch native libraries
         uses: actions/cache/restore@v4
         with:


### PR DESCRIPTION
We're having [this reoccurring error](https://github.com/lambdaclass/lambda_ethereum_consensus/actions/runs/8838463470/job/24269689352?pr=1044). This PR fixes that and removes the unneeded setup-beam step on building the native libraries.