### PR TITLE
fix: endpoint not available on GET /health

### DIFF
--- a/lib/lambda_ethereum_consensus/application.ex
+++ b/lib/lambda_ethereum_consensus/application.ex
@@ -44,9 +44,9 @@ defmodule LambdaEthereumConsensus.Application do
   defp get_children(:full) do
     get_children(:db) ++
       [
+        BeaconApi.Endpoint,
         LambdaEthereumConsensus.P2P.Metadata,
-        LambdaEthereumConsensus.Beacon.BeaconNode,
-        BeaconApi.Endpoint
+        LambdaEthereumConsensus.Beacon.BeaconNode
       ]
   end
 


### PR DESCRIPTION
**Motivation**

We had an error when calling GET /health the first couple of times.

**Description**

Just change the order of how the app supervisor children are initialized.

Closes #1094 

