### PR TITLE
fix: change tools versions with a correct version of go

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 erlang 26.2
 elixir 1.16.2-otp-26
-golang 1.22
+golang 1.24.2
 rust 1.81.0
-protoc 24.3
+protoc 30.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 erlang 26.2
 elixir 1.16.2-otp-26
-golang 1.24.2
+golang 1.22.12
 rust 1.81.0
 protoc 30.2


### PR DESCRIPTION
**Motivation**

In a previous PR the go version was set to 1.22, but it lacked the patch version resulting in a 404 while trying to install. Protobuff was also updated.