### PR TITLE
chore: peerbook penalization config + node start fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,39 +164,43 @@ test-iex:
 
 ##################
 # NODE RUNNERS
-DYSCOVERY_PORT ?= 30303
+DISCOVERY_PORT ?= 9009
+METRICS_PORT ?= 9568
 
-#▶️ checkpoint-sync: @ Run an interactive terminal using checkpoint sync.
-checkpoint-sync: compile-all
-	iex -S mix run -- --checkpoint-sync-url https://mainnet-checkpoint-sync.stakely.io/ --metrics --discovery-port $(DYSCOVERY_PORT)
+#▶️ mainnet: @ Run an interactive terminal using checkpoint sync for mainnet.
+mainnet: compile-all
+	iex -S mix run -- --checkpoint-sync-url https://mainnet-checkpoint-sync.stakely.io/ --metrics --metrics-port $(METRICS_PORT) --discovery-port $(DISCOVERY_PORT)
 
-#▶️ checkpoint-sync.logfile: @ Run an interactive terminal using checkpoint sync with a log file.
-checkpoint-sync.logfile: compile-all
-	iex -S mix run -- --checkpoint-sync-url https://mainnet-checkpoint-sync.stakely.io/ --metrics --log-file ./logs/mainnet.log --discovery-port $(DYSCOVERY_PORT)
+#▶️ mainnet.logfile: @ Run an interactive terminal using checkpoint sync for mainnet with a log file.
+mainnet.logfile: compile-all
+	iex -S mix run -- --checkpoint-sync-url https://mainnet-checkpoint-sync.stakely.io/ --metrics --metrics-port $(METRICS_PORT)  --log-file ./logs/mainnet.log --discovery-port $(DISCOVERY_PORT)
 
 #▶️ sepolia: @ Run an interactive terminal using sepolia network
 sepolia: compile-all
-	iex -S mix run -- --checkpoint-sync-url https://sepolia.beaconstate.info --network sepolia --metrics --discovery-port $(DYSCOVERY_PORT)
+	iex -S mix run -- --checkpoint-sync-url https://sepolia.beaconstate.info --network sepolia --metrics --metrics-port $(METRICS_PORT)  --discovery-port $(DISCOVERY_PORT)
 
 #▶️ sepolia.logfile: @ Run an interactive terminal using sepolia network with a log file
 sepolia.logfile: compile-all
-	iex -S mix run -- --checkpoint-sync-url https://sepolia.beaconstate.info --network sepolia --metrics --log-file ./logs/sepolia.log --discovery-port $(DYSCOVERY_PORT)
+	iex -S mix run -- --checkpoint-sync-url https://sepolia.beaconstate.info --network sepolia --metrics --metrics-port $(METRICS_PORT)  --log-file ./logs/sepolia.log --discovery-port $(DISCOVERY_PORT)
 
 #▶️ holesky: @ Run an interactive terminal using holesky network
 holesky: compile-all
-	iex -S mix run -- --checkpoint-sync-url https://checkpoint-sync.holesky.ethpandaops.io --network holesky --discovery-port $(DYSCOVERY_PORT)
+	iex -S mix run -- --checkpoint-sync-url https://checkpoint-sync.holesky.ethpandaops.io --network holesky --metrics --metrics-port $(METRICS_PORT) --discovery-port $(DISCOVERY_PORT)
 
 #▶️ holesky.logfile: @ Run an interactive terminal using holesky network with a log file
 holesky.logfile: compile-all
-	iex -S mix run -- --checkpoint-sync-url https://checkpoint-sync.holesky.ethpandaops.io --network holesky --log-file ./logs/holesky.log --discovery-port $(DYSCOVERY_PORT)
+	iex -S mix run -- --checkpoint-sync-url https://checkpoint-sync.holesky.ethpandaops.io --network holesky --log-file ./logs/holesky.log --metrics --metrics-port $(METRICS_PORT) --discovery-port $(DISCOVERY_PORT)
 
 #▶️ gnosis: @ Run an interactive terminal using gnosis network
 gnosis: compile-all
-	iex -S mix run -- --checkpoint-sync-url https://checkpoint.gnosischain.com --network gnosis --discovery-port $(DYSCOVERY_PORT)
+	iex -S mix run -- --checkpoint-sync-url https://checkpoint.gnosischain.com --network gnosis --metrics --metrics-port $(METRICS_PORT) --discovery-port $(DISCOVERY_PORT)
 
 #▶️ gnosis.logfile: @ Run an interactive terminal using gnosis network with a log file
 gnosis.logfile: compile-all
-	iex -S mix run -- --checkpoint-sync-url https://checkpoint.gnosischain.com --network gnosis --log-file ./logs/gnosis.log --discovery-port $(DYSCOVERY_PORT)
+	iex -S mix run -- --checkpoint-sync-url https://checkpoint.gnosischain.com --network gnosis --metrics --metrics-port $(METRICS_PORT) --log-file ./logs/gnosis.log --discovery-port $(DISCOVERY_PORT)
+
+#▶️ checkpoint-sync: @ Run an interactive terminal using checkpoint sync for mainnet.
+checkpoint-sync: mainnet
 
 #🔴 test: @ Run tests
 test: compile-all

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -261,10 +261,13 @@ if dsn do
 end
 
 # Peerbook penalization
+
+penalizing_score =
+  case network do
+    "sepolia" -> 20
+    "mainnet" -> 50
+    _ -> 30
+  end
+
 config :lambda_ethereum_consensus, LambdaEthereumConsensus.P2P.Peerbook,
-  penalizing_score:
-    case network do
-      "sepolia" -> 20
-      "mainnet" -> 50
-      _ -> 30
-    end
+  penalizing_score: penalizing_score

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -259,3 +259,12 @@ if dsn do
 
   config :sentry, dsn: dsn, release: String.trim(git_sha)
 end
+
+# Peerbook penalization
+config :lambda_ethereum_consensus, LambdaEthereumConsensus.P2P.Peerbook,
+  penalizing_score:
+    case network do
+      "sepolia" -> 20
+      "mainnet" -> 50
+      _ -> 30
+    end

--- a/lib/lambda_ethereum_consensus/beacon/checkpoint_sync.ex
+++ b/lib/lambda_ethereum_consensus/beacon/checkpoint_sync.ex
@@ -19,7 +19,7 @@ defmodule LambdaEthereumConsensus.Beacon.CheckpointSync do
   def get_finalized_block_and_state(url, genesis_validators_root) do
     tasks = [Task.async(__MODULE__, :get_state, [url]), Task.async(__MODULE__, :get_block, [url])]
 
-    case Task.await_many(tasks, 60_000) do
+    case Task.await_many(tasks, 90_000) do
       [{:ok, state}, {:ok, block}] ->
         if state.genesis_validators_root == genesis_validators_root do
           check_match(url, state, block)
@@ -92,8 +92,8 @@ defmodule LambdaEthereumConsensus.Beacon.CheckpointSync do
   defp get_json_from_url(base_url, path) do
     full_url = concat_url(base_url, path)
 
-    with {:ok, response} <- get(full_url) do
-      {:ok, response.body |> Map.fetch!("data") |> parse_json()}
+    with {:ok, %{body: %{"data" => data}}} <- get(full_url) do
+      {:ok, parse_json(data)}
     end
   end
 

--- a/lib/lambda_ethereum_consensus/p2p/peerbook.ex
+++ b/lib/lambda_ethereum_consensus/p2p/peerbook.ex
@@ -3,7 +3,6 @@ defmodule LambdaEthereumConsensus.P2P.Peerbook do
   General peer bookkeeping.
   """
   require Logger
-  alias IEx.App
   alias LambdaEthereumConsensus.Libp2pPort
   alias LambdaEthereumConsensus.Store.KvSchema
   alias LambdaEthereumConsensus.Utils


### PR DESCRIPTION
**Motivation**

This is a small PR that makes the node run differently on sepolia and mainnet related to peer scoring, making it fastest in mainnet to remove peers.

**Description**

This PR adds a couple of things:
- A config to match penalizing score given the network
- A small fix of a match that caused troubles sometimes in Holesky at node startup
- Added an extra parameter to the make tasks for starting the node to allow them to start multiple nodes easily in the same machine

