### PR TITLE
refactor: make `pubkey` optional for `decoded_json` in `keystore` in `decode_str!` function

### DIFF
--- a/lib/keystore.ex
+++ b/lib/keystore.ex
@@ -26,10 +26,11 @@ defmodule Keystore do
 
     {:ok, derived_pubkey} = Bls.derive_pubkey(privkey)
 
-    pubkey = case Map.has_key?(decoded_json, "pubkey") do
-      true -> Map.get(decoded_json, "pubkey") |> parse_binary!()
-      false -> derived_pubkey
-    end
+    pubkey =
+      case Map.has_key?(decoded_json, "pubkey") do
+        true -> Map.get(decoded_json, "pubkey") |> parse_binary!()
+        false -> derived_pubkey
+      end
 
     if derived_pubkey != pubkey do
       raise("Keystore secret and public keys don't form a valid pair")

--- a/lib/keystore.ex
+++ b/lib/keystore.ex
@@ -24,9 +24,9 @@ defmodule Keystore do
 
     privkey = decrypt!(decoded_json["crypto"], password)
 
-    pubkey = Map.get(decoded_json, "pubkey") |> parse_binary!()
-
     {:ok, derived_pubkey} = Bls.derive_pubkey(privkey)
+
+    pubkey = Map.get(decoded_json, "pubkey", derived_pubkey) |> parse_binary!()
 
     if derived_pubkey != pubkey do
       raise("Keystore secret and public keys don't form a valid pair")

--- a/lib/keystore.ex
+++ b/lib/keystore.ex
@@ -26,7 +26,10 @@ defmodule Keystore do
 
     {:ok, derived_pubkey} = Bls.derive_pubkey(privkey)
 
-    pubkey = Map.get(decoded_json, "pubkey", derived_pubkey) |> parse_binary!()
+    pubkey = case Map.has_key?(decoded_json, "pubkey") do
+      true -> Map.get(decoded_json, "pubkey") |> parse_binary!()
+      false -> derived_pubkey
+    end
 
     if derived_pubkey != pubkey do
       raise("Keystore secret and public keys don't form a valid pair")

--- a/lib/keystore.ex
+++ b/lib/keystore.ex
@@ -24,7 +24,7 @@ defmodule Keystore do
 
     privkey = decrypt!(decoded_json["crypto"], password)
 
-    pubkey = Map.fetch!(decoded_json, "pubkey") |> parse_binary!()
+    pubkey = Map.get(decoded_json, "pubkey") |> parse_binary!()
 
     {:ok, derived_pubkey} = Bls.derive_pubkey(privkey)
 

--- a/test/unit/keystore_test.exs
+++ b/test/unit/keystore_test.exs
@@ -95,9 +95,9 @@ defmodule Unit.KeystoreTest do
 
   test "eip scrypt without pubkey test vector" do
     scrypt_json =
-        Jason.decode!(@pbkdf2_json)
-        |> Map.delete("pubkey")
-        |> Jason.encode!()
+      Jason.decode!(@pbkdf2_json)
+      |> Map.delete("pubkey")
+      |> Jason.encode!()
 
     {pubkey, privkey} = Keystore.decode_str!(scrypt_json, @eip_password)
 
@@ -111,9 +111,9 @@ defmodule Unit.KeystoreTest do
 
   test "eip pbkdf2 without pubkey test vector" do
     pbkdf2_json =
-        Jason.decode!(@pbkdf2_json)
-        |> Map.delete("pubkey")
-        |> Jason.encode!()
+      Jason.decode!(@pbkdf2_json)
+      |> Map.delete("pubkey")
+      |> Jason.encode!()
 
     {pubkey, privkey} = Keystore.decode_str!(pbkdf2_json, @eip_password)
 

--- a/test/unit/keystore_test.exs
+++ b/test/unit/keystore_test.exs
@@ -94,9 +94,10 @@ defmodule Unit.KeystoreTest do
   end
 
   test "eip scrypt without pubkey test vector" do
-    scrypt_json = Jason.decode!(@pbkdf2_json)
-                    |> Map.delete("pubkey")
-                    |> Jason.encode!(escape: :unicode_safe)
+    scrypt_json =
+        Jason.decode!(@pbkdf2_json)
+        |> Map.delete("pubkey")
+        |> Jason.encode!()
 
     {pubkey, privkey} = Keystore.decode_str!(scrypt_json, @eip_password)
 
@@ -109,9 +110,10 @@ defmodule Unit.KeystoreTest do
   end
 
   test "eip pbkdf2 without pubkey test vector" do
-    pbkdf2_json = Jason.decode!(@pbkdf2_json)
-                    |> Map.delete("pubkey")
-                    |> Jason.encode!()
+    pbkdf2_json =
+        Jason.decode!(@pbkdf2_json)
+        |> Map.delete("pubkey")
+        |> Jason.encode!()
 
     {pubkey, privkey} = Keystore.decode_str!(pbkdf2_json, @eip_password)
 

--- a/test/unit/keystore_test.exs
+++ b/test/unit/keystore_test.exs
@@ -94,9 +94,9 @@ defmodule Unit.KeystoreTest do
   end
 
   test "eip scrypt without pubkey test vector" do
-    decoded_json = Jason.decode!(@scrypt_json)
-    Map.delete(decoded_json, "pubkey")
-    scrypt_json = Jason.encode!(decoded_json)
+    scrypt_json = Jason.decode!(@pbkdf2_json)
+                    |> Map.delete("pubkey")
+                    |> Jason.encode!(escape: :unicode_safe)
 
     {pubkey, privkey} = Keystore.decode_str!(scrypt_json, @eip_password)
 
@@ -109,9 +109,9 @@ defmodule Unit.KeystoreTest do
   end
 
   test "eip pbkdf2 without pubkey test vector" do
-    decoded_json = Jason.decode!(@pbkdf2_json)
-    Map.delete(decoded_json, "pubkey")
-    pbkdf2_json = Jason.encode!(decoded_json)
+    pbkdf2_json = Jason.decode!(@pbkdf2_json)
+                    |> Map.delete("pubkey")
+                    |> Jason.encode!()
 
     {pubkey, privkey} = Keystore.decode_str!(pbkdf2_json, @eip_password)
 

--- a/test/unit/keystore_test.exs
+++ b/test/unit/keystore_test.exs
@@ -92,4 +92,34 @@ defmodule Unit.KeystoreTest do
     {:ok, signature} = Bls.sign(privkey, digest)
     assert Bls.valid?(pubkey, digest, signature)
   end
+
+  test "eip scrypt without pubkey test vector" do
+    decoded_json = Jason.decode!(@scrypt_json)
+    Map.delete(decoded_json, "pubkey")
+    scrypt_json = Jason.encode!(decoded_json)
+
+    {pubkey, privkey} = Keystore.decode_str!(scrypt_json, @eip_password)
+
+    assert privkey == @eip_secret
+    assert pubkey == @pubkey
+
+    digest = :crypto.hash(:sha256, "test message")
+    {:ok, signature} = Bls.sign(privkey, digest)
+    assert Bls.valid?(pubkey, digest, signature)
+  end
+
+  test "eip pbkdf2 without pubkey test vector" do
+    decoded_json = Jason.decode!(@pbkdf2_json)
+    Map.delete(decoded_json, "pubkey")
+    pbkdf2_json = Jason.encode!(decoded_json)
+
+    {pubkey, privkey} = Keystore.decode_str!(pbkdf2_json, @eip_password)
+
+    assert privkey == @eip_secret
+    assert pubkey == @pubkey
+
+    digest = :crypto.hash(:sha256, "test message")
+    {:ok, signature} = Bls.sign(privkey, digest)
+    assert Bls.valid?(pubkey, digest, signature)
+  end
 end


### PR DESCRIPTION
**Motivation**

There is not need to raise exception because of cheking pub keys [further](https://github.com/lambdaclass/lambda_ethereum_consensus/blob/ce09e953fe6fd12407fc0ec7b733e90e13d16b7c/lib/keystore.ex#L31)

**Description**

Change `Map.fetch!(decoded_json, "pubkey") |> parse_binary!()` to 

```Elixir
pubkey =
      case Map.has_key?(decoded_json, "pubkey") do
        true -> Map.get(decoded_json, "pubkey") |> parse_binary!()
        false -> derived_pubkey
      end
```

+some tests added

Resolves #1084

Closes #1084

