### PR TITLE
feat: implement electra deposits

### DIFF
--- a/lib/lambda_ethereum_consensus/state_transition/epoch_processing.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/epoch_processing.ex
@@ -432,4 +432,14 @@ defmodule LambdaEthereumConsensus.StateTransition.EpochProcessing do
       max(balance + delta, 0)
     end)
   end
+
+  @spec process_pending_deposits(BeaconState.t()) :: {:ok, BeaconState.t()}
+  def process_pending_deposits(%BeaconState{} = state) do
+    {:ok, state}
+  end
+
+  @spec process_pending_consolidations(BeaconState.t()) :: {:ok, BeaconState.t()}
+  def process_pending_consolidations(%BeaconState{} = state) do
+    {:ok, state}
+  end
 end

--- a/lib/lambda_ethereum_consensus/state_transition/mutators.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/mutators.ex
@@ -156,7 +156,9 @@ defmodule LambdaEthereumConsensus.StateTransition.Mutators do
      }}
   end
 
-  defp apply_initial_deposit(%BeaconState{} = state, pubkey, withdrawal_credentials, amount) do
+  @spec apply_initial_deposit(BeaconState.t(), Types.bls_pubkey(), Types.bytes32(), Types.gwei()) ::
+          {:ok, BeaconState.t()}
+  def apply_initial_deposit(%BeaconState{} = state, pubkey, withdrawal_credentials, amount) do
     Types.Deposit.get_validator_from_deposit(pubkey, withdrawal_credentials, amount)
     |> then(&Aja.Vector.append(state.validators, &1))
     |> then(

--- a/lib/lambda_ethereum_consensus/state_transition/mutators.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/mutators.ex
@@ -5,6 +5,8 @@ defmodule LambdaEthereumConsensus.StateTransition.Mutators do
   alias LambdaEthereumConsensus.StateTransition.Accessors
   alias LambdaEthereumConsensus.StateTransition.Misc
   alias Types.BeaconState
+  alias Types.DepositMessage
+  alias Types.PendingDeposit
   alias Types.Validator
 
   @doc """
@@ -122,27 +124,36 @@ defmodule LambdaEthereumConsensus.StateTransition.Mutators do
           Types.bls_signature()
         ) :: {:ok, BeaconState.t()} | {:error, String.t()}
   def apply_deposit(state, pubkey, withdrawal_credentials, amount, signature) do
-    case Enum.find_index(state.validators, fn validator -> validator.pubkey == pubkey end) do
-      index when is_number(index) ->
-        {:ok, BeaconState.increase_balance(state, index, amount)}
+    deposit = %PendingDeposit{
+      pubkey: pubkey,
+      withdrawal_credentials: withdrawal_credentials,
+      amount: amount,
+      signature: signature,
+      slot: Constants.genesis_slot()
+    }
 
-      _ ->
-        deposit_message = %Types.DepositMessage{
-          pubkey: pubkey,
-          withdrawal_credentials: withdrawal_credentials,
-          amount: amount
-        }
-
-        domain = Misc.compute_domain(Constants.domain_deposit())
-
-        signing_root = Misc.compute_signing_root(deposit_message, domain)
-
-        if Bls.valid?(pubkey, signing_root, signature) do
-          apply_initial_deposit(state, pubkey, withdrawal_credentials, amount)
+    pending_deposits =
+      if !Enum.member?(state.validators, fn validator -> validator.pubkey == pubkey end) do
+        if DepositMessage.valid_deposit_signature?(
+             pubkey,
+             withdrawal_credentials,
+             amount,
+             signature
+           ) do
+          {:ok, state} = apply_initial_deposit(state, pubkey, withdrawal_credentials, amount)
+          state.pending_deposits ++ [deposit]
         else
-          {:ok, state}
+          state.pending_deposits
         end
-    end
+      else
+        state.pending_deposits ++ [deposit]
+      end
+
+    {:ok,
+     %BeaconState{
+       state
+       | pending_deposits: pending_deposits
+     }}
   end
 
   defp apply_initial_deposit(%BeaconState{} = state, pubkey, withdrawal_credentials, amount) do

--- a/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
+++ b/lib/lambda_ethereum_consensus/state_transition/state_transition.ex
@@ -156,6 +156,8 @@ defmodule LambdaEthereumConsensus.StateTransition do
     |> epoch_op(:registry_updates, &EpochProcessing.process_registry_updates/1)
     |> epoch_op(:slashings, &EpochProcessing.process_slashings/1)
     |> epoch_op(:eth1_data_reset, &EpochProcessing.process_eth1_data_reset/1)
+    |> epoch_op(:pending_deposits, &EpochProcessing.process_pending_deposits/1)
+    |> epoch_op(:pending_consolidations, &EpochProcessing.process_pending_consolidations/1)
     |> epoch_op(:effective_balance_updates, &EpochProcessing.process_effective_balance_updates/1)
     |> epoch_op(:slashings_reset, &EpochProcessing.process_slashings_reset/1)
     |> epoch_op(:randao_mixes_reset, &EpochProcessing.process_randao_mixes_reset/1)

--- a/lib/types/beacon_chain/deposit.ex
+++ b/lib/types/beacon_chain/deposit.ex
@@ -22,23 +22,28 @@ defmodule Types.Deposit do
   @spec get_validator_from_deposit(Types.bls_pubkey(), Types.bytes32(), Types.uint64()) ::
           Types.Validator.t()
   def get_validator_from_deposit(pubkey, withdrawal_credentials, amount) do
-    effective_balance =
-      min(
-        amount - rem(amount, ChainSpec.get("EFFECTIVE_BALANCE_INCREMENT")),
-        ChainSpec.get("MAX_EFFECTIVE_BALANCE")
-      )
-
     far_future_epoch = Constants.far_future_epoch()
 
-    %Types.Validator{
+    validator = %Types.Validator{
       pubkey: pubkey,
       withdrawal_credentials: withdrawal_credentials,
       activation_eligibility_epoch: far_future_epoch,
       activation_epoch: far_future_epoch,
       exit_epoch: far_future_epoch,
       withdrawable_epoch: far_future_epoch,
-      effective_balance: effective_balance,
+      effective_balance: 0,
       slashed: false
+    }
+
+    effective_balance =
+      min(
+        amount - rem(amount, ChainSpec.get("EFFECTIVE_BALANCE_INCREMENT")),
+        Types.Validator.get_max_effective_balance(validator)
+      )
+
+    %Types.Validator{
+      validator
+      | effective_balance: effective_balance
     }
   end
 

--- a/lib/types/beacon_chain/deposit_message.ex
+++ b/lib/types/beacon_chain/deposit_message.ex
@@ -3,6 +3,7 @@ defmodule Types.DepositMessage do
   Struct definition for `DepositMessage`.
   Related definitions in `native/ssz_nif/src/types/`.
   """
+  alias LambdaEthereumConsensus.StateTransition.Misc
   use LambdaEthereumConsensus.Container
 
   fields = [
@@ -27,5 +28,24 @@ defmodule Types.DepositMessage do
       {:withdrawal_credentials, TypeAliases.bytes32()},
       {:amount, TypeAliases.gwei()}
     ]
+  end
+
+  @spec valid_deposit_signature?(
+          Types.bls_pubkey(),
+          Types.bytes32(),
+          Types.gwei(),
+          Types.bls_signature()
+        ) :: boolean()
+  def valid_deposit_signature?(pubkey, withdrawal_credentials, amount, signature) do
+    deposit_message = %__MODULE__{
+      pubkey: pubkey,
+      withdrawal_credentials: withdrawal_credentials,
+      amount: amount
+    }
+
+    domain = Misc.compute_domain(Constants.domain_deposit())
+    signing_root = Misc.compute_signing_root(deposit_message, domain)
+
+    Bls.valid?(pubkey, signing_root, signature)
   end
 end


### PR DESCRIPTION
**Motivation**

Implement changes in Electra to deposits + fix all spec-tests related to it.

**Description**

- New `is_valid_deposit_signature`
- Modified `get_validator_from_deposit`
- Modified `add_validator_to_registry` 
    - In our code the function is called `Mutators.apply_initial_deposit`
    - The code from Deneb to Electra does not actually change, the link in the spec just adds a comment referencing the changes made to the function `get_validator_from_deposit`
- Modified `apply_deposit`
- New `apply_pending_deposit`
- New `process_pending_deposits`

**Fixed spec tests**

```
test/generated/mainnet/electra/epoch_processing.exs:377
test/generated/mainnet/electra/epoch_processing.exs:383
test/generated/mainnet/electra/epoch_processing.exs:389
test/generated/mainnet/electra/epoch_processing.exs:395
test/generated/mainnet/electra/epoch_processing.exs:401
test/generated/mainnet/electra/epoch_processing.exs:407
test/generated/mainnet/electra/epoch_processing.exs:413
test/generated/mainnet/electra/epoch_processing.exs:419
test/generated/mainnet/electra/epoch_processing.exs:425
test/generated/mainnet/electra/epoch_processing.exs:431
test/generated/mainnet/electra/epoch_processing.exs:437
test/generated/mainnet/electra/epoch_processing.exs:443
test/generated/mainnet/electra/epoch_processing.exs:449
test/generated/mainnet/electra/epoch_processing.exs:455
test/generated/mainnet/electra/epoch_processing.exs:461
test/generated/mainnet/electra/epoch_processing.exs:467
test/generated/mainnet/electra/epoch_processing.exs:473
test/generated/mainnet/electra/epoch_processing.exs:479
test/generated/mainnet/electra/epoch_processing.exs:485
test/generated/mainnet/electra/epoch_processing.exs:491
test/generated/mainnet/electra/epoch_processing.exs:497
test/generated/mainnet/electra/epoch_processing.exs:503
test/generated/mainnet/electra/epoch_processing.exs:509
test/generated/mainnet/electra/epoch_processing.exs:515
test/generated/mainnet/electra/epoch_processing.exs:521
test/generated/mainnet/electra/epoch_processing.exs:527
test/generated/mainnet/electra/epoch_processing.exs:533
test/generated/mainnet/electra/epoch_processing.exs:539
test/generated/mainnet/electra/epoch_processing.exs:545
test/generated/mainnet/electra/epoch_processing.exs:551
test/generated/mainnet/electra/epoch_processing.exs:557
test/generated/mainnet/electra/epoch_processing.exs:563
test/generated/mainnet/electra/epoch_processing.exs:569
test/generated/mainnet/electra/epoch_processing.exs:575
test/generated/mainnet/electra/epoch_processing.exs:581
test/generated/mainnet/electra/epoch_processing.exs:587
test/generated/mainnet/electra/epoch_processing.exs:593
test/generated/mainnet/electra/epoch_processing.exs:599
test/generated/mainnet/electra/epoch_processing.exs:605
test/generated/mainnet/electra/epoch_processing.exs:611
test/generated/mainnet/electra/epoch_processing.exs:617
test/generated/mainnet/electra/epoch_processing.exs:623
test/generated/mainnet/electra/epoch_processing.exs:629
test/generated/mainnet/electra/epoch_processing.exs:635
test/generated/minimal/electra/epoch_processing.exs:389
test/generated/minimal/electra/epoch_processing.exs:395
test/generated/minimal/electra/epoch_processing.exs:401
test/generated/minimal/electra/epoch_processing.exs:407
test/generated/minimal/electra/epoch_processing.exs:413
test/generated/minimal/electra/epoch_processing.exs:419
test/generated/minimal/electra/epoch_processing.exs:425
test/generated/minimal/electra/epoch_processing.exs:431
test/generated/minimal/electra/epoch_processing.exs:437
test/generated/minimal/electra/epoch_processing.exs:443
test/generated/minimal/electra/epoch_processing.exs:449
test/generated/minimal/electra/epoch_processing.exs:455
test/generated/minimal/electra/epoch_processing.exs:461
test/generated/minimal/electra/epoch_processing.exs:467
test/generated/minimal/electra/epoch_processing.exs:473
test/generated/minimal/electra/epoch_processing.exs:479
test/generated/minimal/electra/epoch_processing.exs:485
test/generated/minimal/electra/epoch_processing.exs:491
test/generated/minimal/electra/epoch_processing.exs:497
test/generated/minimal/electra/epoch_processing.exs:503
test/generated/minimal/electra/epoch_processing.exs:509
test/generated/minimal/electra/epoch_processing.exs:515
test/generated/minimal/electra/epoch_processing.exs:521
test/generated/minimal/electra/epoch_processing.exs:527
test/generated/minimal/electra/epoch_processing.exs:533
test/generated/minimal/electra/epoch_processing.exs:539
test/generated/minimal/electra/epoch_processing.exs:545
test/generated/minimal/electra/epoch_processing.exs:551
test/generated/minimal/electra/epoch_processing.exs:557
test/generated/minimal/electra/epoch_processing.exs:563
test/generated/minimal/electra/epoch_processing.exs:569
test/generated/minimal/electra/epoch_processing.exs:575
test/generated/minimal/electra/epoch_processing.exs:581
test/generated/minimal/electra/epoch_processing.exs:587
test/generated/minimal/electra/epoch_processing.exs:593
test/generated/minimal/electra/epoch_processing.exs:599
test/generated/minimal/electra/epoch_processing.exs:605
test/generated/minimal/electra/epoch_processing.exs:611
test/generated/minimal/electra/epoch_processing.exs:617
test/generated/minimal/electra/epoch_processing.exs:623
test/generated/minimal/electra/epoch_processing.exs:629
test/generated/minimal/electra/epoch_processing.exs:635
test/generated/minimal/electra/epoch_processing.exs:641
test/generated/minimal/electra/epoch_processing.exs:647
test/generated/minimal/electra/epoch_processing.exs:653

```
