### PR TITLE
docs: add execution section in architecture document

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -298,7 +298,7 @@ The consensus node does not live in isolation. It communicates to the execution 
 Aside from payload validation and block building, there's a bit more information we need from the execution client:
 
 - Deposits: transactions to the deposit contract are processed by the execution client and held in logs. We can `get_deposit_logs(block_range)` to get those. We save those in a deposit tree, which is used to transmit the deposits cheaply to syncing nodes (sending deposit snapshots, see [EIP-4881](https://eips.ethereum.org/EIPS/eip-4881)).
-- eth1_vote: 
+- Eth1 vote: the ultimate goal in consensus is not only to chose the right fork, but also to agree on what that head beacon block refers to in the execution chain. We summarize the execution state in `Eth1Data`, a container with the deposit root, deposit amount, and execution block hash. In the current beacon state we save the current eth1 data, and a history of the last N ones.
 
 ## Checkpoint sync
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -288,6 +288,14 @@ In the proposing slot:
 
 ## Execution Chain
 
+The consensus node needs to communicate with the execution client for three different reasons:
+
+- Fork choice updates: the execution clients needs notifications when the head is updated, and payloads need validation. For these goals, `engineAPI` is used.
+- Deposit contract tracking: accounts that wish to become validators need to deposit 32ETH in the deposit contract. This happens in the execution chain, but the information needs to arrive to consensus for the validator set to be updated.
+- Eth 1 votes: consensus nodes agree on a summary of the execution state and a voting mechanism is built for this.
+
+Let's go to this communication sections one by one.
+
 ### Engine API: fork choice updates
 
 The consensus node does not live in isolation. It communicates to the execution client. We implemented, in the `ExecutionClient` module, the following primitives:
@@ -298,8 +306,6 @@ The consensus node does not live in isolation. It communicates to the execution 
 - `notify_new_payload(execution_payload, versioned_hashes, parent_beacon_block_root)`: when the execution client gets a new block, it needs to check if the execution payload is valid. This method is used to send that payload for verification. It may return valid, invalid, or syncing, in the case where the execution client is not yet synced.
 
 ### Deposit contract
-
-Aside from sending the latest fork choice updates and payloads for validation, the consensus layer has two more needs regarding execution: tracking the deposit contract and voting on their view of the eth1 chain.
 
 Each time there's a deposit, a log is included in the execution block that can be read by the consensus layer using the `get_deposit_logs(range)` function for this.
 


### PR DESCRIPTION
Adds execution chain section for architecture document. Includes:

- EngineAPI interactions: fork choice updates and payload validation.
- DepositContract tracking.
- Eth1Data vote.