### PR TITLE
feat: add support for `pbkdf` in keystore.

### DIFF
--- a/lib/keystore.ex
+++ b/lib/keystore.ex
@@ -62,9 +62,15 @@ defmodule Keystore do
     Scrypt.hash(password, salt, log_n, r, p, @derived_key_size)
   end
 
-  # TODO: support pbkdf2
-  defp derive_key!(%{"function" => "pbkdf2"} = drf, _password) do
-    %{"dklen" => _dklen, "salt" => _salt, "c" => _c, "prf" => "hmac-sha256"} = drf
+  defp derive_key!(%{"function" => "pbkdf2", "params" => params}, password) do
+    %{"dklen" => dklen, "salt" => hex_salt, "c" => c, "prf" => "hmac-sha256"} = params
+    salt = parse_binary!(hex_salt)
+
+    if byte_size(salt) != @salt_bytes do
+      raise "Invalid salt size: #{byte_size(salt)}"
+    end
+
+    :crypto.pbkdf2_hmac(:sha256, password, salt, c, dklen)
   end
 
   defp decrypt_secret(derived_key, iv, cipher_message) do

--- a/test/unit/keystore_test.exs
+++ b/test/unit/keystore_test.exs
@@ -3,6 +3,9 @@ defmodule Unit.KeystoreTest do
 
   @eip_password "testpassword"
   @eip_secret Base.decode16!("000000000019D6689C085AE165831E934FF763AE46A2A6C172B3F1B60A8CE26F")
+  @pubkey Base.decode16!(
+            "9612D7A727C9D0A22E185A1C768478DFE919CADA9266988CB32359C11F2B7B27F4AE4040902382AE2910C15E2B420D07"
+          )
 
   # Taken from lighthouse
   @scrypt_json ~s({
@@ -37,16 +40,53 @@ defmodule Unit.KeystoreTest do
         "version": 4
     })
 
+  # Taken from lighthouse, minus "path": "m/12381/60/0/0",
+  @pbkdf2_json ~s({
+            "crypto": {
+                "kdf": {
+                    "function": "pbkdf2",
+                    "params": {
+                        "dklen": 32,
+                        "c": 262144,
+                        "prf": "hmac-sha256",
+                        "salt": "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
+                    },
+                    "message": ""
+                },
+                "checksum": {
+                    "function": "sha256",
+                    "params": {},
+                    "message": "18b148af8e52920318084560fd766f9d09587b4915258dec0676cba5b0da09d8"
+                },
+                "cipher": {
+                    "function": "aes-128-ctr",
+                    "params": {
+                        "iv": "264daa3f303d7259501c93d997d84fe6"
+                    },
+                    "message": "a9249e0ca7315836356e4c7440361ff22b9fe71e2e2ed34fc1eb03976924ed48"
+                }
+            },
+            "pubkey": "9612d7a727c9d0a22e185a1c768478dfe919cada9266988cb32359c11f2b7b27f4ae4040902382ae2910c15e2b420d07",
+            "uuid": "64625def-3331-4eea-ab6f-782f3ed16a83",
+            "version": 4
+        })
+
   test "eip scrypt test vector" do
     {pubkey, privkey} = Keystore.decode_str!(@scrypt_json, @eip_password)
 
-    expected_pubkey =
-      Base.decode16!(
-        "9612D7A727C9D0A22E185A1C768478DFE919CADA9266988CB32359C11F2B7B27F4AE4040902382AE2910C15E2B420D07"
-      )
+    assert privkey == @eip_secret
+    assert pubkey == @pubkey
+
+    digest = :crypto.hash(:sha256, "test message")
+    {:ok, signature} = Bls.sign(privkey, digest)
+    assert Bls.valid?(pubkey, digest, signature)
+  end
+
+  test "eip pbkdf2 test vector" do
+    {pubkey, privkey} = Keystore.decode_str!(@pbkdf2_json, @eip_password)
 
     assert privkey == @eip_secret
-    assert pubkey == expected_pubkey
+    assert pubkey == @pubkey
 
     digest = :crypto.hash(:sha256, "test message")
     {:ok, signature} = Bls.sign(privkey, digest)


### PR DESCRIPTION
**Motivation**
Validators can send key information in `pbkdf` format