### PR TITLE
fix: 2% blocks missed after sync aggregate addition

### DIFF
--- a/lib/lambda_ethereum_consensus/p2p/gossip/operations_collector.ex
+++ b/lib/lambda_ethereum_consensus/p2p/gossip/operations_collector.ex
@@ -118,6 +118,12 @@ defmodule LambdaEthereumConsensus.P2P.Gossip.OperationsCollector do
       |> Enum.reject(&old_attestation?(&1, block.slot))
     end)
 
+    # We only keep the last contributions for each slot, past ones are not needed
+    # since they are not included in the block when it is built.
+    update_operation(:sync_committee_contribution, fn values ->
+      Enum.reject(values, &(&1.message.contribution.slot < block.slot))
+    end)
+
     store_slot(block.slot)
   end
 

--- a/lib/lambda_ethereum_consensus/validator/duties.ex
+++ b/lib/lambda_ethereum_consensus/validator/duties.ex
@@ -71,9 +71,9 @@ defmodule LambdaEthereumConsensus.Validator.Duties do
           ValidatorSet.validators()
         ) :: duties()
   def compute_duties_for_epochs(duties_map, epochs_and_start_slots, head_root, validators) do
-    # TODO: This function needs to be measured and optimized if possible, the main point to look
+    # TODO: (#1299) This function needs to be measured and optimized if possible, the main point to look
     # at is the beacon fetch and sync committees computation. Also this could be done asynchronusly
-    # given that except for the first tame it always calculat 1 epoch ahead of time.
+    # given that except for the first time it always calculat 1 epoch ahead of time.
     Logger.debug("[Duties] Computing duties for epochs: #{inspect(epochs_and_start_slots)}")
 
     for {epoch, slot} <- epochs_and_start_slots, reduce: duties_map do

--- a/lib/lambda_ethereum_consensus/validator/duties.ex
+++ b/lib/lambda_ethereum_consensus/validator/duties.ex
@@ -71,6 +71,9 @@ defmodule LambdaEthereumConsensus.Validator.Duties do
           ValidatorSet.validators()
         ) :: duties()
   def compute_duties_for_epochs(duties_map, epochs_and_start_slots, head_root, validators) do
+    # TODO: This function needs to be measured and optimized if possible, the main point to look
+    # at is the beacon fetch and sync committees computation. Also this could be done asynchronusly
+    # given that except for the first tame it always calculat 1 epoch ahead of time.
     Logger.debug("[Duties] Computing duties for epochs: #{inspect(epochs_and_start_slots)}")
 
     for {epoch, slot} <- epochs_and_start_slots, reduce: duties_map do


### PR DESCRIPTION
**Motivation**

Fixing 2% block missed when proposing on 32 * n + 1 slot.

**Description**

This PR fix the issue related to the Invalid signature error that we got on those particular slots. The problem is related to the parent root, we lacked a filter of contributions that doesn't match our parent root. This was happening at epoch boundaries because that's where we get a delay in the proposal and the second third kicks in before the notify head, which publish messages of the previous root, and make the aggregate become 0.

Resolves #1292
