### PR TITLE
fix: bug when proposing on slot 1

### DIFF
--- a/lib/lambda_ethereum_consensus/validator/block_builder.ex
+++ b/lib/lambda_ethereum_consensus/validator/block_builder.ex
@@ -104,9 +104,10 @@ defmodule LambdaEthereumConsensus.Validator.BlockBuilder do
 
     head_payload_hash =
       if proposed_slot == 1 do
-        {:ok, %{block_hash: block_hash}} = ExecutionClient.get_block_metadata(0)
-        Logger.info("[Store Setup] Receive head payload hash: #{inspect(block_hash)}")
-        block_hash
+        # The genesis block, does not have the payload_block_hash.
+        with {:ok, %{block_hash: block_hash}} <- ExecutionClient.get_block_metadata(0) do
+          block_hash
+        end
       else
         head_block.body.execution_payload.block_hash
       end

--- a/lib/lambda_ethereum_consensus/validator/block_builder.ex
+++ b/lib/lambda_ethereum_consensus/validator/block_builder.ex
@@ -104,7 +104,7 @@ defmodule LambdaEthereumConsensus.Validator.BlockBuilder do
 
     head_payload_hash =
       if proposed_slot == 1 do
-        # The genesis block, does not have the payload_block_hash.
+        # If the head is the genesis block, fetches the payload_block_hash.
         with {:ok, %{block_hash: block_hash}} <- ExecutionClient.get_block_metadata(0) do
           block_hash
         end

--- a/lib/lambda_ethereum_consensus/validator/block_builder.ex
+++ b/lib/lambda_ethereum_consensus/validator/block_builder.ex
@@ -101,7 +101,15 @@ defmodule LambdaEthereumConsensus.Validator.BlockBuilder do
     # PERF: the state can be cached for the later build_block call
     head_block = Blocks.get_block!(head_root)
     pre_state = BlockStates.get_state!(head_root)
-    head_payload_hash = head_block.body.execution_payload.block_hash
+
+    head_payload_hash =
+      if proposed_slot == 1 do
+        {:ok, %{block_hash: block_hash}} = ExecutionClient.get_block_metadata(0)
+        Logger.info("[Store Setup] Receive head payload hash: #{inspect(block_hash)}")
+        block_hash
+      else
+        head_block.body.execution_payload.block_hash
+      end
 
     with {:ok, mid_state} <- StateTransition.process_slots(pre_state, proposed_slot),
          {:ok, finalized_payload_hash} <- get_finalized_block_hash(mid_state) do


### PR DESCRIPTION
This PR fix a bug when building the block for slot 1.
The genesis block does not store the payload_block_hash and we were trying to access to a "null" value.

<img width="637" alt="image" src="https://github.com/lambdaclass/lambda_ethereum_consensus/assets/72628438/d9a2531f-8233-462a-bb55-4cdef81e2c7e">

Closes #1087 
