### PR TITLE
fix: avoid lost attestations and sync committee messages with early subnet subscribe

### DIFF
--- a/lib/lambda_ethereum_consensus/p2p/gossip/attestation.ex
+++ b/lib/lambda_ethereum_consensus/p2p/gossip/attestation.ex
@@ -78,13 +78,18 @@ defmodule LambdaEthereumConsensus.P2P.Gossip.Attestation do
     subscribe(subnet_id)
   end
 
-  @spec stop_collecting(non_neg_integer()) ::
-          {:ok, list(Types.Attestation.t())} | {:error, String.t()}
-  def stop_collecting(subnet_id) do
+  @spec unsubscribe(non_neg_integer()) :: :ok
+  def unsubscribe(subnet_id) do
     # TODO: (#1289) implement some way to unsubscribe without leaving the topic
     topic = topic(subnet_id)
     Libp2pPort.leave_topic(topic)
     Libp2pPort.join_topic(topic)
+  end
+
+  @spec stop_collecting(non_neg_integer()) ::
+          {:ok, list(Types.Attestation.t())} | {:error, String.t()}
+  def stop_collecting(subnet_id) do
+    unsubscribe(subnet_id)
     AttSubnetInfo.stop_collecting(subnet_id)
   end
 

--- a/lib/lambda_ethereum_consensus/p2p/gossip/attestation.ex
+++ b/lib/lambda_ethereum_consensus/p2p/gossip/attestation.ex
@@ -67,11 +67,15 @@ defmodule LambdaEthereumConsensus.P2P.Gossip.Attestation do
     Libp2pPort.publish(topic, message)
   end
 
+  @spec subscribe(non_neg_integer()) :: :ok
+  def subscribe(subnet_id),
+    do: Libp2pPort.async_subscribe_to_topic(topic(subnet_id), __MODULE__)
+
   @spec collect(non_neg_integer(), Types.Attestation.t()) :: :ok
   def collect(subnet_id, attestation) do
     join(subnet_id)
     AttSubnetInfo.new_subnet_with_attestation(subnet_id, attestation)
-    Libp2pPort.async_subscribe_to_topic(topic(subnet_id), __MODULE__)
+    subscribe(subnet_id)
   end
 
   @spec stop_collecting(non_neg_integer()) ::

--- a/lib/lambda_ethereum_consensus/p2p/gossip/sync_committee.ex
+++ b/lib/lambda_ethereum_consensus/p2p/gossip/sync_committee.ex
@@ -72,13 +72,17 @@ defmodule LambdaEthereumConsensus.P2P.Gossip.SyncCommittee do
     Libp2pPort.publish(topic, message)
   end
 
+  @spec subscribe(non_neg_integer()) :: :ok
+  def subscribe(subnet_id),
+    do: Libp2pPort.async_subscribe_to_topic(topic(subnet_id), __MODULE__)
+
   @spec collect([non_neg_integer()], Types.SyncCommitteeMessage.t()) :: :ok
   def collect(subnet_ids, message) do
     join(subnet_ids)
 
     for subnet_id <- subnet_ids do
       SyncSubnetInfo.new_subnet_with_message(subnet_id, message)
-      Libp2pPort.async_subscribe_to_topic(topic(subnet_id), __MODULE__)
+      subscribe(subnet_id)
     end
 
     :ok

--- a/lib/lambda_ethereum_consensus/p2p/gossip/sync_committee.ex
+++ b/lib/lambda_ethereum_consensus/p2p/gossip/sync_committee.ex
@@ -88,13 +88,18 @@ defmodule LambdaEthereumConsensus.P2P.Gossip.SyncCommittee do
     :ok
   end
 
-  @spec stop_collecting(non_neg_integer()) ::
-          {:ok, list(Types.SyncCommitteeMessage.t())} | {:error, String.t()}
-  def stop_collecting(subnet_id) do
+  @spec unsubscribe(non_neg_integer()) :: :ok
+  def unsubscribe(subnet_id) do
     # TODO: (#1289) implement some way to unsubscribe without leaving the topic
     topic = topic(subnet_id)
     Libp2pPort.leave_topic(topic)
     Libp2pPort.join_topic(topic)
+  end
+
+  @spec stop_collecting(non_neg_integer()) ::
+          {:ok, list(Types.SyncCommitteeMessage.t())} | {:error, String.t()}
+  def stop_collecting(subnet_id) do
+    unsubscribe(subnet_id)
     SyncSubnetInfo.stop_collecting(subnet_id)
   end
 

--- a/lib/lambda_ethereum_consensus/validator/duties.ex
+++ b/lib/lambda_ethereum_consensus/validator/duties.ex
@@ -392,7 +392,8 @@ defmodule LambdaEthereumConsensus.Validator.Duties do
     %{
       attesters: get_in(duties, [epoch, :shared, :subnets, :attesters, slot]) || MapSet.new(),
       sync_committees:
-        get_in(duties, [epoch, :shared, :subnets, :sync_committees, max(0, slot - 1)]) || MapSet.new()
+        get_in(duties, [epoch, :shared, :subnets, :sync_committees, max(0, slot - 1)]) ||
+          MapSet.new()
     }
   end
 

--- a/lib/lambda_ethereum_consensus/validator/duties.ex
+++ b/lib/lambda_ethereum_consensus/validator/duties.ex
@@ -41,7 +41,8 @@ defmodule LambdaEthereumConsensus.Validator.Duties do
           aggregation: [sync_committee_aggregator_duty()]
         }
 
-  @type subnets :: [Types.uint64()]
+  @type subnets :: MapSet.t(Types.uint64())
+
   @typedoc "Useful precalculated data not tied to a particular slot/duty."
   @type shared_data_for_duties :: %{
           subnets: %{
@@ -335,7 +336,6 @@ defmodule LambdaEthereumConsensus.Validator.Duties do
       acc ->
         Map.update(acc, slot, MapSet.new([subnet_id]), &MapSet.put(&1, subnet_id))
     end
-    |> Map.new(fn {slot, subnets} -> {slot, MapSet.to_list(subnets)} end)
   end
 
   defp compute_subnets_for_sync_committees(sync_committee_duties) do
@@ -346,7 +346,6 @@ defmodule LambdaEthereumConsensus.Validator.Duties do
       acc ->
         Map.update(acc, slot, MapSet.new([subnet_id]), &MapSet.put(&1, subnet_id))
     end
-    |> Map.new(fn {slot, subnets} -> {slot, MapSet.to_list(subnets)} end)
   end
 
   ############################
@@ -391,9 +390,9 @@ defmodule LambdaEthereumConsensus.Validator.Duties do
           %{attesters: subnets, sync_committees: subnets}
   def current_subnets(duties, epoch, slot) do
     %{
-      attesters: get_in(duties, [epoch, :shared, :subnets, :attesters, slot]) || [],
+      attesters: get_in(duties, [epoch, :shared, :subnets, :attesters, slot]) || MapSet.new(),
       sync_committees:
-        get_in(duties, [epoch, :shared, :subnets, :sync_committees, max(0, slot - 1)]) || []
+        get_in(duties, [epoch, :shared, :subnets, :sync_committees, max(0, slot - 1)]) || MapSet.new()
     }
   end
 

--- a/lib/lambda_ethereum_consensus/validator/duties.ex
+++ b/lib/lambda_ethereum_consensus/validator/duties.ex
@@ -41,7 +41,8 @@ defmodule LambdaEthereumConsensus.Validator.Duties do
           aggregation: [sync_committee_aggregator_duty()]
         }
 
-  @type subnets :: MapSet.t(Types.uint64())
+  @typedoc "Set of subnet indices for a particular slot, used in attestations and sync committees."
+  @type subnets :: MapSet.t(subnet_index :: Types.uint64())
 
   @typedoc "Useful precalculated data not tied to a particular slot/duty."
   @type shared_data_for_duties :: %{

--- a/lib/lambda_ethereum_consensus/validator/validator_set.ex
+++ b/lib/lambda_ethereum_consensus/validator/validator_set.ex
@@ -5,7 +5,11 @@ defmodule LambdaEthereumConsensus.ValidatorSet do
   simplify the delegation of work.
   """
 
-  defstruct slot: nil, head_root: nil, duties: %{}, validators: %{}
+  defstruct slot: nil,
+            head_root: nil,
+            duties: %{},
+            subscribed_subnets: %{attesters: MapSet.new(), sync_committees: MapSet.new()},
+            validators: %{}
 
   require Logger
 
@@ -23,6 +27,7 @@ defmodule LambdaEthereumConsensus.ValidatorSet do
           slot: Types.slot(),
           head_root: Types.root() | nil,
           duties: %{Types.epoch() => Duties.duties()},
+          subscribed_subnets: %{attesters: Duties.subnets(), sync_committees: Duties.subnets()},
           validators: validators()
         }
 
@@ -140,7 +145,7 @@ defmodule LambdaEthereumConsensus.ValidatorSet do
 
   defp process_tick(%{head_root: head_root} = set, epoch, {slot, :first_third}) do
     set
-    |> maybe_subscribe_to_subnets(epoch, slot)
+    |> maybe_resubscribe_to_subnets(epoch, slot)
     |> maybe_propose(epoch, slot, head_root)
   end
 
@@ -332,16 +337,25 @@ defmodule LambdaEthereumConsensus.ValidatorSet do
   ##########################
   # Subnets
 
-  defp maybe_subscribe_to_subnets(set, epoch, slot) do
-    case Duties.current_subnets(set.duties, epoch, slot) do
-      %{attesters: [], sync_committees: []} ->
-        set
+  defp maybe_resubscribe_to_subnets(set, epoch, slot) do
+    %{subscribed_subnets: %{attesters: old_att_subnets, sync_committees: old_sync_subnets}} = set
 
-      %{attesters: att_subnet, sync_committees: sync_subnet} ->
-        Enum.each(att_subnet, &Attestation.subscribe/1)
-        Enum.each(sync_subnet, &SyncCommittee.subscribe/1)
-        set
-    end
+    %{attesters: new_att_subnets, sync_committees: new_sync_sunbnets} =
+      Duties.current_subnets(set.duties, epoch, slot)
+
+    unsubscribe_att = MapSet.difference(old_att_subnets, new_att_subnets)
+    unsubscribe_sync = MapSet.difference(old_sync_subnets, new_sync_sunbnets)
+
+    Enum.each(unsubscribe_att, &Attestation.unsubscribe/1)
+    Enum.each(unsubscribe_sync, &SyncCommittee.unsubscribe/1)
+
+    subscribe_att = MapSet.difference(new_att_subnets, old_att_subnets)
+    subscribe_sync = MapSet.difference(new_sync_sunbnets, old_sync_subnets)
+
+    Enum.each(subscribe_att, &Attestation.subscribe/1)
+    Enum.each(subscribe_sync, &SyncCommittee.subscribe/1)
+
+    %{set | subscribed_subnets: %{attesters: new_att_subnets, sync_committees: new_sync_sunbnets}}
   end
 
   ##########################

--- a/lib/lambda_ethereum_consensus/validator/validator_set.ex
+++ b/lib/lambda_ethereum_consensus/validator/validator_set.ex
@@ -340,22 +340,22 @@ defmodule LambdaEthereumConsensus.ValidatorSet do
   defp maybe_resubscribe_to_subnets(set, epoch, slot) do
     %{subscribed_subnets: %{attesters: old_att_subnets, sync_committees: old_sync_subnets}} = set
 
-    %{attesters: new_att_subnets, sync_committees: new_sync_sunbnets} =
+    %{attesters: new_att_subnets, sync_committees: new_sync_subnets} =
       Duties.current_subnets(set.duties, epoch, slot)
 
     unsubscribe_att = MapSet.difference(old_att_subnets, new_att_subnets)
-    unsubscribe_sync = MapSet.difference(old_sync_subnets, new_sync_sunbnets)
+    unsubscribe_sync = MapSet.difference(old_sync_subnets, new_sync_subnets)
 
     Enum.each(unsubscribe_att, &Attestation.unsubscribe/1)
     Enum.each(unsubscribe_sync, &SyncCommittee.unsubscribe/1)
 
     subscribe_att = MapSet.difference(new_att_subnets, old_att_subnets)
-    subscribe_sync = MapSet.difference(new_sync_sunbnets, old_sync_subnets)
+    subscribe_sync = MapSet.difference(new_sync_subnets, old_sync_subnets)
 
     Enum.each(subscribe_att, &Attestation.subscribe/1)
     Enum.each(subscribe_sync, &SyncCommittee.subscribe/1)
 
-    %{set | subscribed_subnets: %{attesters: new_att_subnets, sync_committees: new_sync_sunbnets}}
+    %{set | subscribed_subnets: %{attesters: new_att_subnets, sync_committees: new_sync_subnets}}
   end
 
   ##########################

--- a/lib/types/att_subnet_info.ex
+++ b/lib/types/att_subnet_info.ex
@@ -49,8 +49,6 @@ defmodule Types.AttSubnetInfo do
   """
   @spec add_attestation!(non_neg_integer(), Types.Attestation.t()) :: :ok
   def add_attestation!(subnet_id, %{data: att_data} = attestation) do
-    %{slot: slot, beacon_block_root: root} = att_data
-
     with {:ok, subnet_info} <- fetch_subnet_info(subnet_id),
          ^att_data <- subnet_info.data do
       new_subnet_info = %__MODULE__{

--- a/lib/types/att_subnet_info.ex
+++ b/lib/types/att_subnet_info.ex
@@ -15,8 +15,6 @@ defmodule Types.AttSubnetInfo do
 
   @subnet_prefix "att_subnet"
 
-  require Logger
-
   @doc """
   Creates a SubnetInfo from an Attestation and stores it into the database.
   The attestation is typically built by a validator before starting to collect others' attestations.

--- a/lib/types/att_subnet_info.ex
+++ b/lib/types/att_subnet_info.ex
@@ -47,6 +47,8 @@ defmodule Types.AttSubnetInfo do
   """
   @spec add_attestation!(non_neg_integer(), Types.Attestation.t()) :: :ok
   def add_attestation!(subnet_id, %{data: att_data} = attestation) do
+    # TODO: (#1302) On delayed scenarios (past second third of the slot) we could discard useful
+    # messages and end up with empty aggregations due to the subnet not being created yet.
     with {:ok, subnet_info} <- fetch_subnet_info(subnet_id),
          ^att_data <- subnet_info.data do
       new_subnet_info = %__MODULE__{

--- a/lib/types/sync_subnet_info.ex
+++ b/lib/types/sync_subnet_info.ex
@@ -18,8 +18,6 @@ defmodule Types.SyncSubnetInfo do
 
   @subnet_prefix "sync_subnet"
 
-  require Logger
-
   @doc """
   Creates a SubnetInfo from an SyncCommitteeMessage and stores it into the database.
   The message is typically built by a validator before starting to collect others' messages.

--- a/lib/types/sync_subnet_info.ex
+++ b/lib/types/sync_subnet_info.ex
@@ -55,6 +55,8 @@ defmodule Types.SyncSubnetInfo do
   def add_message!(subnet_id, %Types.SyncCommitteeMessage{} = message) do
     %{slot: slot, beacon_block_root: root} = message
 
+    # TODO: (#1302) On delayed scenarios (past second third of the slot) we could discard useful
+    # messages and end up with empty aggregations due to the subnet not being created yet.
     with {:ok, subnet_info} <- fetch_subnet_info(subnet_id),
          {^slot, ^root} <- subnet_info.data do
       new_subnet_info = %__MODULE__{

--- a/lib/types/sync_subnet_info.ex
+++ b/lib/types/sync_subnet_info.ex
@@ -18,6 +18,8 @@ defmodule Types.SyncSubnetInfo do
 
   @subnet_prefix "sync_subnet"
 
+  require Logger
+
   @doc """
   Creates a SubnetInfo from an SyncCommitteeMessage and stores it into the database.
   The message is typically built by a validator before starting to collect others' messages.
@@ -50,16 +52,13 @@ defmodule Types.SyncSubnetInfo do
 
   @doc """
   Adds a new SyncCommitteeMessage to the SubnetInfo if the message's data matches the base one.
-  Assumes that the SubnetInfo already exists.
   """
   @spec add_message!(non_neg_integer(), Types.SyncCommitteeMessage.t()) :: :ok
-  def add_message!(
-        subnet_id,
-        %Types.SyncCommitteeMessage{slot: slot, beacon_block_root: root} = message
-      ) do
-    subnet_info = fetch_subnet_info!(subnet_id)
+  def add_message!(subnet_id, %Types.SyncCommitteeMessage{} = message) do
+    %{slot: slot, beacon_block_root: root} = message
 
-    if subnet_info.data == {slot, root} do
+    with {:ok, subnet_info} <- fetch_subnet_info(subnet_id),
+         {^slot, ^root} <- subnet_info.data do
       new_subnet_info = %__MODULE__{
         subnet_info
         | messages: [message | subnet_info.messages]
@@ -98,12 +97,6 @@ defmodule Types.SyncSubnetInfo do
       {:ok, binary} -> {:ok, decode(binary)}
       :not_found -> result
     end
-  end
-
-  @spec fetch_subnet_info!(non_neg_integer()) :: t()
-  defp fetch_subnet_info!(subnet_id) do
-    {:ok, subnet_info} = fetch_subnet_info(subnet_id)
-    subnet_info
   end
 
   @spec delete_subnet(non_neg_integer()) :: :ok


### PR DESCRIPTION
**Motivation**

Some messages from sync committees and attestations weren't part of their aggregates due to late subscribes to the subnets, this PR address it

**Description**
This PR adds the subnets per slot to our shared duties and also adds a new key in the validator set struct to hold our last subnets subscribed to. On the first third of every slot, we check for the difference between the previous subnets and the new ones and do the appropriate unsubscribe/subscribe when needed. Apart from it this PR tackles an issue when receiving messages for non existing subnets crashed Libp2p.

Resolves #1300
Resolves #1301 

