### PR TITLE
refactor: persist Metadata state

### DIFF
--- a/lib/lambda_ethereum_consensus/p2p/metadata.ex
+++ b/lib/lambda_ethereum_consensus/p2p/metadata.ex
@@ -42,27 +42,33 @@ defmodule LambdaEthereumConsensus.P2P.Metadata do
 
   @impl true
   def init(_opts) do
-    {:ok, Metadata.empty()}
+    Metadata.empty() |> Metadata.store_metadata()
+    {:ok, nil}
   end
 
   @impl true
-  def handle_call(:get_seq_number, _, %Metadata{seq_number: seq_number} = metadata) do
-    {:reply, seq_number, metadata}
+  def handle_call(:get_seq_number, _, _state) do
+    %Metadata{seq_number: seq_number} = Metadata.fetch_metadata!()
+    {:reply, seq_number, nil}
   end
 
   @impl true
-  def handle_call(:get_metadata, _, metadata), do: {:reply, metadata, metadata}
+  def handle_call(:get_metadata, _, _metadata), do: {:reply, Metadata.fetch_metadata!(), nil}
 
   @impl true
-  def handle_cast({:set_attestation_subnet, i, set}, metadata) do
+  def handle_cast({:set_attestation_subnet, i, set}, _metadata) do
+    metadata = Metadata.fetch_metadata!()
     attnets = set_or_clear(metadata.attnets, i, set)
-    {:noreply, %{metadata | attnets: attnets} |> increment_seqnum()}
+    %{metadata | attnets: attnets} |> increment_seqnum() |> Metadata.store_metadata()
+    {:noreply, nil}
   end
 
   @impl true
-  def handle_cast({:set_sync_committee, i, set}, metadata) do
+  def handle_cast({:set_sync_committee, i, set}, _metadata) do
+    metadata = Metadata.fetch_metadata!()
     syncnets = set_or_clear(metadata.syncnets, i, set)
-    {:noreply, %{metadata | syncnets: syncnets} |> increment_seqnum()}
+    %{metadata | syncnets: syncnets} |> increment_seqnum() |> Metadata.store_metadata()
+    {:noreply, nil}
   end
 
   ##########################

--- a/test/unit/metadata.exs
+++ b/test/unit/metadata.exs
@@ -1,0 +1,112 @@
+defmodule Unit.AttestationTest do
+  alias LambdaEthereumConsensus.P2P.Metadata
+  alias LambdaEthereumConsensus.Utils.BitVector
+
+  use ExUnit.Case
+
+  doctest Metadata
+
+  setup %{tmp_dir: tmp_dir} do
+    start_link_supervised!({LambdaEthereumConsensus.Store.Db, dir: tmp_dir})
+    start_link_supervised!(Metadata)
+    :ok
+  end
+
+  @tag :tmp_dir
+  test "init metadata" do
+    assert Metadata.get_metadata() == Types.Metadata.empty()
+    assert Metadata.get_seq_number() == 0
+  end
+
+  @tag :tmp_dir
+  test "set and clear attnet" do
+    attnet_index = 5
+
+    expected_attnet =
+      ChainSpec.get("ATTESTATION_SUBNET_COUNT") |> BitVector.new() |> BitVector.set(attnet_index)
+
+    Metadata.set_attnet(attnet_index)
+    new_metadata = Metadata.get_metadata()
+
+    assert new_metadata.attnets == expected_attnet
+    assert new_metadata.seq_number == 1
+
+    Metadata.clear_attnet(5)
+    new_metadata = Metadata.get_metadata()
+
+    expected_attnet =
+      ChainSpec.get("ATTESTATION_SUBNET_COUNT") |> BitVector.new()
+
+    assert new_metadata.attnets == expected_attnet
+    assert new_metadata.seq_number == 2
+  end
+
+  @tag :tmp_dir
+  test "set and clear syncnet" do
+    syncnet_index = 2
+
+    expected_syncnet =
+      Constants.sync_committee_subnet_count() |> BitVector.new() |> BitVector.set(syncnet_index)
+
+    Metadata.set_syncnet(syncnet_index)
+    new_metadata = Metadata.get_metadata()
+
+    assert new_metadata.syncnets == expected_syncnet
+    assert new_metadata.seq_number == 1
+
+    Metadata.clear_syncnet(2)
+    new_metadata = Metadata.get_metadata()
+
+    expected_syncnet =
+      Constants.sync_committee_subnet_count() |> BitVector.new()
+
+    assert new_metadata.syncnets == expected_syncnet
+    assert new_metadata.seq_number == 2
+  end
+
+  @tag :tmp_dir
+  test "syncnet and attnet" do
+    # set attnet
+    attnet_index = 5
+
+    expected_attnet =
+      ChainSpec.get("ATTESTATION_SUBNET_COUNT") |> BitVector.new() |> BitVector.set(attnet_index)
+
+    Metadata.set_attnet(attnet_index)
+
+    # set syncnet
+    syncnet_index = 2
+
+    expected_syncnet =
+      Constants.sync_committee_subnet_count() |> BitVector.new() |> BitVector.set(syncnet_index)
+
+    Metadata.set_syncnet(syncnet_index)
+
+    # check metadata
+    new_metadata = Metadata.get_metadata()
+
+    assert new_metadata.syncnets == expected_syncnet
+    assert new_metadata.attnets == expected_attnet
+    assert new_metadata.seq_number == 2
+
+    # clear syncnet
+    Metadata.clear_syncnet(2)
+    new_metadata = Metadata.get_metadata()
+
+    expected_syncnet =
+      Constants.sync_committee_subnet_count() |> BitVector.new()
+
+    assert new_metadata.syncnets == expected_syncnet
+    assert new_metadata.seq_number == 3
+
+    # clear attnet
+    Metadata.clear_attnet(5)
+    new_metadata = Metadata.get_metadata()
+
+    expected_attnet =
+      ChainSpec.get("ATTESTATION_SUBNET_COUNT") |> BitVector.new()
+
+    assert new_metadata.attnets == expected_attnet
+    assert new_metadata.seq_number == 4
+  end
+end

--- a/test/unit/metadata.exs
+++ b/test/unit/metadata.exs
@@ -22,22 +22,22 @@ defmodule Unit.AttestationTest do
   test "set and clear attnet" do
     attnet_index = 5
 
-    expected_attnet =
+    expected_attnets =
       ChainSpec.get("ATTESTATION_SUBNET_COUNT") |> BitVector.new() |> BitVector.set(attnet_index)
 
     Metadata.set_attnet(attnet_index)
     new_metadata = Metadata.get_metadata()
 
-    assert new_metadata.attnets == expected_attnet
+    assert new_metadata.attnets == expected_attnets
     assert new_metadata.seq_number == 1
 
     Metadata.clear_attnet(5)
     new_metadata = Metadata.get_metadata()
 
-    expected_attnet =
+    expected_attnets =
       ChainSpec.get("ATTESTATION_SUBNET_COUNT") |> BitVector.new()
 
-    assert new_metadata.attnets == expected_attnet
+    assert new_metadata.attnets == expected_attnets
     assert new_metadata.seq_number == 2
   end
 
@@ -45,22 +45,22 @@ defmodule Unit.AttestationTest do
   test "set and clear syncnet" do
     syncnet_index = 2
 
-    expected_syncnet =
+    expected_syncnets =
       Constants.sync_committee_subnet_count() |> BitVector.new() |> BitVector.set(syncnet_index)
 
     Metadata.set_syncnet(syncnet_index)
     new_metadata = Metadata.get_metadata()
 
-    assert new_metadata.syncnets == expected_syncnet
+    assert new_metadata.syncnets == expected_syncnets
     assert new_metadata.seq_number == 1
 
     Metadata.clear_syncnet(2)
     new_metadata = Metadata.get_metadata()
 
-    expected_syncnet =
+    expected_syncnets =
       Constants.sync_committee_subnet_count() |> BitVector.new()
 
-    assert new_metadata.syncnets == expected_syncnet
+    assert new_metadata.syncnets == expected_syncnets
     assert new_metadata.seq_number == 2
   end
 
@@ -69,7 +69,7 @@ defmodule Unit.AttestationTest do
     # set attnet
     attnet_index = 5
 
-    expected_attnet =
+    expected_attnets =
       ChainSpec.get("ATTESTATION_SUBNET_COUNT") |> BitVector.new() |> BitVector.set(attnet_index)
 
     Metadata.set_attnet(attnet_index)
@@ -77,7 +77,7 @@ defmodule Unit.AttestationTest do
     # set syncnet
     syncnet_index = 2
 
-    expected_syncnet =
+    expected_syncnets =
       Constants.sync_committee_subnet_count() |> BitVector.new() |> BitVector.set(syncnet_index)
 
     Metadata.set_syncnet(syncnet_index)
@@ -85,28 +85,30 @@ defmodule Unit.AttestationTest do
     # check metadata
     new_metadata = Metadata.get_metadata()
 
-    assert new_metadata.syncnets == expected_syncnet
-    assert new_metadata.attnets == expected_attnet
+    assert new_metadata.syncnets == expected_syncnets
+    assert new_metadata.attnets == expected_attnets
     assert new_metadata.seq_number == 2
 
     # clear syncnet
     Metadata.clear_syncnet(2)
     new_metadata = Metadata.get_metadata()
 
-    expected_syncnet =
+    expected_syncnets =
       Constants.sync_committee_subnet_count() |> BitVector.new()
 
-    assert new_metadata.syncnets == expected_syncnet
+    assert new_metadata.syncnets == expected_syncnets
+    assert new_metadata.attnets == expected_attnets
     assert new_metadata.seq_number == 3
 
     # clear attnet
     Metadata.clear_attnet(5)
     new_metadata = Metadata.get_metadata()
 
-    expected_attnet =
+    expected_attnets =
       ChainSpec.get("ATTESTATION_SUBNET_COUNT") |> BitVector.new()
 
-    assert new_metadata.attnets == expected_attnet
+    assert new_metadata.attnets == expected_attnets
+    assert new_metadata.syncnets == expected_syncnets
     assert new_metadata.seq_number == 4
   end
 end


### PR DESCRIPTION
This PR persists the `GenServer` state of `Metadata` into the db.

Closes #1155 
