### PR TITLE
docs: add supervision tree graph and update the rest of the architecture document

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,13 +119,19 @@ We use the `go-libp2p` library for the networking primitives, which is an implem
 
 ### Subscribing
 
-At the beginning of the application we subscribe a series of handler processes that will react to new gossipsub events.
+At the beginning of the application we subscribe a series of handler processes that will react to new gossipsub events:
+
+- `Gossip.BeaconBlock` will handle topic `/eth2/<context>/beacon_block/ssz_snappy`.
+- `Gossip.BlobSideCar` will subscribe to all blob subnet topics. They're names are of the form `/eth2/<context>/blob_sidecar_<subnet_index>`.
+- `Gossip.OperationsCollector` will subscribe to operations `beacon_aggregate_and_proof` (attestations), `voluntary_exit`, `proposer_slashing`, `attester_slashing`, `bls_to_execution_change`.
+
+This is the process of subscribing, taking the operations collector as an example:
 
 ```mermaid
 sequenceDiagram
 participant sync as SyncBlocks
 participant ops as OperationsCollector
-participant p2p as Libp2pPort <br> (Genserver)
+participant p2p as Libp2pPort <br> (GenServer)
 participant port as Go Libp2p<br>(Port)
 
 ops ->>+ ops: init()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,7 @@ Application --> BeaconNode
 Application --> BeaconApi.Endpoint
 
 BeaconNode -->|genesis_time,<br>genesis_validators_root,<br> fork_choice_data, time| BeaconChain 
-BeaconNode -->|store, head_slot| ForkChoice
+BeaconNode -->|store, head_slot, time| ForkChoice
 BeaconNode -->|listen_addr, <br>enable_discovery, <br> discovery_addr, <br>bootnodes| P2P.Libp2pPort
 BeaconNode --> P2P.Peerbook
 BeaconNode --> P2P.IncomingRequests
@@ -34,7 +34,7 @@ BeaconNode --> BeaconBlock
 BeaconNode --> BlobSideCar
 BeaconNode --> OperationsCollector
 BeaconNode -->|slot, head_root| ValidatorManager
-BeaconNode --> ExecutionChain
+BeaconNode -->|genesis_time, snapshot, votes| ExecutionChain
 ValidatorManager --> ValidatorN
 
 P2P.IncomingRequests --> IncomingRequests.Handler

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -121,6 +121,43 @@ Also, there's a more complex case: we can only include a block in the fork tree 
 
 **TO DO**: document checkpoint sync.
 
+## Processes
+
+In terms of elixir, this is our current supervision tree:
+
+```mermaid
+graph LR
+
+
+Application --> Telemetry
+Application --> DB
+Application --> Blocks
+Application --> BlockStates
+
+
+Application --> Metadata
+Application --> BeaconNode
+Application --> BeaconApi.Endpoint
+
+BeaconNode -->|genesis_time,<br>genesis_validators_root,<br> fork_choice_data, time| BeaconChain 
+BeaconNode -->|store, head_slot| ForkChoice
+BeaconNode -->|listen_addr, <br>enable_discovery, <br> discovery_addr, <br>bootnodes| P2P.Libp2pPort
+BeaconNode --> P2P.Peerbook
+BeaconNode --> P2P.IncomingRequests
+BeaconNode --> PendingBlocks
+BeaconNode --> SyncBlocks
+BeaconNode --> Attestation
+BeaconNode --> BeaconBlock
+BeaconNode --> BlobSideCar
+BeaconNode --> OperationsCollector
+BeaconNode -->|slot, head_root| ValidatorManager
+BeaconNode --> ExecutionChain
+ValidatorManager --> ValidatorN
+
+P2P.IncomingRequests --> IncomingRequests.Handler
+P2P.IncomingRequests --> IncomingRequests.Receiver
+```
+
 ## Next document
 
 Let's go over [Fork Choice](fork_choice.md) to see a theoretical explanation of LMD GHOST.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,6 +158,8 @@ P2P.IncomingRequests --> IncomingRequests.Handler
 P2P.IncomingRequests --> IncomingRequests.Receiver
 ```
 
+Each box is a process. If it has children, it's a supervisor. If not, it's a GenServer, task, or other non-supervisor process. The tags in the edges/arrows are the init args passed on children init (start or restart after crash).
+
 ## Next document
 
 Let's go over [Fork Choice](fork_choice.md) to see a theoretical explanation of LMD GHOST.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,14 +127,16 @@ In terms of elixir, this is our current supervision tree:
 
 ```mermaid
 graph LR
-
+Application[Application <br> <:one_for_one>]
+BeaconNode[BeaconNode <br> <:one_for_all>]
+P2P.IncomingRequests[P2P.IncomingRequests <br> <:one_for_one>]
+ValidatorManager[ValidatorManager <br> <:one_for_one>]
+Telemetry[Telemetry <br> <:one_for_one>]
 
 Application --> Telemetry
 Application --> DB
 Application --> Blocks
 Application --> BlockStates
-
-
 Application --> Metadata
 Application --> BeaconNode
 Application --> BeaconApi.Endpoint
@@ -156,6 +158,9 @@ ValidatorManager --> ValidatorN
 
 P2P.IncomingRequests --> IncomingRequests.Handler
 P2P.IncomingRequests --> IncomingRequests.Receiver
+
+Telemetry --> :telemetry_poller
+Telemetry --> TelemetryMetricsPrometheus
 ```
 
 Each box is a process. If it has children, it's a supervisor. If not, it's a GenServer, task, or other non-supervisor process. The tags in the edges/arrows are the init args passed on children init (start or restart after crash).


### PR DESCRIPTION
**Motivation**

We need to track all supervisors and other processes with their init args, so that we can fix the restart strategies as per #1097