### PR TITLE
fix: get_blocks_with_status

### DIFF
--- a/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
+++ b/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
@@ -108,9 +108,8 @@ defmodule LambdaEthereumConsensus.Beacon.PendingBlocks do
         end
         |> Enum.each(fn signed_block ->
           signed_block
-          |> BlockInfo.from_block()
-          |> BlockInfo.change_status(:download_blobs)
-          |> Blocks.new_block_info()
+          |> BlockInfo.from_block(:download)
+          |> Blocks.change_status(:download_blobs)
         end)
 
       {:error, reason} ->
@@ -188,8 +187,9 @@ defmodule LambdaEthereumConsensus.Beacon.PendingBlocks do
         case ForkChoice.on_block(block_info) do
           :ok ->
             Blocks.change_status(block_info, :transitioned)
-            # Block is valid. We immediately check if we can process another block.
-            process_blocks()
+
+          # Block is valid. We immediately check if we can process another block.
+          # process_blocks()
 
           {:error, reason} ->
             Logger.error("[PendingBlocks] Saving block as invalid #{reason}",

--- a/test/unit/blocks.exs
+++ b/test/unit/blocks.exs
@@ -13,7 +13,7 @@ defmodule BlocksTest do
 
   @tag :tmp_dir
   test "Block info construction correctly calculates the root." do
-    block_info = BlockInfo.from_block(Block.signed_beacon_block())
+    block_info = new_block_info()
 
     assert {:ok, block_info.root} ==
              Ssz.hash_tree_root(block_info.signed_block.message, BeaconBlock)
@@ -21,7 +21,7 @@ defmodule BlocksTest do
 
   @tag :tmp_dir
   test "Basic block saving and loading" do
-    block_info = BlockInfo.from_block(Block.signed_beacon_block())
+    block_info = new_block_info()
     assert Blocks.get_block(block_info.root) == nil
     Blocks.new_block_info(block_info)
     assert block_info == Blocks.get_block_info(block_info.root)
@@ -30,9 +30,10 @@ defmodule BlocksTest do
   @tag :tmp_dir
   test "Status is updated correctly when changing the status" do
     assert {:ok, []} == Blocks.get_blocks_with_status(:pending)
-    block_info = BlockInfo.from_block(Block.signed_beacon_block())
+    block_info = new_block_info()
 
     Blocks.new_block_info(block_info)
+
     assert {:ok, [block_info]} == Blocks.get_blocks_with_status(:pending)
 
     Blocks.change_status(block_info, :invalid)
@@ -43,10 +44,41 @@ defmodule BlocksTest do
   end
 
   @tag :tmp_dir
+  test "Status change when multiple statuses are present" do
+    block_1 = new_block_info()
+    block_2 = new_block_info()
+    block_3 = new_block_info()
+    Blocks.new_block_info(block_1)
+    Blocks.new_block_info(block_2)
+    Blocks.new_block_info(block_3)
+
+    check_status([block_1, block_2, block_3], :pending)
+
+    Blocks.change_status(block_1, :transitioned)
+    Blocks.change_status(block_2, :download_blobs)
+    check_status([Map.put(block_1, :status, :transitioned)], :transitioned)
+    check_status([Map.put(block_2, :status, :download_blobs)], :download_blobs)
+    check_status([block_3], :pending)
+  end
+
+  @tag :tmp_dir
   test "A nil block can be saved" do
     Blocks.add_block_to_download("some_root")
     {:ok, [block]} = Blocks.get_blocks_with_status(:download)
     assert block == %BlockInfo{status: :download, root: "some_root", signed_block: nil}
     assert Blocks.get_block_info("some_root").signed_block == nil
+  end
+
+  defp new_block_info() do
+    Block.signed_beacon_block() |> BlockInfo.from_block()
+  end
+
+  defp check_status(blocks, status) do
+    {:ok, loaded_blocks} = Blocks.get_blocks_with_status(status)
+    assert sort_by_slot(loaded_blocks) == sort_by_slot(blocks)
+  end
+
+  defp sort_by_slot(blocks) do
+    Enum.sort_by(blocks, fn b -> b.signed_block.message.slot end)
   end
 end

--- a/test/unit/pending_blocks.exs
+++ b/test/unit/pending_blocks.exs
@@ -1,0 +1,55 @@
+defmodule PendingBlocksTest do
+  use ExUnit.Case
+  alias Fixtures.Block
+  alias LambdaEthereumConsensus.Beacon.PendingBlocks
+  alias LambdaEthereumConsensus.P2P.BlockDownloader
+  alias LambdaEthereumConsensus.Store.Blocks
+  alias Types.BlockInfo
+
+  use Patch
+
+  setup %{tmp_dir: tmp_dir} do
+    start_link_supervised!({LambdaEthereumConsensus.Store.Db, dir: tmp_dir})
+    start_link_supervised!(LambdaEthereumConsensus.Store.Blocks)
+    start_link_supervised!(LambdaEthereumConsensus.Beacon.PendingBlocks)
+    :ok
+  end
+
+  defp new_block_info() do
+    Block.signed_beacon_block() |> BlockInfo.from_block()
+  end
+
+  @tag :tmp_dir
+  test "Download blocks" do
+    block_info = new_block_info()
+    Blocks.add_block_to_download(block_info.root)
+
+    assert Blocks.get_blocks_with_status(:download) ==
+             {:ok,
+              [
+                %BlockInfo{
+                  root: block_info.root,
+                  status: :download,
+                  signed_block: nil
+                }
+              ]}
+
+    patch(BlockDownloader, :request_blocks_by_root, fn root ->
+      if root == [block_info.root] do
+        {:ok, [block_info.signed_block]}
+      else
+        {:error, nil}
+      end
+    end)
+
+    Process.send(PendingBlocks, :download_blocks, [])
+
+    # Waits for the block to be downloaded
+    Process.sleep(100)
+
+    expected_block_info = BlockInfo.change_status(block_info, :download_blobs)
+
+    assert Blocks.get_blocks_with_status(:download) == {:ok, []}
+    assert Blocks.get_blocks_with_status(:download_blobs) == {:ok, [expected_block_info]}
+  end
+end

--- a/test/unit/pending_blocks.exs
+++ b/test/unit/pending_blocks.exs
@@ -62,9 +62,9 @@ defmodule PendingBlocksTest do
     rescue
       e in AssertionError ->
         if retries <= 0 do
-          raise e
+          reraise e, __STACKTRACE__
         else
-          assert_retry(delay_milliseconds, retries, assertion)
+          assert_retry(delay_milliseconds, retries - 1, assertion)
         end
     end
   end


### PR DESCRIPTION
Changes `PendingBlocks` to update the root of the block from `:download` to `:download_blobs` once downloaded.
Closes #1174 
