### PR TITLE
fix: config name isn't always a base config

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -80,7 +80,7 @@ config :lambda_ethereum_consensus, LambdaEthereumConsensus.Store.Db, dir: datadi
 {chain_config, bootnodes} =
   case testnet_dir do
     nil ->
-      config = ConfigUtils.parse_config(network)
+      config = ConfigUtils.parse_config!(network)
       bootnodes = YamlElixir.read_from_file!("config/networks/#{network}/boot_enr.yaml")
       {config, bootnodes}
 

--- a/lib/chain_spec/configs/custom.ex
+++ b/lib/chain_spec/configs/custom.ex
@@ -8,11 +8,11 @@ defmodule CustomConfig do
   def load_from_file!(path) do
     config = ConfigUtils.load_config_from_file!(path)
     preset = Map.fetch!(config, "PRESET_BASE") |> ConfigUtils.parse_preset()
-    base_config = Map.fetch!(config, "CONFIG_NAME") |> ConfigUtils.parse_config()
+    config_name = Map.get(config, "CONFIG_NAME") |> ConfigUtils.parse_config()
 
     merged_config =
       preset.get_preset()
-      |> Map.merge(base_config.get_all())
+      |> Map.merge(get_base_config(config_name))
       |> Map.merge(config)
 
     Application.put_env(:lambda_ethereum_consensus, __MODULE__, merged: merged_config)
@@ -37,4 +37,7 @@ defmodule CustomConfig do
   end
 
   defp parse_int(v), do: v
+
+  defp get_base_config(:unknown), do: %{}
+  defp get_base_config(config_name), do: config_name.get_all()
 end

--- a/lib/chain_spec/utils.ex
+++ b/lib/chain_spec/utils.ex
@@ -30,7 +30,13 @@ defmodule ConfigUtils do
   def parse_config("holesky"), do: HoleskyConfig
   def parse_config("minimal"), do: MinimalConfig
   def parse_config("gnosis"), do: GnosisConfig
-  def parse_config(other), do: raise("Unknown config: #{other}")
+  def parse_config(_), do: :unknown
+
+  def parse_config!(config) do
+    with :unknown <- parse_config(config) do
+      raise("Unknown config: #{config}")
+    end
+  end
 
   def parse_preset("mainnet"), do: MainnetPreset
   def parse_preset("minimal"), do: MinimalPreset


### PR DESCRIPTION
The field `CONFIG_NAME` doesn't always refer to an existing base config. In those cases, we should just ignore it.