### PR TITLE
fix: eth1data votes error on block propose

### DIFF
--- a/lib/lambda_ethereum_consensus/execution/execution_chain.ex
+++ b/lib/lambda_ethereum_consensus/execution/execution_chain.ex
@@ -267,11 +267,7 @@ defmodule LambdaEthereumConsensus.Execution.ExecutionChain do
 
       data = get_eth1_data(block, new_tree)
 
-      # Spec says: get_eth1_data(block).deposit_count >= state.eth1_data.deposit_count, but this clearly
-      # overrites eth1data even when no deposits ocurred, eth2book instead says:
-      # "Filter out any blocks that have a deposit count less than state.eth1_data.deposit_count:
-      # we've already seen these." Which make a lot more sense.
-      if data.deposit_count > default.deposit_count,
+      if data.deposit_count >= default.deposit_count,
         do: {MapSet.put(set, data), new_tree, data},
         else: {set, new_tree, last_eth1_data}
     end)

--- a/lib/lambda_ethereum_consensus/execution/execution_chain.ex
+++ b/lib/lambda_ethereum_consensus/execution/execution_chain.ex
@@ -247,7 +247,7 @@ defmodule LambdaEthereumConsensus.Execution.ExecutionChain do
       end)
 
     # Default vote on latest eth1 block data in the period range unless eth1 chain is not live
-    default_vote = (last_eth1_data || default)
+    default_vote = last_eth1_data || default
 
     # Tiebreak by smallest distance to period start
     result =

--- a/lib/lambda_ethereum_consensus/validator/block_builder.ex
+++ b/lib/lambda_ethereum_consensus/validator/block_builder.ex
@@ -299,7 +299,7 @@ defmodule LambdaEthereumConsensus.Validator.BlockBuilder do
         {:error, reason} ->
           # Default to the last eth1 data on error
           Logger.error("Failed to fetch eth1 vote: #{reason}")
-          head_state.eth1_data
+          head_state.eth1_data |> IO.inspect(label: "old eth1_data")
 
         {:ok, nil} ->
           head_state.eth1_data

--- a/lib/lambda_ethereum_consensus/validator/block_builder.ex
+++ b/lib/lambda_ethereum_consensus/validator/block_builder.ex
@@ -299,7 +299,7 @@ defmodule LambdaEthereumConsensus.Validator.BlockBuilder do
         {:error, reason} ->
           # Default to the last eth1 data on error
           Logger.error("Failed to fetch eth1 vote: #{reason}")
-          head_state.eth1_data |> IO.inspect(label: "old eth1_data")
+          head_state.eth1_data
 
         {:ok, nil} ->
           head_state.eth1_data

--- a/lib/types/deposit_tree.ex
+++ b/lib/types/deposit_tree.ex
@@ -130,6 +130,8 @@ defmodule Types.DepositTree do
     {:node, {create_node(leaves_left, depth - 1), create_node(leaves_right, depth - 1)}}
   end
 
+  # This new clause needed to transform zero in get_finalized into a [], this bug was
+  # similar to one present in teku: https://github.com/Consensys/teku/pull/7628
   defp finalize_tree({:zero, depth}, 0 = _deposit_count, _), do: {:zero, depth}
   defp finalize_tree({:finalized, _} = node, _, _), do: node
   defp finalize_tree({:leaf, {hash, _}}, _, _), do: {:finalized, {hash, 1}}

--- a/lib/types/deposit_tree.ex
+++ b/lib/types/deposit_tree.ex
@@ -130,6 +130,7 @@ defmodule Types.DepositTree do
     {:node, {create_node(leaves_left, depth - 1), create_node(leaves_right, depth - 1)}}
   end
 
+  defp finalize_tree({:zero, depth}, 0 = _deposit_count, _), do: {:zero, depth}
   defp finalize_tree({:finalized, _} = node, _, _), do: node
   defp finalize_tree({:leaf, {hash, _}}, _, _), do: {:finalized, {hash, 1}}
 

--- a/lib/types/deposit_tree.ex
+++ b/lib/types/deposit_tree.ex
@@ -130,8 +130,6 @@ defmodule Types.DepositTree do
     {:node, {create_node(leaves_left, depth - 1), create_node(leaves_right, depth - 1)}}
   end
 
-  # This new clause needed to transform zero in get_finalized into a [], this bug was
-  # similar to one present in teku: https://github.com/Consensys/teku/pull/7628
   defp finalize_tree({:zero, depth}, 0 = _deposit_count, _), do: {:zero, depth}
   defp finalize_tree({:finalized, _} = node, _, _), do: node
   defp finalize_tree({:leaf, {hash, _}}, _, _), do: {:finalized, {hash, 1}}

--- a/test/unit/deposit_tree_test.exs
+++ b/test/unit/deposit_tree_test.exs
@@ -11,7 +11,17 @@ defmodule Unit.DepositTreeTest do
 
   doctest DepositTree
 
-  # Testcases taken from EIP-4881
+  # Testcases taken from EIP-4881 + empty case
+  @snapshot_empty %DepositTreeSnapshot{
+    finalized: [],
+    deposit_root:
+      Base.decode16!("D70A234731285C6804C2A4F56711DDB8C82C99740F207854891028AF34E27E5E"),
+    deposit_count: 0,
+    execution_block_hash:
+      Base.decode16!("C0B2CBA66FA21E555461E6B699E0F280A5C4A9CD7AE724D79F711E57460FFB2B"),
+    execution_block_height: 0
+  }
+
   @snapshot_1 %DepositTreeSnapshot{
     finalized: [
       Base.decode16!("7AF7DA533B0DC64B690CB0604F5A81E40ED83796DD14037EA3A55383B8F0976A")
@@ -107,5 +117,17 @@ defmodule Unit.DepositTreeTest do
     assert tree == DepositTree.from_snapshot(@snapshot_2)
 
     assert DepositTree.get_snapshot(tree) == @snapshot_2
+  end
+
+  test "finalizing an empty tree is equal to itself" do
+    eth1_data = %Eth1Data{
+      deposit_root: @snapshot_empty.deposit_root,
+      deposit_count: @snapshot_empty.deposit_count,
+      block_hash: @snapshot_empty.execution_block_hash
+    }
+
+    tree = DepositTree.from_snapshot(@snapshot_empty) |> DepositTree.finalize(eth1_data, 0)
+
+    assert tree == DepositTree.from_snapshot(@snapshot_empty)
   end
 end


### PR DESCRIPTION
**Motivation**

This errors were encountered on a long running session after passing the  `ChainSpec.get("SECONDS_PER_ETH1_BLOCK") * ChainSpec.get("ETH1_FOLLOW_DISTANCE")` slots threshold. 

**Description**
This PR solved 4 issues, from lower to higher priority:
- The `has_majority?/2` calculation was not updating the votes past half of period, effectively this wasn't an issue, worst case another vote has also half of the votes totalling to the 100%, but it was pretty useful when debugging, adding it doesn't modify functionality.
- There were an old line of code trying to do a `List.last/1` on a MapSet, this was part of some previous refactor.
- The implementation of getting the first vote had some difference with the spec, it wasn't taking into account the previous eth1data when the valid_votes was empty, and it lacked a comparison with the deposit count of the previous vote.
- There was an issue related to finalization of the empty deposit tree, it was solved following what was seen in the empty snapshots, also here is an issue in Teku that targeted the same problem: https://github.com/Consensys/teku/pull/7628

Resolves #1304

