### PR TITLE
fix: trigger pruning on tick

### DIFF
--- a/lib/lambda_ethereum_consensus/store/state_db.ex
+++ b/lib/lambda_ethereum_consensus/store/state_db.ex
@@ -40,7 +40,7 @@ defmodule LambdaEthereumConsensus.Store.StateDb do
            Exleveldb.iterator_move(it, last_finalized_key),
          {:ok, slots_to_remove} <- get_slots_to_remove(it),
          :ok <- Exleveldb.iterator_close(it) do
-      slots_to_remove |> Enum.map(&remove_by_slot/1)
+      slots_to_remove |> Enum.each(&remove_by_slot/1)
       Logger.info("[StateDb] Pruning finished. #{length(slots_to_remove)} slots removed.")
     end
   end
@@ -55,7 +55,7 @@ defmodule LambdaEthereumConsensus.Store.StateDb do
     end
   end
 
-  def remove_by_slot(slot) do
+  defp remove_by_slot(slot) do
     key_slot = root_by_slot_key(slot)
 
     with {:ok, block_root} <- Db.get(key_slot),

--- a/lib/lambda_ethereum_consensus/store/state_db.ex
+++ b/lib/lambda_ethereum_consensus/store/state_db.ex
@@ -31,6 +31,7 @@ defmodule LambdaEthereumConsensus.Store.StateDb do
     Db.put(slothash_key_block, block_root)
   end
 
+  @spec prune_states_older_than(non_neg_integer()) :: :ok | {:error, String.t()} | :not_found
   def prune_states_older_than(slot) do
     Logger.info("[StateDb] Pruning started.", slot: slot)
     last_finalized_key = slot |> root_by_slot_key()
@@ -45,6 +46,7 @@ defmodule LambdaEthereumConsensus.Store.StateDb do
     end
   end
 
+  @spec get_slots_to_remove(list(), :eleveldb.itr_ref()) :: {:ok, list(non_neg_integer())}
   defp get_slots_to_remove(slots_to_remove \\ [], iterator) do
     case Exleveldb.iterator_move(iterator, :prev) do
       {:ok, @stateslot_prefix <> slot, _root} ->
@@ -55,6 +57,7 @@ defmodule LambdaEthereumConsensus.Store.StateDb do
     end
   end
 
+  @spec remove_by_slot(non_neg_integer()) :: :ok | :not_found
   defp remove_by_slot(slot) do
     key_slot = root_by_slot_key(slot)
 


### PR DESCRIPTION
State pruning was not being triggered because checkpoint updates were occurring within the `on_tick` function, while only updates within the `on_block` function had been considered.