### PR TITLE
refactor: make BlockBySlot its own KvSchema

### DIFF
--- a/lib/beacon_api/controllers/v1/beacon_controller.ex
+++ b/lib/beacon_api/controllers/v1/beacon_controller.ex
@@ -5,7 +5,7 @@ defmodule BeaconApi.V1.BeaconController do
   alias BeaconApi.ErrorController
   alias BeaconApi.Helpers
   alias BeaconApi.Utils
-  alias LambdaEthereumConsensus.Store.BlockDb
+  alias LambdaEthereumConsensus.Store.BlockBySlot
   alias LambdaEthereumConsensus.Store.Blocks
   alias LambdaEthereumConsensus.Store.StoreDb
 
@@ -94,7 +94,7 @@ defmodule BeaconApi.V1.BeaconController do
 
   def get_block_root(conn, %{block_id: block_id}) do
     with {slot, ""} when slot >= 0 <- Integer.parse(block_id),
-         {:ok, block_root} <- BlockDb.get_block_root_by_slot(slot) do
+         {:ok, block_root} <- BlockBySlot.get(slot) do
       conn |> root_response(block_root, true, false)
     else
       :not_found ->

--- a/lib/beacon_api/helpers.ex
+++ b/lib/beacon_api/helpers.ex
@@ -8,10 +8,11 @@ defmodule BeaconApi.Helpers do
   alias LambdaEthereumConsensus.Store.BlockDb
   alias LambdaEthereumConsensus.Store.Blocks
   alias LambdaEthereumConsensus.Store.StateDb
-  alias Types.StateInfo
-
   alias Types.BeaconState
   alias Types.SignedBeaconBlock
+  alias Types.StateInfo
+
+  import Types.Guards
 
   @type named_root() :: :genesis | :justified | :finalized | :head
   @type block_id() :: named_root() | :invalid_id | Types.slot() | Types.root()
@@ -79,11 +80,14 @@ defmodule BeaconApi.Helpers do
 
   def block_root_by_block_id(slot) when is_integer(slot) do
     with :ok <- check_valid_slot(slot, ForkChoice.get_current_chain_slot()),
-         {:ok, root} <- BlockBySlot.get(slot) do
+         {:ok, root} when is_root(root) <- BlockBySlot.get(slot) do
       # TODO compute is_optimistic_or_invalid() and is_finalized()
       execution_optimistic = true
       finalized = false
       {:ok, {root, execution_optimistic, finalized}}
+    else
+      {:ok, :empty_slot} -> :empty_slot
+      other -> other
     end
   end
 

--- a/lib/beacon_api/helpers.ex
+++ b/lib/beacon_api/helpers.ex
@@ -4,6 +4,7 @@ defmodule BeaconApi.Helpers do
   """
 
   alias LambdaEthereumConsensus.ForkChoice
+  alias LambdaEthereumConsensus.Store.BlockBySlot
   alias LambdaEthereumConsensus.Store.BlockDb
   alias LambdaEthereumConsensus.Store.Blocks
   alias LambdaEthereumConsensus.Store.StateDb
@@ -78,7 +79,7 @@ defmodule BeaconApi.Helpers do
 
   def block_root_by_block_id(slot) when is_integer(slot) do
     with :ok <- check_valid_slot(slot, ForkChoice.get_current_chain_slot()),
-         {:ok, root} <- BlockDb.get_block_root_by_slot(slot) do
+         {:ok, root} <- BlockBySlot.get(slot) do
       # TODO compute is_optimistic_or_invalid() and is_finalized()
       execution_optimistic = true
       finalized = false

--- a/lib/lambda_ethereum_consensus/store/block_by_slot.ex
+++ b/lib/lambda_ethereum_consensus/store/block_by_slot.ex
@@ -1,4 +1,11 @@
 defmodule LambdaEthereumConsensus.Store.BlockBySlot do
+  @moduledoc """
+  KvSchema that stores block roots indexed by slot. As we store blocks by their root, this module
+  acts as an index if we need to look for them using their root. Some use cases are block pruning
+  (removing all blocks prior to a slot) or checking if a range of slots contain blocks, for
+  checkpoint sync checks.
+  """
+
   alias LambdaEthereumConsensus.Store.KvSchema
   use KvSchema, prefix: "blockSlot"
   @type value_t :: Types.root() | <<>>

--- a/lib/lambda_ethereum_consensus/store/block_by_slot.ex
+++ b/lib/lambda_ethereum_consensus/store/block_by_slot.ex
@@ -1,0 +1,64 @@
+defmodule LambdaEthereumConsensus.Store.BlockBySlot do
+  alias LambdaEthereumConsensus.Store.KvSchema
+  use KvSchema, prefix: "blockSlot"
+  @type value_t :: Types.root() | <<>>
+
+  ################################
+  ### PUBLIC API
+  ################################
+
+  @doc """
+  Checks if all the blocks between first_slot and last_slot are present in the db.
+  This iterates through the db checking each one individually, although it only checks
+  the keys, so it doesn't need to decode the values, making it a relatively cheap
+  linear O(last_slot - first_slot) operation.
+  """
+  @spec all_present?(Types.slot(), Types.slot()) :: boolean()
+  def all_present?(first_slot, last_slot) do
+    fold_keys(last_slot, MapSet.new(), fn slot, set -> MapSet.put(set, slot) end,
+      include_first: true
+    )
+    |> case do
+      {:ok, available} ->
+        Enum.all?(first_slot..last_slot, fn slot -> slot in available end)
+
+      {:error, :invalid_iterator} ->
+        false
+
+      {:error, "Failed to start iterator for table" <> _} ->
+        false
+    end
+  end
+
+  ################################
+  ### Schema implementation
+  ################################
+
+  @impl KvSchema
+  @spec encode_key(Types.slot()) :: {:ok, binary()} | {:error, binary()}
+  def encode_key(slot), do: {:ok, <<slot::64>>}
+
+  @impl KvSchema
+  @spec decode_key(binary()) :: {:ok, integer()} | {:error, binary()}
+  def decode_key(<<slot::64>>), do: {:ok, slot}
+
+  def decode_key(other) do
+    {:error, "[Block by slot] Could not decode slot, not 64 bit integer: #{other}"}
+  end
+
+  @impl KvSchema
+  @spec encode_value(value_t()) :: {:ok, value_t()} | {:error, binary()}
+  def encode_value(root), do: check_root("Encoding", root)
+
+  @impl KvSchema
+  @spec decode_value(value_t()) :: {:ok, value_t()} | {:error, binary()}
+  def decode_value(root), do: check_root("Decoding", root)
+
+  ################################
+  ### Private functions
+  ################################
+
+  defp check_root(_op, <<>>), do: {:ok, <<>>}
+  defp check_root(_op, <<_::256>> = root), do: {:ok, root}
+  defp check_root(op, other), do: {:error, "[Block by slot] #{op} error. Invalid root: #{other}"}
+end

--- a/lib/lambda_ethereum_consensus/store/block_by_slot.ex
+++ b/lib/lambda_ethereum_consensus/store/block_by_slot.ex
@@ -8,7 +8,7 @@ defmodule LambdaEthereumConsensus.Store.BlockBySlot do
 
   alias LambdaEthereumConsensus.Store.KvSchema
   use KvSchema, prefix: "blockSlot"
-  @type value_t :: Types.root() | <<>>
+  @type value_t :: Types.root() | :empty_slot
 
   ################################
   ### PUBLIC API
@@ -55,17 +55,11 @@ defmodule LambdaEthereumConsensus.Store.BlockBySlot do
 
   @impl KvSchema
   @spec encode_value(value_t()) :: {:ok, value_t()} | {:error, binary()}
-  def encode_value(root), do: check_root("Encoding", root)
+  def encode_value(:empty_slot), do: {:ok, <<>>}
+  def encode_value(<<_::256>> = root), do: {:ok, root}
 
   @impl KvSchema
   @spec decode_value(value_t()) :: {:ok, value_t()} | {:error, binary()}
-  def decode_value(root), do: check_root("Decoding", root)
-
-  ################################
-  ### Private functions
-  ################################
-
-  defp check_root(_op, <<>>), do: {:ok, <<>>}
-  defp check_root(_op, <<_::256>> = root), do: {:ok, root}
-  defp check_root(op, other), do: {:error, "[Block by slot] #{op} error. Invalid root: #{other}"}
+  def decode_value(<<>>), do: {:ok, :empty_slot}
+  def decode_value(<<_::256>> = root), do: {:ok, root}
 end

--- a/lib/lambda_ethereum_consensus/store/checkpoint_states_db.ex
+++ b/lib/lambda_ethereum_consensus/store/checkpoint_states_db.ex
@@ -76,7 +76,7 @@ defmodule LambdaEthereumConsensus.Store.CheckpointStates do
   def prune(finalized_checkpoint) do
     Logger.debug("Pruning old checkpoint states")
 
-    case fold(finalized_checkpoint, 0, fn key, acc ->
+    case fold_keys(finalized_checkpoint, 0, fn key, acc ->
            delete(key)
            acc + 1
          end) do

--- a/lib/lambda_ethereum_consensus/store/kv_schema.ex
+++ b/lib/lambda_ethereum_consensus/store/kv_schema.ex
@@ -56,18 +56,30 @@ defmodule LambdaEthereumConsensus.Store.KvSchema do
         end)
       end
 
-      @spec fold(key(), acc(), (key(), acc() -> acc())) :: {:ok, acc()} | {:error, binary()}
-      def fold(start_key, starting_value, f) do
-        db_span("fold", fn ->
-          with {:ok, it} <- Db.iterate(),
+      @spec fold_keys(key(), acc(), (key(), acc() -> acc())) :: {:ok, acc()} | {:error, any()}
+      def fold_keys(start_key, starting_value, f, opts \\ []) do
+        db_span("fold_keys", fn ->
+          include_first? = Keyword.get(opts, :include_first, false)
+          direction = Keyword.get(opts, :direction, :prev)
+
+          with {:ok, it} <- Db.iterate_keys(),
                {:ok, encoded_start} <- do_encode_key(start_key),
-               {:ok, ^encoded_start, _} <- Exleveldb.iterator_move(it, encoded_start) do
-            res = iterate(it, starting_value, f)
+               {:ok, ^encoded_start} <- Exleveldb.iterator_move(it, encoded_start) do
+            res =
+              if include_first? do
+                case accumulate(it, starting_value, f, encoded_start) do
+                  {:cont, acc} -> iterate(it, acc, f, direction)
+                  {:halt, acc} -> acc
+                end
+              else
+                iterate(it, starting_value, f, direction)
+              end
+
             Exleveldb.iterator_close(it)
             {:ok, res}
           else
-            # Failed at moving the iterator for the first time.
-            {:ok, some_key, _some_value} ->
+            # The iterator moved for the first time to a place where it wasn't expected.
+            {:ok, some_key} ->
               {:error,
                "Failed to start iterator for table #{@prefix}. The obtained key is: #{some_key}"}
 
@@ -77,16 +89,21 @@ defmodule LambdaEthereumConsensus.Store.KvSchema do
         end)
       end
 
-      defp iterate(it, acc, f) do
-        case Exleveldb.iterator_move(it, :prev) do
-          # TODO: add option to get the value in the function too if needed.
-          {:ok, @prefix <> _ = k, v} ->
-            # TODO: plan for weird corner cases where the key can't be decoded.
+      defp iterate(it, acc, f, direction) do
+        case accumulate(it, acc, f, direction) do
+          {:cont, acc} -> iterate(it, acc, f, direction)
+          {:halt, acc} -> acc
+        end
+      end
+
+      defp accumulate(it, acc, f, direction) do
+        case Exleveldb.iterator_move(it, direction) do
+          {:ok, @prefix <> _ = k} ->
             {:ok, decoded_key} = do_decode_key(k)
-            iterate(it, f.(decoded_key, acc), f)
+            {:cont, f.(decoded_key, acc)}
 
           _ ->
-            acc
+            {:halt, acc}
         end
       end
 

--- a/lib/types/types.ex
+++ b/lib/types/types.ex
@@ -48,4 +48,12 @@ defmodule Types do
   @type kzg_proof :: Kzg.proof()
   @type bls_signature :: Bls.signature()
   @type bls_pubkey :: Bls.pubkey()
+
+  defmodule Guards do
+    @moduledoc """
+    Module defining guards for some types. Added as needed.
+    """
+
+    defguard is_root(binary) when is_binary(binary) and byte_size(binary) == 32
+  end
 end

--- a/test/fixtures/block.ex
+++ b/test/fixtures/block.ex
@@ -5,6 +5,7 @@ defmodule Fixtures.Block do
 
   alias Fixtures.Random
   alias LambdaEthereumConsensus.Utils.BitVector
+  alias Types.BlockInfo
 
   alias Types.BeaconBlock
   alias Types.BeaconBlockBody
@@ -12,6 +13,11 @@ defmodule Fixtures.Block do
   alias Types.ExecutionPayload
   alias Types.ExecutionPayloadHeader
   alias Types.SignedBeaconBlock
+
+  @spec block_info :: BlockInfo.t()
+  def block_info() do
+    signed_beacon_block() |> BlockInfo.from_block()
+  end
 
   @spec signed_beacon_block :: SignedBeaconBlock.t()
   def signed_beacon_block() do

--- a/test/fixtures/utils.ex
+++ b/test/fixtures/utils.ex
@@ -18,6 +18,9 @@ defmodule Fixtures.Random do
     binary(32)
   end
 
+  @spec slot() :: Types.slot()
+  def slot(), do: uint64()
+
   @spec bls_signature :: binary
   def bls_signature() do
     binary(96)

--- a/test/unit/store/block_by_slot_test.exs
+++ b/test/unit/store/block_by_slot_test.exs
@@ -41,4 +41,20 @@ defmodule Unit.Store.BlockBySlotTest do
     assert BlockBySlot.all_present?(1, 1)
     refute BlockBySlot.all_present?(1, 3)
   end
+
+  @tag :tmp_dir
+  test "retrieving an empty slot" do
+    assert :ok == BlockBySlot.put(1, :empty_slot)
+    assert {:ok, :empty_slot} == BlockBySlot.get(1)
+  end
+
+  @tag :tmp_dir
+  test "Trying to save an atom that's not :empty_slot fails" do
+    assert_raise(FunctionClauseError, fn -> BlockBySlot.put(1, :some_atom) end)
+  end
+
+  @tag :tmp_dir
+  test "Trying to save a non-root binary fails" do
+    assert_raise(FunctionClauseError, fn -> BlockBySlot.put(1, "Hello") end)
+  end
 end

--- a/test/unit/store/block_by_slot_test.exs
+++ b/test/unit/store/block_by_slot_test.exs
@@ -5,10 +5,6 @@ defmodule Unit.Store.BlockBySlotTest do
   use ExUnit.Case
 
   setup %{tmp_dir: tmp_dir} do
-    Application.fetch_env!(:lambda_ethereum_consensus, ChainSpec)
-    |> Keyword.put(:config, MinimalConfig)
-    |> then(&Application.put_env(:lambda_ethereum_consensus, ChainSpec, &1))
-
     start_link_supervised!({LambdaEthereumConsensus.Store.Db, dir: tmp_dir})
     :ok
   end

--- a/test/unit/store/block_db_test.exs
+++ b/test/unit/store/block_db_test.exs
@@ -5,6 +5,10 @@ defmodule Unit.Store.BlockDbTest do
   use ExUnit.Case
 
   setup %{tmp_dir: tmp_dir} do
+    Application.fetch_env!(:lambda_ethereum_consensus, ChainSpec)
+    |> Keyword.put(:config, MainnetConfig)
+    |> then(&Application.put_env(:lambda_ethereum_consensus, ChainSpec, &1))
+
     start_link_supervised!({LambdaEthereumConsensus.Store.Db, dir: tmp_dir})
     :ok
   end

--- a/test/unit/store/block_db_test.exs
+++ b/test/unit/store/block_db_test.exs
@@ -67,4 +67,6 @@ defmodule Unit.Store.BlockDbTest do
     assert {:ok, block_2} == BlockDb.get_block_info(block_2.root)
     assert {:ok, block_3} == BlockDb.get_block_info(block_3.root)
   end
+
+  # TODO: test for empty slots.
 end

--- a/test/unit/store/block_db_test.exs
+++ b/test/unit/store/block_db_test.exs
@@ -1,0 +1,66 @@
+defmodule Unit.Store.BlockDbTest do
+  alias Fixtures.Block
+  alias LambdaEthereumConsensus.Store.BlockDb
+
+  use ExUnit.Case
+
+  setup %{tmp_dir: tmp_dir} do
+    start_link_supervised!({LambdaEthereumConsensus.Store.Db, dir: tmp_dir})
+    :ok
+  end
+
+  @tag :tmp_dir
+  test "Simple block saving and loading" do
+    block_info = Block.block_info()
+    BlockDb.store_block_info(block_info)
+    assert {:ok, block_info} == BlockDb.get_block_info(block_info.root)
+  end
+
+  @tag :tmp_dir
+  test "A saved block's root can be retrieved using its slot" do
+    block_info = Block.block_info()
+    BlockDb.store_block_info(block_info)
+
+    assert {:ok, block_info} ==
+             BlockDb.get_block_info_by_slot(block_info.signed_block.message.slot)
+  end
+
+  @tag :tmp_dir
+  test "Pruning deletes only blocks prior to the one selected as target" do
+    blocks =
+      [block_1, block_2, block_3] =
+      [Block.block_info(), Block.block_info(), Block.block_info()]
+      |> Enum.sort_by(& &1.signed_block.message.slot)
+
+    Enum.each(blocks, &BlockDb.store_block_info/1)
+
+    assert {:ok, block_1} == BlockDb.get_block_info(block_1.root)
+    assert {:ok, block_2} == BlockDb.get_block_info(block_2.root)
+    assert {:ok, block_3} == BlockDb.get_block_info(block_3.root)
+
+    BlockDb.prune_blocks_older_than(block_2.signed_block.message.slot)
+
+    assert :not_found == BlockDb.get_block_info(block_1.root)
+    assert {:ok, block_2} == BlockDb.get_block_info(block_2.root)
+    assert {:ok, block_3} == BlockDb.get_block_info(block_3.root)
+  end
+
+  @tag :tmp_dir
+  test "Pruning on a non existent root returns and doesn't delete anything" do
+    # TODO: this might not work for empty blocks. We may need to delete any block with lower slot
+    # anyway, even if the slot doesn't match anything.
+
+    blocks =
+      [block_1, block_2, block_3] =
+      [Block.block_info(), Block.block_info(), Block.block_info()]
+      |> Enum.sort_by(& &1.signed_block.message.slot)
+
+    Enum.each(blocks, &BlockDb.store_block_info/1)
+
+    random_slot = (blocks |> Enum.map(& &1.signed_block.message.slot) |> Enum.max()) + 1
+    assert :ok == BlockDb.prune_blocks_older_than(random_slot)
+    assert {:ok, block_1} == BlockDb.get_block_info(block_1.root)
+    assert {:ok, block_2} == BlockDb.get_block_info(block_2.root)
+    assert {:ok, block_3} == BlockDb.get_block_info(block_3.root)
+  end
+end

--- a/test/unit/store/kv_schema_test.exs
+++ b/test/unit/store/kv_schema_test.exs
@@ -97,7 +97,18 @@ defmodule Unit.Store.KvSchemaTest do
     NumberSchema.put(5, %{b: 3})
     NumberSchema.put(70, %{c: 5})
 
-    assert {:ok, 6} == NumberSchema.fold(70, 0, fn n, acc -> acc + n end)
+    assert {:ok, 6} == NumberSchema.fold_keys(70, 0, fn n, acc -> acc + n end)
+  end
+
+  @tag :tmp_dir
+  test "Folding includes the first value if so requested" do
+    TupleSchema.put({1, 2}, [])
+    NumberSchema.put(1, %{"a" => "b"})
+    NumberSchema.put(5, %{b: 3})
+    NumberSchema.put(70, %{c: 5})
+
+    assert {:ok, 76} ==
+             NumberSchema.fold_keys(70, 0, fn n, acc -> acc + n end, include_first: true)
   end
 
   @tag :tmp_dir
@@ -106,7 +117,7 @@ defmodule Unit.Store.KvSchemaTest do
     NumberSchema.put(200, %{b: 3})
     NumberSchema.put(700, %{c: 5})
 
-    assert {:ok, 300} == NumberSchema.fold(700, 0, fn n, acc -> acc + n end)
+    assert {:ok, 300} == NumberSchema.fold_keys(700, 0, fn n, acc -> acc + n end)
   end
 
   @tag :tmp_dir
@@ -114,6 +125,6 @@ defmodule Unit.Store.KvSchemaTest do
     NumberSchema.put(1, %{"a" => "b"})
     NumberSchema.put(5, %{b: 3})
 
-    {:error, _} = NumberSchema.fold(3, 0, fn n, acc -> acc + n end)
+    {:error, _} = NumberSchema.fold_keys(3, 0, fn n, acc -> acc + n end)
   end
 end


### PR DESCRIPTION
Changes:

- Added `fold_keys` function + option to include the starting key in KvSchema.
- Added `BlockBySlot` module, implementing `KvSchema`. Includes tests.
- Implement an `all_present?` function in `BlockBySlot` to check if a range of slots has all blocks available.
- Made the BlockDb module use BlockBySlot instead of implementing all. Reduced code via KvSchema gets, puts, folds, removes.
- Added tests for BlockDb behaviors that require block by slot like pruning.

Part of #1207
