### PR TITLE
refactor: remove GenServer behavior from Metadata

### DIFF
--- a/lib/lambda_ethereum_consensus/application.ex
+++ b/lib/lambda_ethereum_consensus/application.ex
@@ -45,7 +45,6 @@ defmodule LambdaEthereumConsensus.Application do
     get_children(:db) ++
       [
         BeaconApi.Endpoint,
-        LambdaEthereumConsensus.P2P.Metadata,
         LambdaEthereumConsensus.Beacon.BeaconNode
       ]
   end

--- a/lib/lambda_ethereum_consensus/beacon/beacon_node.ex
+++ b/lib/lambda_ethereum_consensus/beacon/beacon_node.ex
@@ -22,6 +22,8 @@ defmodule LambdaEthereumConsensus.Beacon.BeaconNode do
     {store, genesis_validators_root} = StoreSetup.setup!()
     deposit_tree_snapshot = StoreSetup.get_deposit_snapshot!()
 
+    LambdaEthereumConsensus.P2P.Metadata.init()
+
     Cache.initialize_cache()
 
     libp2p_args = get_libp2p_args()

--- a/lib/lambda_ethereum_consensus/p2p/metadata.ex
+++ b/lib/lambda_ethereum_consensus/p2p/metadata.ex
@@ -1,6 +1,6 @@
 defmodule LambdaEthereumConsensus.P2P.Metadata do
   @moduledoc """
-  This module handles node's Metadata (fetch and edit operations).
+  This module handles node's Metadata (fetch and edit).
   """
 
   alias LambdaEthereumConsensus.Store.Db

--- a/lib/types/p2p/metadata.ex
+++ b/lib/types/p2p/metadata.ex
@@ -3,10 +3,8 @@ defmodule Types.Metadata do
   Struct definition for `Metadata`.
   Related definitions in `native/ssz_nif/src/types/`.
   """
-  alias LambdaEthereumConsensus.Store.Db
-  alias LambdaEthereumConsensus.Utils.BitVector
 
-  @metadata_prefix "metadata"
+  alias LambdaEthereumConsensus.Utils.BitVector
 
   fields = [
     :seq_number,
@@ -52,31 +50,5 @@ defmodule Types.Metadata do
     map
     |> Map.update!(:attnets, &BitVector.new(&1, subnet_count))
     |> Map.update!(:syncnets, &BitVector.new(&1, syncnet_count))
-  end
-
-  def store_metadata(%__MODULE__{} = map) do
-    :telemetry.span([:db, :latency], %{}, fn ->
-      {Db.put(
-         @metadata_prefix,
-         :erlang.term_to_binary(map)
-       ), %{module: "metadata", action: "persist"}}
-    end)
-  end
-
-  def fetch_metadata() do
-    result =
-      :telemetry.span([:db, :latency], %{}, fn ->
-        {Db.get(@metadata_prefix), %{module: "metadata", action: "fetch"}}
-      end)
-
-    case result do
-      {:ok, binary} -> {:ok, :erlang.binary_to_term(binary)}
-      :not_found -> result
-    end
-  end
-
-  def fetch_metadata!() do
-    {:ok, metadata} = fetch_metadata()
-    metadata
   end
 end

--- a/test/unit/beacon_api/beacon_api_v1_test.exs
+++ b/test/unit/beacon_api/beacon_api_v1_test.exs
@@ -159,7 +159,7 @@ defmodule Unit.BeaconApiTest.V1 do
     patch(BeaconChain, :get_fork_version, fn -> ChainSpec.get("DENEB_FORK_VERSION") end)
 
     start_link_supervised!(Libp2pPort)
-    start_link_supervised!(Metadata)
+    Metadata.init()
     identity = Libp2pPort.get_node_identity()
     metadata = Metadata.get_metadata()
 

--- a/test/unit/metadata.exs
+++ b/test/unit/metadata.exs
@@ -8,7 +8,7 @@ defmodule Unit.AttestationTest do
 
   setup %{tmp_dir: tmp_dir} do
     start_link_supervised!({LambdaEthereumConsensus.Store.Db, dir: tmp_dir})
-    start_link_supervised!(Metadata)
+    Metadata.init()
     :ok
   end
 


### PR DESCRIPTION
This PR removes all GenServer behavior from Metadata.

Also moves the db calls from `Types.Metadata` to `P2P.Metadata`.

Closes #1158 

