### PR TITLE
fix: fixed kurtosis image to 1.3.1, 1.4.0 breaks kurtosis engine startup

### DIFF
--- a/.github/workflows/assertoor.yml
+++ b/.github/workflows/assertoor.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Setup kurtosis testnet and run assertoor tests
         uses: ethpandaops/kurtosis-assertoor-github-action@v1
         with:
+          kurtosis_version: '1.3.1'
           ethereum_package_url: 'github.com/lambdaclass/ethereum-package'
           ethereum_package_branch: 'lecc-integration-and-assertoor'
           ethereum_package_args: './assertoor-config.yml'


### PR DESCRIPTION
**Motivation**

Kurtosis moved from 1.3.1 to 1.4.0 and our checks started failing when loading the kurtosis engine

**Description**

This PR fixes kurtosis version to the latest working one: 1.3.1
