### PR TITLE
refactor: cache sequential writes

### DIFF
--- a/bench/block_processing.exs
+++ b/bench/block_processing.exs
@@ -3,9 +3,9 @@ alias LambdaEthereumConsensus.ForkChoice.Handlers
 alias LambdaEthereumConsensus.StateTransition.Cache
 alias LambdaEthereumConsensus.Store
 alias LambdaEthereumConsensus.Store.BlockDb
-alias LambdaEthereumConsensus.Store.BlockDb.BlockInfo
 alias LambdaEthereumConsensus.Store.StateDb
 alias Types.BeaconState
+alias Types.BlockInfo
 alias Types.SignedBeaconBlock
 
 Logger.configure(level: :warning)

--- a/bench/multiple_blocks_processing.exs
+++ b/bench/multiple_blocks_processing.exs
@@ -3,9 +3,9 @@ alias LambdaEthereumConsensus.ForkChoice.Handlers
 alias LambdaEthereumConsensus.StateTransition.Cache
 alias LambdaEthereumConsensus.Store
 alias LambdaEthereumConsensus.Store.BlockDb
-alias LambdaEthereumConsensus.Store.BlockDb.BlockInfo
 alias LambdaEthereumConsensus.Store.StateDb
 alias Types.BeaconState
+alias Types.BlockInfo
 alias Types.SignedBeaconBlock
 
 Logger.configure(level: :warning)

--- a/lib/beacon_api/controllers/v2/beacon_controller.ex
+++ b/lib/beacon_api/controllers/v2/beacon_controller.ex
@@ -5,9 +5,9 @@ defmodule BeaconApi.V2.BeaconController do
   alias BeaconApi.ErrorController
   alias BeaconApi.Utils
   alias LambdaEthereumConsensus.Store.BlockDb
-  alias LambdaEthereumConsensus.Store.BlockDb.BlockInfo
   alias LambdaEthereumConsensus.Store.Blocks
   alias Types
+  alias Types.BlockInfo
 
   plug(OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true)
 

--- a/lib/beacon_api/helpers.ex
+++ b/lib/beacon_api/helpers.ex
@@ -7,6 +7,7 @@ defmodule BeaconApi.Helpers do
   alias LambdaEthereumConsensus.Store.BlockDb
   alias LambdaEthereumConsensus.Store.Blocks
   alias LambdaEthereumConsensus.Store.StateDb
+  alias Types.StateInfo
 
   alias Types.BeaconState
   alias Types.SignedBeaconBlock
@@ -131,7 +132,7 @@ defmodule BeaconApi.Helpers do
     finalized = false
 
     case StateDb.get_state_by_state_root(hex_root) do
-      {:ok, state} -> {:ok, {state, execution_optimistic, finalized}}
+      {:ok, %StateInfo{beacon_state: state}} -> {:ok, {state, execution_optimistic, finalized}}
       _ -> :not_found
     end
   end

--- a/lib/lambda_ethereum_consensus/beacon/beacon_node.ex
+++ b/lib/lambda_ethereum_consensus/beacon/beacon_node.ex
@@ -70,7 +70,7 @@ defmodule LambdaEthereumConsensus.Beacon.BeaconNode do
   end
 
   defp get_validator_children(snapshot, slot, head_root, genesis_time) do
-    %BeaconState{eth1_data_votes: votes} = BlockStates.get_state!(head_root)
+    %BeaconState{eth1_data_votes: votes} = BlockStates.get_state_info!(head_root).beacon_state
     # TODO: move checkpoint sync outside and move this to application.ex
     [
       {ValidatorManager, {slot, head_root}},

--- a/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
+++ b/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
@@ -12,8 +12,8 @@ defmodule LambdaEthereumConsensus.Beacon.PendingBlocks do
   alias LambdaEthereumConsensus.P2P.BlobDownloader
   alias LambdaEthereumConsensus.P2P.BlockDownloader
   alias LambdaEthereumConsensus.Store.BlobDb
-  alias LambdaEthereumConsensus.Store.BlockDb.BlockInfo
   alias LambdaEthereumConsensus.Store.Blocks
+  alias Types.BlockInfo
   alias Types.SignedBeaconBlock
 
   @type block_status :: :pending | :invalid | :download | :download_blobs | :unknown

--- a/lib/lambda_ethereum_consensus/fork_choice/fork_choice.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/fork_choice.ex
@@ -12,12 +12,12 @@ defmodule LambdaEthereumConsensus.ForkChoice do
   alias LambdaEthereumConsensus.P2P.Gossip.OperationsCollector
   alias LambdaEthereumConsensus.Store.BlobDb
   alias LambdaEthereumConsensus.Store.BlockDb
-  alias LambdaEthereumConsensus.Store.BlockDb.BlockInfo
   alias LambdaEthereumConsensus.Store.Blocks
   alias LambdaEthereumConsensus.Store.StateDb
   alias LambdaEthereumConsensus.Store.StoreDb
   alias LambdaEthereumConsensus.Validator.ValidatorManager
   alias Types.Attestation
+  alias Types.BlockInfo
   alias Types.Store
 
   ##########################

--- a/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
@@ -11,9 +11,9 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
   alias LambdaEthereumConsensus.StateTransition.Misc
   alias LambdaEthereumConsensus.StateTransition.Predicates
   alias LambdaEthereumConsensus.Store.BlobDb
-  alias LambdaEthereumConsensus.Store.BlockDb.BlockInfo
   alias LambdaEthereumConsensus.Store.Blocks
   alias LambdaEthereumConsensus.Store.BlockStates
+  alias Types.BlockInfo
 
   alias Types.Attestation
   alias Types.AttestationData
@@ -60,7 +60,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
     %{epoch: finalized_epoch, root: finalized_root} = store.finalized_checkpoint
     finalized_slot = Misc.compute_start_slot_at_epoch(finalized_epoch)
 
-    base_state = BlockStates.get_state(block.parent_root)
+    base_state = BlockStates.get_state_info(block.parent_root)
 
     cond do
       # Parent block must be known
@@ -166,7 +166,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
           attestation_2: %IndexedAttestation{} = attestation_2
         }
       ) do
-    state = BlockStates.get_state!(store.justified_checkpoint.root)
+    state = BlockStates.get_state_info!(store.justified_checkpoint.root).beacon_state
 
     cond do
       not Predicates.slashable_attestation_data?(attestation_1.data, attestation_2.data) ->
@@ -211,7 +211,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
         |> handle_verify_payload_result()
       end)
 
-    with {:ok, state} <- StateTransition.state_transition(state, block_info.signed_block, true),
+    with {:ok, state_info} <- StateTransition.state_transition(state, block_info, true),
          {:ok, _execution_status} <- Task.await(payload_verification_task) do
       seconds_per_slot = ChainSpec.get("SECONDS_PER_SLOT")
       intervals_per_slot = Constants.intervals_per_slot()
@@ -220,7 +220,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
       is_before_attesting_interval = time_into_slot < div(seconds_per_slot, intervals_per_slot)
 
       # Add new block and state to the store
-      BlockStates.store_state(block_info.root, state)
+      BlockStates.store_state_info(state_info)
 
       is_first_block = store.proposer_boost_root == <<0::256>>
       # TODO: store block timeliness data?
@@ -421,7 +421,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
           {:ok, BeaconState.t()} | {:error, String.t()}
   def compute_target_checkpoint_state(target_epoch, target_root) do
     target_slot = Misc.compute_start_slot_at_epoch(target_epoch)
-    state = BlockStates.get_state!(target_root)
+    state = BlockStates.get_state_info!(target_root).beacon_state
 
     if state.slot < target_slot do
       StateTransition.process_slots(state, target_slot)

--- a/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/handlers.ex
@@ -211,7 +211,12 @@ defmodule LambdaEthereumConsensus.ForkChoice.Handlers do
         |> handle_verify_payload_result()
       end)
 
-    with {:ok, state_info} <- StateTransition.state_transition(state_info, block_info, true),
+    with {:ok, state_info} <-
+           StateTransition.state_transition(
+             state_info.beacon_state,
+             block_info.signed_block,
+             true
+           ),
          {:ok, _execution_status} <- Task.await(payload_verification_task) do
       seconds_per_slot = ChainSpec.get("SECONDS_PER_SLOT")
       intervals_per_slot = Constants.intervals_per_slot()

--- a/lib/lambda_ethereum_consensus/fork_choice/head.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/head.ex
@@ -160,7 +160,7 @@ defmodule LambdaEthereumConsensus.ForkChoice.Head do
       store.unrealized_justifications[block_root]
     else
       # The block is not from a prior epoch, therefore the voting source is not pulled up
-      head_state = BlockStates.get_state!(block_root)
+      head_state = BlockStates.get_state_info!(block_root).beacon_state
       head_state.current_justified_checkpoint
     end
   end

--- a/lib/lambda_ethereum_consensus/p2p/incoming_requests/handler.ex
+++ b/lib/lambda_ethereum_consensus/p2p/incoming_requests/handler.ex
@@ -124,7 +124,7 @@ defmodule LambdaEthereumConsensus.P2P.IncomingRequests.Handler do
   defp map_block_result({:ok, block}), do: map_block_result(block)
   defp map_block_result({:error, _}), do: {:error, {2, "Server Error"}}
 
-  alias LambdaEthereumConsensus.Store.BlockDb.BlockInfo
+  alias Types.BlockInfo
 
   defp map_block_result(%BlockInfo{} = block_info),
     do:

--- a/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
@@ -4,7 +4,6 @@ defmodule LambdaEthereumConsensus.StateTransition do
   """
 
   require Logger
-  alias LambdaEthereumConsensus.StateTransition
   alias LambdaEthereumConsensus.StateTransition.EpochProcessing
   alias LambdaEthereumConsensus.StateTransition.Operations
   alias Types.BeaconBlockHeader
@@ -15,16 +14,16 @@ defmodule LambdaEthereumConsensus.StateTransition do
 
   import LambdaEthereumConsensus.Utils, only: [map_ok: 2]
 
-  @spec state_transition(BeaconState.t(), SignedBeaconBlock.t(), boolean()) ::
+  @spec state_transition(StateInfo.t(), BlockInfo.t(), boolean()) ::
           {:ok, StateInfo.t()} | {:error, String.t()}
   def state_transition(
-        %BeaconState{} = state,
+        %StateInfo{} = state_info,
         %BlockInfo{} = block_info,
         validate_result
       ) do
     block = block_info.signed_block.message
 
-    state
+    state_info.beacon_state
     # Process slots (including those with no blocks) since block
     |> process_slots(block.slot)
     # Verify signature

--- a/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
@@ -10,27 +10,26 @@ defmodule LambdaEthereumConsensus.StateTransition do
   alias LambdaEthereumConsensus.StateTransition.Operations
   alias Types.BeaconBlockHeader
   alias Types.BeaconState
-  alias Types.BlockInfo
   alias Types.SignedBeaconBlock
   alias Types.StateInfo
 
   import LambdaEthereumConsensus.Utils, only: [map_ok: 2]
 
-  @spec state_transition(StateInfo.t(), BlockInfo.t(), boolean()) ::
+  @spec state_transition(BeaconState.t(), SignedBeaconBlock.t(), boolean()) ::
           {:ok, StateInfo.t()} | {:error, String.t()}
   def state_transition(
-        %StateInfo{} = state_info,
-        %BlockInfo{} = block_info,
+        beacon_state,
+        signed_block,
         validate_result
       ) do
-    block = block_info.signed_block.message
+    block = signed_block.message
 
-    state_info.beacon_state
+    beacon_state
     # Process slots (including those with no blocks) since block
     |> process_slots(block.slot)
     # Verify signature
     |> map_ok(fn st ->
-      if not validate_result or block_signature_valid?(st, block_info.signed_block) do
+      if not validate_result or block_signature_valid?(st, signed_block) do
         {:ok, st}
       else
         {:error, "invalid block signature"}

--- a/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
@@ -15,38 +15,40 @@ defmodule LambdaEthereumConsensus.StateTransition do
 
   import LambdaEthereumConsensus.Utils, only: [map_ok: 2]
 
-  @spec state_transition(BeaconState.t(), SignedBeaconBlock.t(), boolean()) ::
+  @spec verified_transition(BeaconState.t(), BlockInfo.t()) ::
           {:ok, StateInfo.t()} | {:error, String.t()}
-  def state_transition(
-        beacon_state,
-        signed_block,
-        validate_result
-      ) do
-    block = signed_block.message
-
+  def verified_transition(beacon_state, block_info) do
     beacon_state
-    # Process slots (including those with no blocks) since block
-    |> process_slots(block.slot)
+    |> transition(block_info.signed_block)
     # Verify signature
     |> map_ok(fn st ->
-      if not validate_result or block_signature_valid?(st, signed_block) do
+      if block_signature_valid?(st, block_info.signed_block) do
         {:ok, st}
       else
         {:error, "invalid block signature"}
       end
     end)
-    # Process block
-    |> map_ok(&process_block(&1, block))
-    # Verify state root
     |> map_ok(fn new_state ->
-      with {:ok, state_info} <- StateInfo.from_beacon_state(new_state) do
-        if not validate_result or block.state_root == state_info.root do
+      with {:ok, state_info} <-
+             StateInfo.from_beacon_state(new_state, block_root: block_info.root) do
+        if block_info.signed_block.message.state_root == state_info.root do
           {:ok, state_info}
         else
           {:error, "mismatched state roots"}
         end
       end
     end)
+  end
+
+  @spec transition(BeaconState.t(), SignedBeaconBlock.t()) :: {:ok, BeaconState.t()}
+  def transition(beacon_state, signed_block) do
+    block = signed_block.message
+
+    beacon_state
+    # Process slots (including those with no blocks) since block
+    |> process_slots(block.slot)
+    # Process block
+    |> map_ok(&process_block(&1, block))
   end
 
   def process_slots(%BeaconState{slot: old_slot}, slot) when old_slot >= slot,

--- a/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
@@ -4,7 +4,9 @@ defmodule LambdaEthereumConsensus.StateTransition do
   """
 
   require Logger
+  alias LambdaEthereumConsensus.StateTransition.Accessors
   alias LambdaEthereumConsensus.StateTransition.EpochProcessing
+  alias LambdaEthereumConsensus.StateTransition.Misc
   alias LambdaEthereumConsensus.StateTransition.Operations
   alias Types.BeaconBlockHeader
   alias Types.BeaconState
@@ -123,8 +125,8 @@ defmodule LambdaEthereumConsensus.StateTransition do
 
   def block_signature_valid?(%BeaconState{} = state, %SignedBeaconBlock{} = signed_block) do
     proposer = Aja.Vector.at!(state.validators, signed_block.message.proposer_index)
-    domain = StateTransition.Accessors.get_domain(state, Constants.domain_beacon_proposer())
-    signing_root = StateTransition.Misc.compute_signing_root(signed_block.message, domain)
+    domain = Accessors.get_domain(state, Constants.domain_beacon_proposer())
+    signing_root = Misc.compute_signing_root(signed_block.message, domain)
     Bls.valid?(proposer.pubkey, signing_root, signed_block.signature)
   end
 

--- a/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
@@ -10,6 +10,7 @@ defmodule LambdaEthereumConsensus.StateTransition do
   alias LambdaEthereumConsensus.StateTransition.Operations
   alias Types.BeaconBlockHeader
   alias Types.BeaconState
+  alias Types.BlockInfo
   alias Types.SignedBeaconBlock
   alias Types.StateInfo
 

--- a/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
@@ -39,12 +39,12 @@ defmodule LambdaEthereumConsensus.StateTransition do
     |> map_ok(&process_block(&1, block))
     # Verify state root
     |> map_ok(fn new_state ->
-      state_info = StateInfo.from_beacon_state(new_state)
-
-      if not validate_result or block.state_root == state_info.root do
-        {:ok, state_info}
-      else
-        {:error, "mismatched state roots"}
+      with {:ok, state_info} <- StateInfo.from_beacon_state(new_state) do
+        if not validate_result or block.state_root == state_info.root do
+          {:ok, state_info}
+        else
+          {:error, "mismatched state roots"}
+        end
       end
     end)
   end

--- a/lib/lambda_ethereum_consensus/store/block_states.ex
+++ b/lib/lambda_ethereum_consensus/store/block_states.ex
@@ -4,7 +4,7 @@ defmodule LambdaEthereumConsensus.Store.BlockStates do
   """
   alias LambdaEthereumConsensus.Store.LRUCache
   alias LambdaEthereumConsensus.Store.StateDb
-  alias Types.BeaconState
+  alias Types.StateInfo
 
   @table :states_by_block_hash
   @max_entries 128
@@ -20,7 +20,7 @@ defmodule LambdaEthereumConsensus.Store.BlockStates do
       table: @table,
       max_entries: @max_entries,
       batch_prune_size: @batch_prune_size,
-      store_func: &StateDb.store_state(&2, &1)
+      store_func: fn _k, v -> StateDb.store_state_info(v) end
     )
   end
 
@@ -31,15 +31,15 @@ defmodule LambdaEthereumConsensus.Store.BlockStates do
     }
   end
 
-  @spec store_state(Types.root(), BeaconState.t()) :: :ok
-  def store_state(block_root, state), do: LRUCache.put(@table, block_root, state)
+  @spec store_state_info(StateInfo.t()) :: :ok
+  def store_state_info(state_info), do: LRUCache.put(@table, state_info.root, state_info)
 
-  @spec get_state(Types.root()) :: BeaconState.t() | nil
-  def get_state(block_root), do: LRUCache.get(@table, block_root, &fetch_state/1)
+  @spec get_state_info(Types.root()) :: StateInfo.t() | nil
+  def get_state_info(block_root), do: LRUCache.get(@table, block_root, &fetch_state/1)
 
-  @spec get_state!(Types.root()) :: BeaconState.t()
-  def get_state!(block_root) do
-    case get_state(block_root) do
+  @spec get_state_info!(Types.root()) :: StateInfo.t()
+  def get_state_info!(block_root) do
+    case get_state_info(block_root) do
       nil -> raise "State not found: 0x#{Base.encode16(block_root, case: :lower)}"
       v -> v
     end

--- a/lib/lambda_ethereum_consensus/store/blocks.ex
+++ b/lib/lambda_ethereum_consensus/store/blocks.ex
@@ -3,9 +3,9 @@ defmodule LambdaEthereumConsensus.Store.Blocks do
   Interface to `Store.blocks`.
   """
   alias LambdaEthereumConsensus.Store.BlockDb
-  alias LambdaEthereumConsensus.Store.BlockDb.BlockInfo
   alias LambdaEthereumConsensus.Store.LRUCache
   alias Types.BeaconBlock
+  alias Types.BlockInfo
 
   @table :blocks_by_hash
   @max_entries 512

--- a/lib/lambda_ethereum_consensus/store/lru_cache.ex
+++ b/lib/lambda_ethereum_consensus/store/lru_cache.ex
@@ -4,6 +4,7 @@ defmodule LambdaEthereumConsensus.Store.LRUCache do
   and `LambdaEthereumConsensus.Store.BlockStates`.
   """
   use GenServer
+  require Logger
 
   @default_max_entries 512
   @default_batch_prune_size 32
@@ -33,12 +34,30 @@ defmodule LambdaEthereumConsensus.Store.LRUCache do
 
   @spec put(atom(), key(), value()) :: :ok
   def put(table, key, value) do
-    cache_value(table, key, value)
-    GenServer.cast(table, {:put, key, value})
+    Logger.notice("DEBUG: before call")
+    GenServer.call(table, {:put, key, value})
+    :ok
   end
 
   @spec get(atom(), key(), (key() -> value() | nil)) :: value() | nil
-  def get(table, key, fetch_func), do: lookup(table, key, fetch_func)
+  def get(table, key, fetch_func) do
+    case :ets.lookup_element(table, key, 2, nil) do
+      nil ->
+        # Cache miss.
+        case fetch_func.(key) do
+          nil ->
+            nil
+
+          value ->
+            GenServer.call(table, {:cache_value, key, value})
+            value
+        end
+
+      v ->
+        :ok = GenServer.cast(table, {:touch_entry, key})
+        v
+    end
+  end
 
   ##########################
   ### GenServer Callbacks
@@ -71,15 +90,30 @@ defmodule LambdaEthereumConsensus.Store.LRUCache do
   end
 
   @impl GenServer
-  def handle_cast({:put, key, value}, %{store_func: store} = state) do
+  def handle_call({:put, key, value}, _from, %{store_func: store} = state) do
+    Logger.notice("DEBUG: before store key value")
+
     store.(key, value)
-    handle_cast({:touch_entry, key}, state)
+    Logger.notice("DEBUG: before caching")
+
+    cache_value(state, key, value)
+    Logger.notice("DEBUG: before touch entry")
+
+    touch_entry(key, state)
+    Logger.notice("DEBUG: after touch entry")
+
+    {:reply, :ok, state}
+  end
+
+  @impl GenServer
+  def handle_call({:cache_value, key, value}, _from, state) do
+    cache_value(state, key, value)
+    {:reply, :ok, value}
   end
 
   @impl GenServer
   def handle_cast({:touch_entry, key}, state) do
-    update_ttl(state[:data_table], state[:ttl_table], key)
-    prune_cache(state)
+    touch_entry(key, state)
     {:noreply, state}
   end
 
@@ -87,28 +121,14 @@ defmodule LambdaEthereumConsensus.Store.LRUCache do
   ### Private Functions
   ##########################
 
-  defp lookup(table, key, fetch_func) do
-    case :ets.lookup_element(table, key, 2, nil) do
-      nil ->
-        cache_miss(table, key, fetch_func)
-
-      v ->
-        :ok = GenServer.cast(table, {:touch_entry, key})
-        v
-    end
+  defp touch_entry(key, state) do
+    update_ttl(state[:data_table], state[:ttl_table], key)
+    prune_cache(state)
   end
 
-  defp cache_miss(table, key, fetch_func) do
-    case fetch_func.(key) do
-      nil -> nil
-      value -> cache_value(table, key, value)
-    end
-  end
-
-  defp cache_value(table, key, value) do
-    :ets.insert_new(table, {key, value, nil})
-    GenServer.cast(table, {:touch_entry, key})
-    value
+  defp cache_value(state, key, value) do
+    :ets.insert(state.data_table, {key, value, nil})
+    touch_entry(key, state)
   end
 
   defp update_ttl(data_table, ttl_table, key) do

--- a/lib/lambda_ethereum_consensus/store/lru_cache.ex
+++ b/lib/lambda_ethereum_consensus/store/lru_cache.ex
@@ -34,7 +34,6 @@ defmodule LambdaEthereumConsensus.Store.LRUCache do
 
   @spec put(atom(), key(), value()) :: :ok
   def put(table, key, value) do
-    Logger.notice("DEBUG: before call")
     GenServer.call(table, {:put, key, value})
     :ok
   end
@@ -91,16 +90,11 @@ defmodule LambdaEthereumConsensus.Store.LRUCache do
 
   @impl GenServer
   def handle_call({:put, key, value}, _from, %{store_func: store} = state) do
-    Logger.notice("DEBUG: before store key value")
-
     store.(key, value)
-    Logger.notice("DEBUG: before caching")
 
     cache_value(state, key, value)
-    Logger.notice("DEBUG: before touch entry")
 
     touch_entry(key, state)
-    Logger.notice("DEBUG: after touch entry")
 
     {:reply, :ok, state}
   end

--- a/lib/lambda_ethereum_consensus/store/lru_cache.ex
+++ b/lib/lambda_ethereum_consensus/store/lru_cache.ex
@@ -108,7 +108,7 @@ defmodule LambdaEthereumConsensus.Store.LRUCache do
   @impl GenServer
   def handle_call({:cache_value, key, value}, _from, state) do
     cache_value(state, key, value)
-    {:reply, :ok, value}
+    {:reply, :ok, state}
   end
 
   @impl GenServer

--- a/lib/lambda_ethereum_consensus/store/state_db.ex
+++ b/lib/lambda_ethereum_consensus/store/state_db.ex
@@ -69,21 +69,17 @@ defmodule LambdaEthereumConsensus.Store.StateDb do
 
   @spec get_state_by_block_root(Types.root()) ::
           {:ok, StateInfo.t()} | {:error, String.t()} | :not_found
-  def get_state_by_block_root(root) do
-    get_state(root)
+  def get_state_by_block_root(block_root) do
+    with {:ok, bin} <- block_root |> state_key() |> Db.get() do
+      StateInfo.decode(bin, block_root)
+    end
   end
 
   @spec get_state_by_state_root(Types.root()) ::
           {:ok, StateInfo.t()} | {:error, String.t()} | :not_found
-  def get_state_by_state_root(root) do
-    with {:ok, block_root} <- root |> block_key() |> Db.get() do
-      get_state(block_root)
-    end
-  end
-
-  defp get_state(root) do
-    with {:ok, bin} <- root |> state_key() |> Db.get() do
-      StateInfo.decode(bin, root)
+  def get_state_by_state_root(state_root) do
+    with {:ok, block_root} <- state_root |> block_key() |> Db.get() do
+      get_state_by_block_root(block_root)
     end
   end
 

--- a/lib/lambda_ethereum_consensus/store/state_db.ex
+++ b/lib/lambda_ethereum_consensus/store/state_db.ex
@@ -58,7 +58,7 @@ defmodule LambdaEthereumConsensus.Store.StateDb do
     with {:ok, block_root} <- Db.get(key_slot),
          key_block <- state_key(block_root),
          {:ok, encoded_state} <- Db.get(key_block),
-         {:ok, state_info} = StateInfo.decode(encoded_state, block_root) do
+         {:ok, state_info} <- StateInfo.decode(encoded_state, block_root) do
       key_state = block_key(state_info.root)
 
       Db.delete(key_slot)

--- a/lib/lambda_ethereum_consensus/store/state_db.ex
+++ b/lib/lambda_ethereum_consensus/store/state_db.ex
@@ -6,29 +6,22 @@ defmodule LambdaEthereumConsensus.Store.StateDb do
   alias LambdaEthereumConsensus.Store.Db
   alias LambdaEthereumConsensus.Store.Utils
   alias Types.BeaconState
+  alias Types.StateInfo
 
   @state_prefix "beacon_state"
   @state_block_prefix "beacon_state_by_state"
   @stateslot_prefix @state_prefix <> "slot"
 
-  @spec store_state(BeaconState.t(), Types.root()) :: :ok
-  def store_state(%BeaconState{} = state) do
-    # NOTE: due to how SSZ-hashing works, hash(block) == hash(header)
-    store_state(state, Ssz.hash_tree_root!(state.latest_block_header))
-  end
-
-  def store_state(%BeaconState{} = state, block_root) do
-    state_root = Ssz.hash_tree_root!(state)
-    {:ok, encoded_state} = Ssz.to_ssz(state)
-
-    key_block = state_key(block_root)
-    key_state = block_key(state_root)
-    Db.put(key_block, encoded_state)
-    Db.put(key_state, block_root)
+  @spec store_state_info(StateInfo.t()) :: :ok
+  def store_state_info(%StateInfo{} = state_info) do
+    key_block = state_key(state_info.block_root)
+    key_state = block_key(state_info.root)
+    Db.put(key_block, StateInfo.encode(state_info))
+    Db.put(key_state, state_info.root)
 
     # WARN: this overrides any previous mapping for the same slot
-    slothash_key_block = root_by_slot_key(state.slot)
-    Db.put(slothash_key_block, block_root)
+    slothash_key_block = root_by_slot_key(state_info.beacon_state.slot)
+    Db.put(slothash_key_block, state_info.root)
   end
 
   @spec prune_states_older_than(non_neg_integer()) :: :ok | {:error, String.t()} | :not_found
@@ -64,9 +57,9 @@ defmodule LambdaEthereumConsensus.Store.StateDb do
 
     with {:ok, block_root} <- Db.get(key_slot),
          key_block <- state_key(block_root),
-         {:ok, encoded_state} <- Db.get(key_block) do
-      key_state =
-        encoded_state |> Ssz.from_ssz!(BeaconState) |> Ssz.hash_tree_root!() |> block_key()
+         {:ok, encoded_state} <- Db.get(key_block),
+         {:ok, state_info} = StateInfo.decode(encoded_state, block_root) do
+      key_state = block_key(state_info.root)
 
       Db.delete(key_slot)
       Db.delete(key_block)
@@ -75,13 +68,13 @@ defmodule LambdaEthereumConsensus.Store.StateDb do
   end
 
   @spec get_state_by_block_root(Types.root()) ::
-          {:ok, BeaconState.t()} | {:error, String.t()} | :not_found
+          {:ok, StateInfo.t()} | {:error, String.t()} | :not_found
   def get_state_by_block_root(root) do
     get_state(root)
   end
 
   @spec get_state_by_state_root(Types.root()) ::
-          {:ok, BeaconState.t()} | {:error, String.t()} | :not_found
+          {:ok, StateInfo.t()} | {:error, String.t()} | :not_found
   def get_state_by_state_root(root) do
     with {:ok, block_root} <- root |> block_key() |> Db.get() do
       get_state(block_root)
@@ -90,12 +83,12 @@ defmodule LambdaEthereumConsensus.Store.StateDb do
 
   defp get_state(root) do
     with {:ok, bin} <- root |> state_key() |> Db.get() do
-      Ssz.from_ssz(bin, BeaconState)
+      StateInfo.decode(bin, root)
     end
   end
 
   @spec get_latest_state() ::
-          {:ok, BeaconState.t()} | {:error, String.t()} | :not_found
+          {:ok, StateInfo.t()} | {:error, String.t()} | :not_found
   def get_latest_state() do
     last_key = root_by_slot_key(0xFFFFFFFFFFFFFFFF)
 

--- a/lib/lambda_ethereum_consensus/validator/block_builder.ex
+++ b/lib/lambda_ethereum_consensus/validator/block_builder.ex
@@ -35,7 +35,7 @@ defmodule LambdaEthereumConsensus.Validator.BlockBuilder do
   @spec build_block(LambdaEthereumConsensus.Validator.BuildBlockRequest.t(), payload_id()) ::
           {:ok, {SignedBeaconBlock.t(), BlobSidecar.t()}} | {:error, any()}
   def build_block(%BuildBlockRequest{parent_root: parent_root} = request, payload_id) do
-    pre_state = BlockStates.get_state!(parent_root)
+    pre_state = BlockStates.get_state_info!(parent_root).beacon_state
 
     with {:ok, mid_state} <- StateTransition.process_slots(pre_state, request.slot),
          {:ok, {execution_payload, blobs_bundle}} <- ExecutionClient.get_payload(payload_id),
@@ -100,7 +100,7 @@ defmodule LambdaEthereumConsensus.Validator.BlockBuilder do
   def start_building_payload(proposed_slot, head_root) do
     # PERF: the state can be cached for the later build_block call
     head_block = Blocks.get_block!(head_root)
-    pre_state = BlockStates.get_state!(head_root)
+    pre_state = BlockStates.get_state_info!(head_root).beacon_state
 
     head_payload_data =
       if proposed_slot == 1 do

--- a/lib/lambda_ethereum_consensus/validator/block_builder.ex
+++ b/lib/lambda_ethereum_consensus/validator/block_builder.ex
@@ -140,9 +140,9 @@ defmodule LambdaEthereumConsensus.Validator.BlockBuilder do
   def seal_block(pre_state, block, privkey) do
     wrapped_block = %SignedBeaconBlock{message: block, signature: <<0::768>>}
 
-    with {:ok, post_state} <- StateTransition.state_transition(pre_state, wrapped_block, false) do
-      %BeaconBlock{block | state_root: post_state.root}
-      |> sign_block(post_state.beacon_state, privkey)
+    with {:ok, post_state} <- StateTransition.transition(pre_state, wrapped_block) do
+      %BeaconBlock{block | state_root: Ssz.hash_tree_root!(post_state)}
+      |> sign_block(post_state, privkey)
       |> then(&{:ok, &1})
     end
   end

--- a/lib/lambda_ethereum_consensus/validator/block_builder.ex
+++ b/lib/lambda_ethereum_consensus/validator/block_builder.ex
@@ -141,8 +141,8 @@ defmodule LambdaEthereumConsensus.Validator.BlockBuilder do
     wrapped_block = %SignedBeaconBlock{message: block, signature: <<0::768>>}
 
     with {:ok, post_state} <- StateTransition.state_transition(pre_state, wrapped_block, false) do
-      %BeaconBlock{block | state_root: Ssz.hash_tree_root!(post_state)}
-      |> sign_block(post_state, privkey)
+      %BeaconBlock{block | state_root: post_state.root}
+      |> sign_block(post_state.beacon_state, privkey)
       |> then(&{:ok, &1})
     end
   end

--- a/lib/lambda_ethereum_consensus/validator/validator.ex
+++ b/lib/lambda_ethereum_consensus/validator/validator.ex
@@ -333,7 +333,7 @@ defmodule LambdaEthereumConsensus.Validator do
       slot: slot
     } = duty
 
-    head_state = BlockStates.get_state!(head_root) |> go_to_slot(slot)
+    head_state = BlockStates.get_state_info!(head_root).beacon_state |> go_to_slot(slot)
     head_epoch = Misc.compute_epoch_at_slot(slot)
 
     epoch_boundary_block_root =
@@ -375,7 +375,7 @@ defmodule LambdaEthereumConsensus.Validator do
   end
 
   defp go_to_slot(%{latest_block_header: %{parent_root: parent_root}}, slot) do
-    BlockStates.get_state!(parent_root) |> go_to_slot(slot)
+    BlockStates.get_state_info!(parent_root).beacon_state |> go_to_slot(slot)
   end
 
   @spec fetch_validator_index(Types.BeaconState.t(), %{index: nil, pubkey: Bls.pubkey()}) ::

--- a/lib/types/block_info.ex
+++ b/lib/types/block_info.ex
@@ -1,0 +1,87 @@
+defmodule Types.BlockInfo do
+  @moduledoc """
+  Signed beacon block accompanied with its root and its processing status.
+  Maps to what's saved on the blocks db.
+
+  signed_block field may be nil if it's queued for download.
+  """
+
+  alias Types.SignedBeaconBlock
+
+  @type block_status ::
+          :pending
+          | :invalid
+          | :download
+          | :download_blobs
+          | :unknown
+          | :transitioned
+
+  @type t :: %__MODULE__{
+          root: Types.root(),
+          signed_block: Types.SignedBeaconBlock.t() | nil,
+          status: block_status()
+        }
+  defstruct [:root, :signed_block, :status]
+
+  defguard is_status(atom)
+           when atom in [
+                  :pending,
+                  :invalid,
+                  :processing,
+                  :download,
+                  :download_blobs,
+                  :unknown,
+                  :transitioned
+                ]
+
+  @spec from_block(SignedBeaconBlock.t(), block_status()) :: t()
+  def from_block(signed_block, status \\ :pending) do
+    {:ok, root} = Ssz.hash_tree_root(signed_block.message)
+    from_block(signed_block, root, status)
+  end
+
+  @spec from_block(SignedBeaconBlock.t(), Types.root(), block_status()) :: t()
+  def from_block(signed_block, root, status) do
+    %__MODULE__{root: root, signed_block: signed_block, status: status}
+  end
+
+  @spec change_status(t(), block_status()) :: t()
+  def change_status(%__MODULE__{} = block_info, new_status) when is_status(new_status) do
+    %__MODULE__{block_info | status: new_status}
+  end
+
+  @spec encode(t()) :: {:ok, binary()} | {:error, binary()}
+  def encode(%__MODULE__{} = block_info) do
+    with {:ok, encoded_signed_block} <- encode_signed_block(block_info.signed_block) do
+      {:ok, :erlang.term_to_binary({encoded_signed_block, block_info.status})}
+    end
+  end
+
+  @spec decode(Types.root(), binary()) :: {:error, binary()} | {:ok, t()}
+  def decode(block_root, data) do
+    with {:ok, {encoded_signed_block, status}} <- validate_term(:erlang.binary_to_term(data)),
+         {:ok, signed_block} <- decode_signed_block(encoded_signed_block) do
+      {:ok, %__MODULE__{root: block_root, signed_block: signed_block, status: status}}
+    end
+  end
+
+  defp encode_signed_block(nil), do: {:ok, nil}
+  defp encode_signed_block(%SignedBeaconBlock{} = block), do: Ssz.to_ssz(block)
+
+  defp decode_signed_block(nil), do: {:ok, nil}
+
+  defp decode_signed_block(data) when is_binary(data) do
+    Ssz.from_ssz(data, SignedBeaconBlock)
+  end
+
+  # Validates a term that came out of the first decoding step for a stored block info tuple.
+  defp validate_term({encoded_signed_block, status})
+       when (is_binary(encoded_signed_block) or is_nil(encoded_signed_block)) and
+              is_status(status) do
+    {:ok, {encoded_signed_block, status}}
+  end
+
+  defp validate_term(other) do
+    {:error, "Block decoding failed, decoded term is not the expected tuple: #{other}"}
+  end
+end

--- a/lib/types/state_info.ex
+++ b/lib/types/state_info.ex
@@ -40,7 +40,7 @@ defmodule Types.StateInfo do
     {state_info.encoded, state_info.root} |> :erlang.term_to_binary()
   end
 
-  @spec decode(binary(), Types.root()) :: t()
+  @spec decode(binary(), Types.root()) :: {:ok, t()} | {:error, binary()}
   def decode(bin, block_root) do
     with {:ok, encoded, root} <- :erlang.binary_to_term(bin) |> validate_term(),
          {:ok, beacon_state} <- Ssz.from_ssz(encoded, BeaconState) do
@@ -58,6 +58,7 @@ defmodule Types.StateInfo do
     with :error <- Keyword.fetch(keyword, key), do: fun.()
   end
 
+  @spec validate_term(term()) :: {:ok, binary(), Types.root()} | {:error, binary()}
   defp validate_term({ssz_encoded, root}) when is_binary(ssz_encoded) and is_binary(root) do
     {:ok, ssz_encoded, root}
   end

--- a/lib/types/state_info.ex
+++ b/lib/types/state_info.ex
@@ -17,7 +17,7 @@ defmodule Types.StateInfo do
           block_root: Types.root()
         }
 
-  @spec from_beacon_state(Types.BeaconState.t(), keyword()) :: Types.StateInfo.t()
+  @spec from_beacon_state(Types.BeaconState.t(), keyword()) :: t()
   def from_beacon_state(%BeaconState{} = state, fields \\ []) do
     encoded = Keyword.get_lazy(fields, :encoded, fn -> Ssz.to_ssz(state) end)
 
@@ -36,10 +36,12 @@ defmodule Types.StateInfo do
     %__MODULE__{root: root, beacon_state: state, encoded: encoded, block_root: block_root}
   end
 
+  @spec encode(t()) :: binary()
   def encode(%__MODULE__{} = state_info) do
     {state_info.encoded, state_info.root} |> :erlang.term_to_binary()
   end
 
+  @spec decode(binary(), Types.root()) :: t()
   def decode(bin, block_root) do
     with {:ok, encoded, root} <- :erlang.binary_to_term(bin) |> validate_term(),
          {:ok, beacon_state} <- Ssz.from_ssz(bin, BeaconState) do

--- a/lib/types/state_info.ex
+++ b/lib/types/state_info.ex
@@ -1,0 +1,63 @@
+defmodule Types.StateInfo do
+  @moduledoc """
+  Struct to hold state and metadata for easier db storing:
+  - beacon_state: A beacon state.
+  - root: The hash tree root of the state, so that we don't recalculate it before saving.
+  - encoded: The ssz encoded version of the state. It's common that we save a
+    state after
+  """
+  alias Types.BeaconState
+
+  defstruct [:root, :beacon_state, :encoded, :block_root]
+
+  @type t :: %__MODULE__{
+          beacon_state: Types.BeaconState.t(),
+          root: Types.root(),
+          encoded: binary(),
+          block_root: Types.root()
+        }
+
+  @spec from_beacon_state(Types.BeaconState.t(), keyword()) :: Types.StateInfo.t()
+  def from_beacon_state(%BeaconState{} = state, fields \\ []) do
+    encoded = Keyword.get_lazy(fields, :encoded, fn -> Ssz.to_ssz(state) end)
+
+    block_root =
+      Keyword.get_lazy(fields, :block_root, fn ->
+        # NOTE: due to how SSZ-hashing works, hash(block) == hash(header)
+        Ssz.hash_tree_root(state.latest_block_header)
+      end)
+
+    from_beacon_state(state, encoded, block_root)
+  end
+
+  @spec from_beacon_state(Types.BeaconState.t(), binary(), Types.root()) :: t()
+  def from_beacon_state(%BeaconState{} = state, encoded, block_root) do
+    root = Ssz.hash_tree_root!(state)
+    %__MODULE__{root: root, beacon_state: state, encoded: encoded, block_root: block_root}
+  end
+
+  def encode(%__MODULE__{} = state_info) do
+    {state_info.encoded, state_info.root} |> :erlang.term_to_binary()
+  end
+
+  def decode(bin, block_root) do
+    with {:ok, encoded, root} <- :erlang.binary_to_term(bin) |> validate_term(),
+         {:ok, beacon_state} <- Ssz.from_ssz(bin, BeaconState) do
+      %__MODULE__{
+        beacon_state: beacon_state,
+        root: root,
+        block_root: block_root,
+        encoded: encoded
+      }
+    end
+  end
+
+  defp validate_term({ssz_encoded, root}) when is_binary(ssz_encoded) and is_binary(root) do
+    {:ok, ssz_encoded, root}
+  end
+
+  defp validate_term(other) do
+    {:error,
+     "Error when decoding state info binary. Expected a {binary(), binary()} tuple. Found: #{other}"}
+  end
+end

--- a/lib/types/store.ex
+++ b/lib/types/store.ex
@@ -54,7 +54,7 @@ defmodule Types.Store do
         %SignedBeaconBlock{message: anchor_block} = signed_block
       ) do
     block_info = BlockInfo.from_block(signed_block, :transitioned)
-    state_info = StateInfo.from_beacon_state(anchor_state, block_root: block_info.root)
+    {:ok, state_info} = StateInfo.from_beacon_state(anchor_state, block_root: block_info.root)
     anchor_block_root = block_info.root
     anchor_state_root = state_info.root
 

--- a/test/integration/fork_choice/handlers_test.exs
+++ b/test/integration/fork_choice/handlers_test.exs
@@ -4,10 +4,10 @@ defmodule Integration.ForkChoice.HandlersTest do
   alias LambdaEthereumConsensus.ForkChoice.Handlers
   alias LambdaEthereumConsensus.StateTransition.Cache
   alias LambdaEthereumConsensus.Store.BlockDb
-  alias LambdaEthereumConsensus.Store.BlockDb.BlockInfo
   alias LambdaEthereumConsensus.Store.Blocks
   alias LambdaEthereumConsensus.Store.Db
   alias LambdaEthereumConsensus.Store.StateDb
+  alias Types.BlockInfo
 
   setup_all do
     start_supervised!(Db)

--- a/test/spec/runners/fork_choice.ex
+++ b/test/spec/runners/fork_choice.ex
@@ -9,10 +9,10 @@ defmodule ForkChoiceTestRunner do
   alias LambdaEthereumConsensus.ForkChoice.Handlers
   alias LambdaEthereumConsensus.ForkChoice.Head
   alias LambdaEthereumConsensus.Store.BlobDb
-  alias LambdaEthereumConsensus.Store.BlockDb.BlockInfo
   alias LambdaEthereumConsensus.Store.Blocks
   alias Types.BeaconBlock
   alias Types.BeaconState
+  alias Types.BlockInfo
   alias Types.SignedBeaconBlock
   alias Types.Store
 

--- a/test/spec/runners/helpers/process_blocks.ex
+++ b/test/spec/runners/helpers/process_blocks.ex
@@ -5,6 +5,7 @@ defmodule Helpers.ProcessBlocks do
 
   use ExUnit.CaseTemplate
 
+  alias Types.BlockInfo
   alias LambdaEthereumConsensus.StateTransition
   alias LambdaEthereumConsensus.Utils.Diff
   alias Types.BeaconState
@@ -32,7 +33,7 @@ defmodule Helpers.ProcessBlocks do
     result =
       blocks
       |> Enum.reduce_while({:ok, pre}, fn block, {:ok, state} ->
-        case StateTransition.state_transition(state, block, true) do
+        case StateTransition.verified_transition(state, BlockInfo.from_block(block)) do
           {:ok, post_state} -> {:cont, {:ok, post_state}}
           {:error, error} -> {:halt, {:error, error}}
         end

--- a/test/spec/runners/helpers/process_blocks.ex
+++ b/test/spec/runners/helpers/process_blocks.ex
@@ -5,10 +5,10 @@ defmodule Helpers.ProcessBlocks do
 
   use ExUnit.CaseTemplate
 
-  alias Types.BlockInfo
   alias LambdaEthereumConsensus.StateTransition
   alias LambdaEthereumConsensus.Utils.Diff
   alias Types.BeaconState
+  alias Types.BlockInfo
   alias Types.SignedBeaconBlock
 
   def process_blocks(%SpecTestCase{} = testcase) do
@@ -34,7 +34,7 @@ defmodule Helpers.ProcessBlocks do
       blocks
       |> Enum.reduce_while({:ok, pre}, fn block, {:ok, state} ->
         case StateTransition.verified_transition(state, BlockInfo.from_block(block)) do
-          {:ok, post_state} -> {:cont, {:ok, post_state}}
+          {:ok, post_state} -> {:cont, {:ok, post_state.beacon_state}}
           {:error, error} -> {:halt, {:error, error}}
         end
       end)

--- a/test/unit/beacon_api/beacon_api_v1_test.exs
+++ b/test/unit/beacon_api/beacon_api_v1_test.exs
@@ -7,8 +7,8 @@ defmodule Unit.BeaconApiTest.V1 do
   alias BeaconApi.Utils
   alias LambdaEthereumConsensus.Beacon.BeaconChain
   alias LambdaEthereumConsensus.Store.BlockDb
-  alias LambdaEthereumConsensus.Store.BlockDb.BlockInfo
   alias LambdaEthereumConsensus.Store.Db
+  alias Types.BlockInfo
 
   @moduletag :beacon_api_case
   @moduletag :tmp_dir

--- a/test/unit/beacon_api/beacon_api_v1_test.exs
+++ b/test/unit/beacon_api/beacon_api_v1_test.exs
@@ -131,13 +131,13 @@ defmodule Unit.BeaconApiTest.V1 do
 
   test "get genesis data" do
     expected_response = %{
-        "data" => %{
-          "genesis_time" => BeaconChain.get_genesis_time(),
-          "genesis_validators_root" =>
-            ChainSpec.get_genesis_validators_root() |> Utils.hex_encode(),
-          "genesis_fork_version" => ChainSpec.get("GENESIS_FORK_VERSION") |> Utils.hex_encode()
-        }
+      "data" => %{
+        "genesis_time" => BeaconChain.get_genesis_time(),
+        "genesis_validators_root" =>
+          ChainSpec.get_genesis_validators_root() |> Utils.hex_encode(),
+        "genesis_fork_version" => ChainSpec.get("GENESIS_FORK_VERSION") |> Utils.hex_encode()
       }
+    }
 
     conn = conn(:get, "/eth/v1/beacon/genesis", nil) |> Router.call(@opts)
 
@@ -164,18 +164,18 @@ defmodule Unit.BeaconApiTest.V1 do
     metadata = Metadata.get_metadata()
 
     expected_response = %{
-        "data" => %{
-          "peer_id" => identity[:pretty_peer_id],
-          "enr" => identity[:enr],
-          "p2p_addresses" => identity[:p2p_addresses],
-          "discovery_addresses" => identity[:discovery_addresses],
-          "metadata" => %{
-            "seq_number" => Utils.to_json(metadata.seq_number),
-            "attnets" => Utils.to_json(metadata.attnets),
-            "syncnets" => Utils.to_json(metadata.syncnets)
-          }
+      "data" => %{
+        "peer_id" => identity[:pretty_peer_id],
+        "enr" => identity[:enr],
+        "p2p_addresses" => identity[:p2p_addresses],
+        "discovery_addresses" => identity[:discovery_addresses],
+        "metadata" => %{
+          "seq_number" => Utils.to_json(metadata.seq_number),
+          "attnets" => Utils.to_json(metadata.attnets),
+          "syncnets" => Utils.to_json(metadata.syncnets)
         }
       }
+    }
 
     conn = conn(:get, "/eth/v1/node/identity", nil) |> Router.call(@opts)
     assert conn.state == :sent

--- a/test/unit/beacon_api/beacon_api_v2_test.exs
+++ b/test/unit/beacon_api/beacon_api_v2_test.exs
@@ -5,9 +5,9 @@ defmodule Unit.BeaconApiTest.V2 do
 
   alias BeaconApi.Router
   alias LambdaEthereumConsensus.Store.BlockDb
-  alias LambdaEthereumConsensus.Store.BlockDb.BlockInfo
   alias LambdaEthereumConsensus.Store.Blocks
   alias LambdaEthereumConsensus.Store.Db
+  alias Types.BlockInfo
 
   @moduletag :beacon_api_case
   @moduletag :tmp_dir

--- a/test/unit/beacon_api/beacon_api_v2_test.exs
+++ b/test/unit/beacon_api/beacon_api_v2_test.exs
@@ -5,9 +5,9 @@ defmodule Unit.BeaconApiTest.V2 do
 
   alias BeaconApi.Router
   alias LambdaEthereumConsensus.Store.BlockDb
-  alias Types.BlockInfo
   alias LambdaEthereumConsensus.Store.Blocks
   alias LambdaEthereumConsensus.Store.Db
+  alias Types.BlockInfo
 
   @moduletag :beacon_api_case
   @moduletag :tmp_dir

--- a/test/unit/beacon_api/beacon_api_v2_test.exs
+++ b/test/unit/beacon_api/beacon_api_v2_test.exs
@@ -5,9 +5,9 @@ defmodule Unit.BeaconApiTest.V2 do
 
   alias BeaconApi.Router
   alias LambdaEthereumConsensus.Store.BlockDb
+  alias Types.BlockInfo
   alias LambdaEthereumConsensus.Store.Blocks
   alias LambdaEthereumConsensus.Store.Db
-  alias Types.BlockInfo
 
   @moduletag :beacon_api_case
   @moduletag :tmp_dir

--- a/test/unit/block_states.exs
+++ b/test/unit/block_states.exs
@@ -1,0 +1,54 @@
+defmodule BlockStatesTest do
+  use ExUnit.Case
+
+  alias LambdaEthereumConsensus.Store.BlockStates
+  alias Types.BeaconState
+  alias Types.StateInfo
+
+  setup_all do
+    Application.fetch_env!(:lambda_ethereum_consensus, ChainSpec)
+    |> Keyword.put(:config, MinimalConfig)
+    |> then(&Application.put_env(:lambda_ethereum_consensus, ChainSpec, &1))
+  end
+
+  setup %{tmp_dir: tmp_dir} do
+    Application.fetch_env!(:lambda_ethereum_consensus, ChainSpec)
+    |> Keyword.put(:config, MinimalConfig)
+    |> then(&Application.put_env(:lambda_ethereum_consensus, ChainSpec, &1))
+
+    start_link_supervised!({LambdaEthereumConsensus.Store.Db, dir: tmp_dir})
+    start_link_supervised!(LambdaEthereumConsensus.Store.BlockStates)
+    :ok
+  end
+
+  @tag :tmp_dir
+  test "Encoded field is calculated if not provided" do
+    {encoded, decoded} = get_state()
+
+    {:ok, state_info_1} = StateInfo.from_beacon_state(decoded, encoded: encoded)
+    {:ok, state_info_2} = StateInfo.from_beacon_state(decoded)
+
+    assert state_info_1 == state_info_2
+  end
+
+  @tag :tmp_dir
+  test "Save and load state" do
+    {encoded, decoded} = get_state()
+
+    {:ok, state_info} = StateInfo.from_beacon_state(decoded, encoded: encoded)
+
+    BlockStates.store_state_info(state_info)
+    loaded_state = BlockStates.get_state_info(state_info.block_root)
+
+    assert state_info == loaded_state
+  end
+
+  defp get_state() do
+    {:ok, encoded} =
+      File.read!("test/fixtures/validator/proposer/beacon_state.ssz_snappy")
+      |> :snappyer.decompress()
+
+    {:ok, decoded} = SszEx.decode(encoded, BeaconState)
+    {encoded, decoded}
+  end
+end

--- a/test/unit/blocks.exs
+++ b/test/unit/blocks.exs
@@ -1,0 +1,29 @@
+defmodule BlocksTest do
+  use ExUnit.Case
+  alias Fixtures.Block
+  alias LambdaEthereumConsensus.Store.Blocks
+  alias Types.BeaconBlock
+  alias Types.BlockInfo
+
+  setup %{tmp_dir: tmp_dir} do
+    start_link_supervised!({LambdaEthereumConsensus.Store.Db, dir: tmp_dir})
+    start_link_supervised!(LambdaEthereumConsensus.Store.Blocks)
+    :ok
+  end
+
+  @tag :tmp_dir
+  test "Block info construction correctly calculates the root." do
+    block_info = BlockInfo.from_block(Block.signed_beacon_block())
+
+    assert {:ok, block_info.root} ==
+             Ssz.hash_tree_root(block_info.signed_block.message, BeaconBlock)
+  end
+
+  @tag :tmp_dir
+  test "Basic block saving and loading" do
+    block_info = BlockInfo.from_block(Block.signed_beacon_block())
+    assert Blocks.get_block(block_info.root) == nil
+    Blocks.new_block_info(block_info)
+    assert block_info == Blocks.get_block_info(block_info.root)
+  end
+end

--- a/test/unit/validator/block_builder_test.exs
+++ b/test/unit/validator/block_builder_test.exs
@@ -1,6 +1,7 @@
 defmodule Unit.Validator.BlockBuilderTest do
   @moduledoc false
 
+  alias Types.BlockInfo
   alias LambdaEthereumConsensus.StateTransition
   alias LambdaEthereumConsensus.StateTransition.Predicates
   alias LambdaEthereumConsensus.Validator.BlockBuilder
@@ -61,7 +62,7 @@ defmodule Unit.Validator.BlockBuilderTest do
 
     assert signed_block.signature == spec_block.signature
 
-    assert {:ok, _} = StateTransition.state_transition(pre_state, signed_block, true)
+    assert {:ok, _} = StateTransition.verified_transition(pre_state, BlockInfo.from_block(signed_block))
   end
 
   test "prove commitments" do

--- a/test/unit/validator/block_builder_test.exs
+++ b/test/unit/validator/block_builder_test.exs
@@ -1,13 +1,13 @@
 defmodule Unit.Validator.BlockBuilderTest do
   @moduledoc false
 
-  alias Types.BlockInfo
   alias LambdaEthereumConsensus.StateTransition
   alias LambdaEthereumConsensus.StateTransition.Predicates
   alias LambdaEthereumConsensus.Validator.BlockBuilder
   alias LambdaEthereumConsensus.Validator.BuildBlockRequest
   alias Types.BeaconBlockBody
   alias Types.BeaconState
+  alias Types.BlockInfo
   alias Types.SignedBeaconBlock
 
   use ExUnit.Case
@@ -62,7 +62,8 @@ defmodule Unit.Validator.BlockBuilderTest do
 
     assert signed_block.signature == spec_block.signature
 
-    assert {:ok, _} = StateTransition.verified_transition(pre_state, BlockInfo.from_block(signed_block))
+    assert {:ok, _} =
+             StateTransition.verified_transition(pre_state, BlockInfo.from_block(signed_block))
   end
 
   test "prove commitments" do


### PR DESCRIPTION
Changes:

- Add StateInfo struct/module with the root, block_root, and encoded fields to avoid recalculating them when storing and recovering when loading.
- Separate BlockInfo struct/module as it's growing a lot.

Next steps:

- Make LRU cache writes sequential (calls).

Closes #1133 
