### PR TITLE
fix: path generation

### DIFF
--- a/lib/keystore.ex
+++ b/lib/keystore.ex
@@ -147,17 +147,19 @@ defmodule Keystore do
   defp sanitize_password(password),
     do: password |> String.normalize(:nfkd) |> String.replace(~r/[\x00-\x1f\x80-\x9f\x7f]/, "")
 
-  def get_keystore_dir() do
+  def keystore_file(base_name) do
     config =
       Application.get_env(:lambda_ethereum_consensus, LambdaEthereumConsensus.Validator.Setup, [])
 
-    Keyword.get(config, :keystore_dir) || "keystore_dir"
+    keystore_dir = Keyword.get(config, :keystore_dir) || "keystore_dir"
+    Path.join(keystore_dir, base_name <> ".json")
   end
 
-  def get_keystore_pass_dir() do
+  def keystore_pass_file(base_name) do
     config =
       Application.get_env(:lambda_ethereum_consensus, LambdaEthereumConsensus.Validator.Setup, [])
 
-    Keyword.get(config, :keystore_pass_dir) || "keystore_pass_dir"
+    keystore_pass_dir = Keyword.get(config, :keystore_pass_dir) || "keystore_pass_dir"
+    Path.join(keystore_pass_dir, base_name <> ".txt")
   end
 end


### PR DESCRIPTION
**Motivation**

The path generation for the Keystore files wasn't working.

**Description**
- Use the encoded version of the `pubkey` to generate the path to the keystore file.
- `@keystore_dir` and `@keystore_pass_dir` were always set to the defaults values since they were being computed at compile time. Replace them with function calls to the `Keystore` module.

