### PR TITLE
refactor: remove GenServer behavior from Peerbook

### DIFF
--- a/lib/lambda_ethereum_consensus/beacon/beacon_node.ex
+++ b/lib/lambda_ethereum_consensus/beacon/beacon_node.ex
@@ -50,7 +50,6 @@ defmodule LambdaEthereumConsensus.Beacon.BeaconNode do
         {LambdaEthereumConsensus.Beacon.BeaconChain,
          {store.genesis_time, genesis_validators_root, fork_choice_data, time}},
         {LambdaEthereumConsensus.Libp2pPort, libp2p_args},
-        LambdaEthereumConsensus.P2P.Peerbook,
         LambdaEthereumConsensus.P2P.IncomingRequests,
         LambdaEthereumConsensus.Beacon.PendingBlocks,
         LambdaEthereumConsensus.Beacon.SyncBlocks,

--- a/lib/lambda_ethereum_consensus/p2p/peerbook.ex
+++ b/lib/lambda_ethereum_consensus/p2p/peerbook.ex
@@ -2,12 +2,10 @@ defmodule LambdaEthereumConsensus.P2P.Peerbook do
   @moduledoc """
   General peer bookkeeping.
   """
-  use GenServer
   alias LambdaEthereumConsensus.Libp2pPort
   alias LambdaEthereumConsensus.Store.KvSchema
 
   @initial_score 100
-  @prune_interval 2000
   @target_peers 128
   @max_prune_size 8
   @prune_percentage 0.05
@@ -32,72 +30,55 @@ defmodule LambdaEthereumConsensus.P2P.Peerbook do
   @spec decode_value(binary()) :: {:ok, map()} | {:error, binary()}
   def decode_value(bin), do: {:ok, :erlang.binary_to_term(bin)}
 
-  def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  @doc """
+    Initializes the table in the db by storing an empty peerbook.
+  """
+  def init() do
+    store_peerbook(%{})
   end
 
   @doc """
   Get some peer from the peerbook.
   """
   def get_some_peer() do
-    GenServer.call(__MODULE__, :get_some_peer)
-  end
-
-  def penalize_peer(peer_id) do
-    GenServer.cast(__MODULE__, {:remove_peer, peer_id})
-  end
-
-  def handle_new_peer(peer_id) do
-    GenServer.cast(__MODULE__, {:new_peer, peer_id})
-  end
-
-  @doc """
-    Initializes the table in the db by storing an empty peerbook.
-  """
-  @impl true
-  def init(_opts) do
-    store_peerbook(%{})
-    schedule_pruning()
-    {:ok, nil}
-  end
-
-  @impl true
-  def handle_call(:get_some_peer, _, map) when map == %{}, do: {:reply, nil, %{}}
-
-  @impl true
-  def handle_call(:get_some_peer, _, _peerbook) do
     # TODO: use some algorithm to pick a good peer, for now it's random
     peerbook = fetch_peerbook!()
 
     if peerbook == %{} do
-      {:reply, nil, nil}
+      nil
     else
       {peer_id, _score} = Enum.random(peerbook)
-      {:reply, peer_id, nil}
+      peer_id
     end
   end
 
-  @impl true
-  def handle_cast({:remove_peer, peer_id}, _peerbook) do
+  def penalize_peer(peer_id) do
     fetch_peerbook!() |> Map.delete(peer_id) |> store_peerbook()
-    {:noreply, nil}
   end
 
-  @impl true
-  def handle_cast({:new_peer, peer_id}, _peerbook) do
+  def handle_new_peer(peer_id) do
     peerbook = fetch_peerbook!()
 
-    if Map.has_key?(peerbook, peer_id) do
-      {:noreply, nil}
-    else
+    if not Map.has_key?(peerbook, peer_id) do
       :telemetry.execute([:peers, :connection], %{id: peer_id}, %{result: "success"})
       Map.put(peerbook, peer_id, @initial_score) |> store_peerbook()
-      {:noreply, nil}
+    end
+
+    prune()
+  end
+
+  def challenge_peer(peer_id) do
+    case Libp2pPort.send_request(peer_id, @metadata_protocol_id, "") do
+      {:ok, <<0, 17>> <> _payload} ->
+        :telemetry.execute([:peers, :challenge], %{}, %{result: "passed"})
+
+      _ ->
+        :telemetry.execute([:peers, :challenge], %{}, %{result: "failed"})
+        penalize_peer(peer_id)
     end
   end
 
-  @impl true
-  def handle_info(:prune, _peerbook) do
+  defp prune() do
     peerbook = fetch_peerbook!()
     len = map_size(peerbook)
 
@@ -117,24 +98,6 @@ defmodule LambdaEthereumConsensus.P2P.Peerbook do
       |> Stream.take(prune_size)
       |> Enum.each(fn peer_id -> Task.start(__MODULE__, :challenge_peer, [peer_id]) end)
     end
-
-    schedule_pruning()
-    {:noreply, nil}
-  end
-
-  def challenge_peer(peer_id) do
-    case Libp2pPort.send_request(peer_id, @metadata_protocol_id, "") do
-      {:ok, <<0, 17>> <> _payload} ->
-        :telemetry.execute([:peers, :challenge], %{}, %{result: "passed"})
-
-      _ ->
-        :telemetry.execute([:peers, :challenge], %{}, %{result: "failed"})
-        penalize_peer(peer_id)
-    end
-  end
-
-  def schedule_pruning(interval \\ @prune_interval) do
-    Process.send_after(__MODULE__, :prune, interval)
   end
 
   defp store_peerbook(peerbook), do: put("", peerbook)

--- a/lib/libp2p_port.ex
+++ b/lib/libp2p_port.ex
@@ -56,7 +56,6 @@ defmodule LambdaEthereumConsensus.Libp2pPort do
           | {:enable_discovery, boolean()}
           | {:discovery_addr, String.t()}
           | {:bootnodes, [String.t()]}
-          | {:new_peer_handler, pid()}
           | {:join_init_topics, boolean()}
 
   ######################

--- a/lib/libp2p_port.ex
+++ b/lib/libp2p_port.ex
@@ -294,6 +294,8 @@ defmodule LambdaEthereumConsensus.Libp2pPort do
 
     if join_init_topics, do: join_init_topics(port)
 
+    Peerbook.init()
+
     {:ok, %{port: port, subscriptors: %{}}}
   end
 

--- a/test/unit/libp2p_port_test.exs
+++ b/test/unit/libp2p_port_test.exs
@@ -8,8 +8,9 @@ defmodule Unit.Libp2pPortTest do
 
   doctest Libp2pPort
 
-  setup do
+  setup %{tmp_dir: tmp_dir} do
     patch(BeaconChain, :get_fork_version, fn -> ChainSpec.get("DENEB_FORK_VERSION") end)
+    start_link_supervised!({LambdaEthereumConsensus.Store.Db, dir: tmp_dir})
     :ok
   end
 
@@ -17,8 +18,10 @@ defmodule Unit.Libp2pPortTest do
     start_link_supervised!({Libp2pPort, [opts: [name: name]] ++ init_args}, id: name)
   end
 
+  @tag :tmp_dir
   test "start port", do: start_port()
 
+  @tag :tmp_dir
   test "start multiple ports" do
     start_port()
     start_port(:host1)
@@ -26,11 +29,13 @@ defmodule Unit.Libp2pPortTest do
     start_port(:host3)
   end
 
+  @tag :tmp_dir
   test "set stream handler" do
     start_port()
     :ok = Libp2pPort.set_handler("/my-app/amazing-protocol/1.0.1")
   end
 
+  @tag :tmp_dir
   test "start two hosts, and play one round of ping-pong" do
     # Setup sender
     start_port(:sender, listen_addr: ["/ip4/127.0.0.1/tcp/48787"])
@@ -82,6 +87,7 @@ defmodule Unit.Libp2pPortTest do
     assert_receive {:new_peer, _peer_id}, 10_000
   end
 
+  @tag :tmp_dir
   defp two_hosts_gossip() do
     gossiper_addr = ["/ip4/127.0.0.1/tcp/48766"]
     start_port(:publisher)
@@ -123,10 +129,12 @@ defmodule Unit.Libp2pPortTest do
       retry_test(f, retries - 1)
   end
 
+  @tag :tmp_dir
   test "start two hosts, and gossip about" do
     retry_test(&two_hosts_gossip/0, 5)
   end
 
+  @tag :tmp_dir
   test "subscribe, leave, and join topic" do
     port = start_port(:some, listen_addr: ["/ip4/127.0.0.1/tcp/48790"])
     topic = "test"
@@ -136,6 +144,7 @@ defmodule Unit.Libp2pPortTest do
     Libp2pPort.join_topic(port, topic)
   end
 
+  @tag :tmp_dir
   test "get node identity" do
     addr = "/ip4/127.0.0.1/tcp/48795"
 


### PR DESCRIPTION
- Replaces all `GenServer` casts and calls with function calls.
- Uses `KvSchema` behavior for db calls.

Closes #1170 

