### PR TITLE
fix: recompute head was taking more than 20s in mainnet

### DIFF
--- a/lib/lambda_ethereum_consensus/fork_choice/head.ex
+++ b/lib/lambda_ethereum_consensus/fork_choice/head.ex
@@ -8,8 +8,6 @@ defmodule LambdaEthereumConsensus.ForkChoice.Head do
   alias Types.BeaconState
   alias Types.Store
 
-  require Logger
-
   @spec get_head(Store.t()) :: {:ok, Types.root()} | {:error, any}
   def get_head(%Store{} = store) do
     # Get filtered block tree that only includes viable branches


### PR DESCRIPTION
**Motivation**

Running the node for more than an epoch and just after block processing, 20+ seconds were taken before finishing the fork choice step, which made it impossible to execute sequentially inside the slot range (12s)

**Description**

After extensive debugging, the issue was found in the recompute head calculation, specially in the repeatedly call of get_weight where it wasn't really needed (outside of forks). The solution was taking into account this cases and stop calculating get_weight when encountered. 

Resolves #1381 

