### PR TITLE
fix: protobuf warnings in container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,5 +17,5 @@ tmp/
 flake.*
 native/**/target/
 Dockerfile
-*.pb.ex
-*.pb.go
+**/*.pb.ex
+**/*.pb.go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
         sudo apt-get install -y protobuf-compiler
         echo $(protoc --version)
         mix escript.install --force hex protobuf
-        protoc --elixir_out=./lib proto/libp2p.proto
+        protoc --elixir_out=. proto/libp2p.proto
         mix deps.get
     - name: Set up cargo cache
       uses: Swatinem/rust-cache@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN mix deps.compile
 COPY . .
 COPY --from=libp2p_builder /libp2p_port/libp2p_port /consensus/priv/native/libp2p_port
 
-RUN protoc --elixir_out=./lib proto/libp2p.proto
+RUN protoc --elixir_out=. proto/libp2p.proto
 
 RUN mix compile
 


### PR DESCRIPTION
When running the docker container, it emits warnings because we're redefining the protobuf-generated structs. This happens due to the output path being different from the repo, along with the `.dockerignore` not correctly ignoring generated files when copying.