### PR TITLE
chore(core): assertoor version fixes

### DIFF
--- a/.github/workflows/assertoor.yml
+++ b/.github/workflows/assertoor.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup kurtosis testnet and run assertoor tests
         uses: ethpandaops/kurtosis-assertoor-github-action@v1
         with:
-          kurtosis_version: '1.3.1'
+          kurtosis_version: "1.4.2"
           ethereum_package_url: 'github.com/lambdaclass/ethereum-package'
           ethereum_package_branch: 'lecc-integration-and-assertoor'
           ethereum_package_args: './assertoor-config.yml'

--- a/assertoor-config.yml
+++ b/assertoor-config.yml
@@ -1,7 +1,10 @@
 participants:
   - el_type: geth
+    el_image: ethereum/client-go:v1.14.12
     cl_type: lighthouse
+    cl_image: sigp/lighthouse:v5.3.0
   - el_type: geth
+    el_image: ethereum/client-go:v1.14.12
     cl_type: lambda
     cl_image: lambda_ethereum_consensus:latest
     use_separate_vc: false


### PR DESCRIPTION
**Motivation**

Assertoor step is failing due to versions not fixed (this was already don on ethrex)

**Description**

Even if we just have the skeleton of the assertoor integration, improver versions make the step to fail,. this solves it.

