### PR TITLE
fix: add a check for pending blocks at node startup

### DIFF
--- a/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
+++ b/lib/lambda_ethereum_consensus/beacon/pending_blocks.ex
@@ -58,11 +58,12 @@ defmodule LambdaEthereumConsensus.Beacon.PendingBlocks do
     end
   end
 
-  ##########################
-  ### Private Functions
-  ##########################
-
-  defp process_blocks() do
+  @doc """
+  Sends any blocks that are ready to block processing. This should usually be called only by this
+  module after receiving a new block, but there are some other cases like at node startup, as there
+  may be pending blocks from prior executions.
+  """
+  def process_blocks() do
     case Blocks.get_blocks_with_status(:pending) do
       {:ok, blocks} ->
         blocks
@@ -75,6 +76,10 @@ defmodule LambdaEthereumConsensus.Beacon.PendingBlocks do
         )
     end
   end
+
+  ##########################
+  ### Private Functions
+  ##########################
 
   # Processes a block. If it was transitioned or declared invalid, then process_blocks
   # is called to check if there's any children that can now be processed. This function

--- a/lib/libp2p_port.ex
+++ b/lib/libp2p_port.ex
@@ -377,7 +377,16 @@ defmodule LambdaEthereumConsensus.Libp2pPort do
        subscribers: %{},
        requests: Requests.new(),
        syncing: true
-     }}
+     }, {:continue, :check_pending_blocks}}
+  end
+
+  # There may be pending blocks from a prior execution, regardless of the optimistic sync
+  # state. We should run a process_blocks round. If no pending blocks are available, this
+  # call is a noop.
+  @impl GenServer
+  def handle_continue(:check_pending_blocks, state) do
+    PendingBlocks.process_blocks()
+    {:noreply, state}
   end
 
   @impl GenServer


### PR DESCRIPTION
Changes:

- Makes `process_blocks` public in `PendingBlocks` 
- Calls `process_blocks` once at app startup in `Libp2pPort` at `handle_continue`, so pending blocks from prior executions are processed if considered recent.

Closes #1235 

