### PR TITLE
refactor: persist forkchoice state

### DIFF
--- a/lib/lambda_ethereum_consensus/fork_choice/fork_choice.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/fork_choice.ex
@@ -230,12 +230,17 @@ defmodule LambdaEthereumConsensus.ForkChoice do
   end
 
   defp persist_fork_choice_store(store) do
-    StoreDb.persist_fork_choice_store(store)
-    Logger.debug("[Fork choice] Store persisted")
+    :telemetry.span([:fork_choice, :persist], %{}, fn ->
+      {StoreDb.persist_fork_choice_store(store), %{}}
+    end)
   end
 
   defp fetch_fork_choice_store!() do
-    {:ok, store} = StoreDb.fetch_fork_choice_store()
+    {:ok, store} =
+      :telemetry.span([:fork_choice, :fetch], %{}, fn ->
+        {StoreDb.fetch_fork_choice_store(), %{}}
+      end)
+
     store
   end
 end

--- a/lib/lambda_ethereum_consensus/store/store_db.ex
+++ b/lib/lambda_ethereum_consensus/store/store_db.ex
@@ -5,23 +5,20 @@ defmodule LambdaEthereumConsensus.Store.StoreDb do
   alias LambdaEthereumConsensus.Store.Db
 
   @store_prefix "store"
-  @fork_choice_store_prefix "fork_choice_store"
   @snapshot_prefix "snapshot"
 
   @spec fetch_store() :: {:ok, Types.Store.t()} | :not_found
-  def fetch_store(), do: get(@store_prefix)
-
-  @spec fetch_fork_choice_store() :: {:ok, Types.Store.t()} | :not_found
-  def fetch_fork_choice_store(), do: get(@fork_choice_store_prefix)
+  def fetch_store() do
+    :telemetry.span([:fork_choice, :fetch], %{}, fn ->
+      {get(@store_prefix), %{}}
+    end)
+  end
 
   @spec persist_store(Types.Store.t()) :: :ok
   def persist_store(%Types.Store{} = store) do
-    put(@store_prefix, store)
-  end
-
-  @spec persist_fork_choice_store(Types.Store.t()) :: :ok
-  def persist_fork_choice_store(%Types.Store{} = store) do
-    put(@fork_choice_store_prefix, store)
+    :telemetry.span([:fork_choice, :persist], %{}, fn ->
+      {put(@store_prefix, store), %{}}
+    end)
   end
 
   @spec fetch_deposits_snapshot() :: {:ok, Types.DepositTreeSnapshot.t()} | :not_found

--- a/lib/lambda_ethereum_consensus/store/store_db.ex
+++ b/lib/lambda_ethereum_consensus/store/store_db.ex
@@ -5,14 +5,23 @@ defmodule LambdaEthereumConsensus.Store.StoreDb do
   alias LambdaEthereumConsensus.Store.Db
 
   @store_prefix "store"
+  @fork_choice_store_prefix "fork_choice_store"
   @snapshot_prefix "snapshot"
 
   @spec fetch_store() :: {:ok, Types.Store.t()} | :not_found
   def fetch_store(), do: get(@store_prefix)
 
+  @spec fetch_fork_choice_store() :: {:ok, Types.Store.t()} | :not_found
+  def fetch_fork_choice_store(), do: get(@fork_choice_store_prefix)
+
   @spec persist_store(Types.Store.t()) :: :ok
   def persist_store(%Types.Store{} = store) do
     put(@store_prefix, store)
+  end
+
+  @spec persist_fork_choice_store(Types.Store.t()) :: :ok
+  def persist_fork_choice_store(%Types.Store{} = store) do
+    put(@fork_choice_store_prefix, store)
   end
 
   @spec fetch_deposits_snapshot() :: {:ok, Types.DepositTreeSnapshot.t()} | :not_found

--- a/lib/lambda_ethereum_consensus/telemetry.ex
+++ b/lib/lambda_ethereum_consensus/telemetry.ex
@@ -122,7 +122,21 @@ defmodule LambdaEthereumConsensus.Telemetry do
       last_value("vm.uptime.total", unit: :millisecond),
 
       # Db Metrics
-      last_value("db.size.total", unit: :byte)
+      last_value("db.size.total", unit: :byte),
+
+      # ForkChoice Metrics
+      last_value("fork_choice.persist.stop.duration",
+        unit: {:native, :millisecond}
+      ),
+      last_value("fork_choice.persist.exception.duration",
+        unit: {:native, :millisecond}
+      ),
+      last_value("fork_choice.fetch.stop.duration",
+        unit: {:native, :millisecond}
+      ),
+      last_value("fork_choice.fetch.exception.duration",
+        unit: {:native, :millisecond}
+      )
     ]
   end
 

--- a/metrics/grafana/provisioning/dashboards/home.json
+++ b/metrics/grafana/provisioning/dashboards/home.json
@@ -133,6 +133,210 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "fork_choice_persist_stop_duration",
+          "range": true,
+          "instant": true,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "legendFormat": "__auto",
+          "useBackend": false,
+          "disableTextWrap": false,
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "hide": false
+        }
+      ],
+      "type": "timeseries",
+      "title": "ForkChoice Persisting Store Duration",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "tooltip": {
+          "mode": "single",
+          "sort": "none",
+          "maxHeight": 600
+        },
+        "legend": {
+          "showLegend": false,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "barAlignment": 0,
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "insertNulls": false,
+            "showPoints": "auto",
+            "pointSize": 1,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
+            "axisBorderShow": false,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "axisCenteredZero": false,
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 80,
+                "color": "red"
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "id": 25
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "fork_choice_fetch_stop_duration",
+          "range": true,
+          "instant": true,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "legendFormat": "__auto",
+          "useBackend": false,
+          "disableTextWrap": false,
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "hide": false
+        }
+      ],
+      "type": "timeseries",
+      "title": "ForkChoice Fetching Store Duration",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "tooltip": {
+          "mode": "single",
+          "sort": "none",
+          "maxHeight": 600
+        },
+        "legend": {
+          "showLegend": false,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "barAlignment": 0,
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "insertNulls": false,
+            "showPoints": "auto",
+            "pointSize": 1,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
+            "axisBorderShow": false,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "axisCenteredZero": false,
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 80,
+                "color": "red"
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "id": 26
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {


### PR DESCRIPTION
**Motivation**

In order to reduce complexity, we need to reduce concurrency as much as possible.

**Description**

This PR removes the use of the `GenServer` state, storing it into the db, taking the first step towards removing the `GenServer` calls.

Additionally, it adds some metrics on store persisting and fetching:
<img width="564" alt="image" src="https://github.com/lambdaclass/lambda_ethereum_consensus/assets/72628438/2ae53a38-f48b-4566-9293-76b27021c72c">


Closes #1116 
Closes #1117 
