### PR TITLE
fix: skipped spec tests in electra

### DIFF
--- a/test/spec/runners/bls.ex
+++ b/test/spec/runners/bls.ex
@@ -6,21 +6,11 @@ defmodule BlsTestRunner do
   use ExUnit.CaseTemplate
   use TestRunner
 
-  # Remove handler from here once you implement the corresponding functions
-  @disabled_handlers [
-    # "sign",
-    # "verify",
-    # "aggregate",
-    # "fast_aggregate_verify",
-    # "aggregate_verify",
-    # "eth_aggregate_pubkeys"
-    # "eth_fast_aggregate_verify"
-  ]
-
   @impl TestRunner
-  def skip?(%SpecTestCase{} = testcase) do
-    Enum.member?(@disabled_handlers, testcase.handler)
-  end
+  def skip?(%SpecTestCase{fork: "capella"}), do: false
+  def skip?(%SpecTestCase{fork: "deneb"}), do: false
+  def skip?(%SpecTestCase{fork: "electra"}), do: false
+  def skip?(_), do: true
 
   @impl TestRunner
   def run_test_case(%SpecTestCase{} = testcase) do

--- a/test/spec/runners/bls.ex
+++ b/test/spec/runners/bls.ex
@@ -7,9 +7,6 @@ defmodule BlsTestRunner do
   use TestRunner
 
   @impl TestRunner
-  def skip?(_), do: false
-
-  @impl TestRunner
   def run_test_case(%SpecTestCase{} = testcase) do
     case_dir = SpecTestCase.dir(testcase)
 

--- a/test/spec/runners/bls.ex
+++ b/test/spec/runners/bls.ex
@@ -7,10 +7,7 @@ defmodule BlsTestRunner do
   use TestRunner
 
   @impl TestRunner
-  def skip?(%SpecTestCase{fork: "capella"}), do: false
-  def skip?(%SpecTestCase{fork: "deneb"}), do: false
-  def skip?(%SpecTestCase{fork: "electra"}), do: false
-  def skip?(_), do: true
+  def skip?(_), do: false
 
   @impl TestRunner
   def run_test_case(%SpecTestCase{} = testcase) do

--- a/test/spec/runners/epoch_processing.ex
+++ b/test/spec/runners/epoch_processing.ex
@@ -9,22 +9,9 @@ defmodule EpochProcessingTestRunner do
   use ExUnit.CaseTemplate
   use TestRunner
 
-  # Remove handler from here once you implement the corresponding functions
+  # TODO: We need to make sure this 2 are still needed to be here
   @disabled_handlers [
-    # "justification_and_finalization",
-    # "inactivity_updates",
-    # "rewards_and_penalties",
-    # "registry_updates",
-    # "slashings",
-    # "effective_balance_updates",
-    # "eth1_data_reset",
-    # "slashings_reset",
-    # "randao_mixes_reset",
-    # "historical_summaries_update",
     "participation_record_updates"
-
-    # "participation_flag_updates",
-    # "sync_committee_updates"
   ]
 
   @deprecated_handlers [
@@ -36,7 +23,6 @@ defmodule EpochProcessingTestRunner do
     Enum.member?(@disabled_handlers ++ @deprecated_handlers, handler)
   end
 
-  @impl TestRunner
   def skip?(%SpecTestCase{fork: "deneb"}), do: false
   def skip?(%SpecTestCase{fork: "electra"}), do: false
   def skip?(_), do: true

--- a/test/spec/runners/epoch_processing.ex
+++ b/test/spec/runners/epoch_processing.ex
@@ -23,9 +23,7 @@ defmodule EpochProcessingTestRunner do
     Enum.member?(@disabled_handlers ++ @deprecated_handlers, handler)
   end
 
-  def skip?(%SpecTestCase{fork: "deneb"}), do: false
-  def skip?(%SpecTestCase{fork: "electra"}), do: false
-  def skip?(_), do: true
+  def skip?(_), do: false
 
   @impl TestRunner
   def run_test_case(%SpecTestCase{} = testcase) do

--- a/test/spec/runners/finality.ex
+++ b/test/spec/runners/finality.ex
@@ -7,12 +7,6 @@ defmodule FinalityTestRunner do
   use TestRunner
 
   @impl TestRunner
-  def skip?(%SpecTestCase{fork: "capella"}), do: false
-  def skip?(%SpecTestCase{fork: "deneb"}), do: false
-  def skip?(%SpecTestCase{fork: "electra"}), do: false
-  def skip?(_), do: true
-
-  @impl TestRunner
   def run_test_case(testcase) do
     Helpers.ProcessBlocks.process_blocks(testcase)
   end

--- a/test/spec/runners/finality.ex
+++ b/test/spec/runners/finality.ex
@@ -7,7 +7,10 @@ defmodule FinalityTestRunner do
   use TestRunner
 
   @impl TestRunner
-  def skip?(_), do: false
+  def skip?(%SpecTestCase{fork: "capella"}), do: false
+  def skip?(%SpecTestCase{fork: "deneb"}), do: false
+  def skip?(%SpecTestCase{fork: "electra"}), do: false
+  def skip?(_), do: true
 
   @impl TestRunner
   def run_test_case(testcase) do

--- a/test/spec/runners/finality.ex
+++ b/test/spec/runners/finality.ex
@@ -7,10 +7,7 @@ defmodule FinalityTestRunner do
   use TestRunner
 
   @impl TestRunner
-  def skip?(%SpecTestCase{fork: "capella"}), do: false
-  def skip?(%SpecTestCase{fork: "deneb"}), do: false
-  def skip?(%SpecTestCase{fork: "electra"}), do: false
-  def skip?(_), do: true
+  def skip?(_), do: false
 
   @impl TestRunner
   def run_test_case(testcase) do

--- a/test/spec/runners/finality.ex
+++ b/test/spec/runners/finality.ex
@@ -6,25 +6,10 @@ defmodule FinalityTestRunner do
   use ExUnit.CaseTemplate
   use TestRunner
 
-  @disabled_cases [
-    # "finality_no_updates_at_genesis",
-    # "finality_rule_1",
-    # "finality_rule_2",
-    # "finality_rule_3",
-    # "finality_rule_4"
-  ]
-
   @impl TestRunner
-  def skip?(%SpecTestCase{fork: "capella", case: testcase}) do
-    Enum.member?(@disabled_cases, testcase)
-  end
-
-  @impl TestRunner
-  def skip?(%SpecTestCase{fork: "deneb", case: testcase}) do
-    Enum.member?(@disabled_cases, testcase)
-  end
-
-  @impl TestRunner
+  def skip?(%SpecTestCase{fork: "capella"}), do: false
+  def skip?(%SpecTestCase{fork: "deneb"}), do: false
+  def skip?(%SpecTestCase{fork: "electra"}), do: false
   def skip?(_), do: true
 
   @impl TestRunner

--- a/test/spec/runners/fork_choice.ex
+++ b/test/spec/runners/fork_choice.ex
@@ -24,12 +24,6 @@ defmodule ForkChoiceTestRunner do
   end
 
   @impl TestRunner
-  def skip?(%SpecTestCase{fork: "capella"}), do: false
-  def skip?(%SpecTestCase{fork: "deneb"}), do: false
-  def skip?(%SpecTestCase{fork: "electra"}), do: false
-  def skip?(_testcase), do: true
-
-  @impl TestRunner
   def run_test_case(testcase) do
     case_dir = SpecTestCase.dir(testcase)
 

--- a/test/spec/runners/kzg.ex
+++ b/test/spec/runners/kzg.ex
@@ -7,9 +7,6 @@ defmodule KzgTestRunner do
   use TestRunner
 
   @impl TestRunner
-  def skip?(_), do: false
-
-  @impl TestRunner
   def run_test_case(%SpecTestCase{} = testcase) do
     case_dir = SpecTestCase.dir(testcase)
 

--- a/test/spec/runners/kzg.ex
+++ b/test/spec/runners/kzg.ex
@@ -7,10 +7,7 @@ defmodule KzgTestRunner do
   use TestRunner
 
   @impl TestRunner
-  def skip?(%SpecTestCase{fork: "capella"}), do: false
-  def skip?(%SpecTestCase{fork: "deneb"}), do: false
-  def skip?(%SpecTestCase{fork: "electra"}), do: false
-  def skip?(_), do: true
+  def skip?(_), do: false
 
   @impl TestRunner
   def run_test_case(%SpecTestCase{} = testcase) do

--- a/test/spec/runners/kzg.ex
+++ b/test/spec/runners/kzg.ex
@@ -6,20 +6,11 @@ defmodule KzgTestRunner do
   use ExUnit.CaseTemplate
   use TestRunner
 
-  # Remove handler from here once you implement the corresponding functions
-  @disabled_handlers [
-    # "blob_to_kzg_commitment"
-    # "compute_kzg_proof",
-    # "verify_kzg_proof",
-    # "compute_blob_kzg_proof",
-    # "verify_blob_kzg_proof",
-    # "verify_blob_kzg_proof_batch"
-  ]
-
   @impl TestRunner
-  def skip?(%SpecTestCase{} = testcase) do
-    Enum.member?(@disabled_handlers, testcase.handler)
-  end
+  def skip?(%SpecTestCase{fork: "capella"}), do: false
+  def skip?(%SpecTestCase{fork: "deneb"}), do: false
+  def skip?(%SpecTestCase{fork: "electra"}), do: false
+  def skip?(_), do: true
 
   @impl TestRunner
   def run_test_case(%SpecTestCase{} = testcase) do

--- a/test/spec/runners/light_client.ex
+++ b/test/spec/runners/light_client.ex
@@ -19,15 +19,9 @@ defmodule LightClientTestRunner do
     Enum.member?(@disabled_handlers, testcase.handler)
   end
 
-  def skip?(%SpecTestCase{fork: "deneb"} = _testcase) do
-    # TODO: all of them fail
-    true
-  end
-
-  @impl TestRunner
-  def skip?(_testcase) do
-    true
-  end
+  # TODO: We didn't implement lightclient functions yet
+  def skip?(%SpecTestCase{fork: fork}) when fork in ["deneb", "electra"], do: true
+  def skip?(_), do: true
 
   @impl TestRunner
   def run_test_case(%SpecTestCase{} = testcase) do

--- a/test/spec/runners/light_client.ex
+++ b/test/spec/runners/light_client.ex
@@ -21,7 +21,6 @@ defmodule LightClientTestRunner do
 
   # TODO: We didn't implement lightclient functions yet
   def skip?(%SpecTestCase{fork: fork}) when fork in ["deneb", "electra"], do: true
-  def skip?(_), do: true
 
   @impl TestRunner
   def run_test_case(%SpecTestCase{} = testcase) do

--- a/test/spec/runners/operations.ex
+++ b/test/spec/runners/operations.ex
@@ -54,12 +54,6 @@ defmodule OperationsTestRunner do
   }
 
   @impl TestRunner
-  def skip?(%SpecTestCase{fork: "capella"}), do: false
-  def skip?(%SpecTestCase{fork: "deneb"}), do: false
-  def skip?(%SpecTestCase{fork: "electra"}), do: false
-  def skip?(_), do: true
-
-  @impl TestRunner
   def run_test_case(%SpecTestCase{handler: handler} = testcase) do
     case_dir = SpecTestCase.dir(testcase) <> "/"
 

--- a/test/spec/runners/operations.ex
+++ b/test/spec/runners/operations.ex
@@ -53,48 +53,11 @@ defmodule OperationsTestRunner do
     # "deposit_receipt" => "deposit_receipt" Not yet implemented
   }
 
-  # Remove handler from here once you implement the corresponding functions
-  # "deposit_receipt" handler is not yet implemented
-  @disabled_handlers [
-    # "attester_slashing",
-    # "attestation",
-    # "block_header",
-    # "deposit",
-    # "proposer_slashing",
-    # "voluntary_exit",
-    # "sync_aggregate",
-    # "execution_payload",
-    # "withdrawals",
-    # "bls_to_execution_change"
-  ]
-
-  @disabled_handlers_deneb [
-    # "attester_slashing",
-    # "attestation",
-    # "block_header",
-    # "deposit",
-    # "proposer_slashing",
-    # "voluntary_exit"
-    # "sync_aggregate",
-    # "execution_payload",
-    # "withdrawals",
-    # "bls_to_execution_change"
-  ]
-
   @impl TestRunner
-  def skip?(%SpecTestCase{fork: "capella", handler: handler}) do
-    Enum.member?(@disabled_handlers, handler)
-  end
-
-  @impl TestRunner
-  def skip?(%SpecTestCase{fork: "deneb", handler: handler}) do
-    Enum.member?(@disabled_handlers_deneb, handler)
-  end
-
-  @impl TestRunner
-  def skip?(_testcase) do
-    true
-  end
+  def skip?(%SpecTestCase{fork: "capella"}), do: false
+  def skip?(%SpecTestCase{fork: "deneb"}), do: false
+  def skip?(%SpecTestCase{fork: "electra"}), do: false
+  def skip?(_), do: true
 
   @impl TestRunner
   def run_test_case(%SpecTestCase{handler: handler} = testcase) do

--- a/test/spec/runners/random.ex
+++ b/test/spec/runners/random.ex
@@ -7,12 +7,6 @@ defmodule RandomTestRunner do
   use TestRunner
 
   @impl TestRunner
-  def skip?(%SpecTestCase{fork: "capella"}), do: false
-  def skip?(%SpecTestCase{fork: "deneb"}), do: false
-  def skip?(%SpecTestCase{fork: "electra"}), do: false
-  def skip?(_), do: true
-
-  @impl TestRunner
   def run_test_case(testcase) do
     Helpers.ProcessBlocks.process_blocks(testcase)
   end

--- a/test/spec/runners/rewards.ex
+++ b/test/spec/runners/rewards.ex
@@ -7,12 +7,6 @@ defmodule RewardsTestRunner do
   alias Types.BeaconState
 
   @impl TestRunner
-  def skip?(%SpecTestCase{fork: "capella"}), do: false
-  def skip?(%SpecTestCase{fork: "deneb"}), do: false
-  def skip?(%SpecTestCase{fork: "electra"}), do: false
-  def skip?(_), do: true
-
-  @impl TestRunner
   def run_test_case(%SpecTestCase{} = testcase) do
     case_dir = SpecTestCase.dir(testcase)
 

--- a/test/spec/runners/rewards.ex
+++ b/test/spec/runners/rewards.ex
@@ -6,17 +6,9 @@ defmodule RewardsTestRunner do
   use TestRunner
   alias Types.BeaconState
 
-  @disabled [
-    # "basic",
-    # "leak",
-    # "random"
-  ]
 
   @impl TestRunner
-  def skip?(%SpecTestCase{fork: "capella", handler: handler}) do
-    Enum.member?(@disabled, handler)
-  end
-
+  def skip?(%SpecTestCase{fork: "capella"}), do: false
   def skip?(%SpecTestCase{fork: "deneb"}), do: false
   def skip?(%SpecTestCase{fork: "electra"}), do: false
   def skip?(_), do: true

--- a/test/spec/runners/rewards.ex
+++ b/test/spec/runners/rewards.ex
@@ -6,7 +6,6 @@ defmodule RewardsTestRunner do
   use TestRunner
   alias Types.BeaconState
 
-
   @impl TestRunner
   def skip?(%SpecTestCase{fork: "capella"}), do: false
   def skip?(%SpecTestCase{fork: "deneb"}), do: false

--- a/test/spec/runners/sanity.ex
+++ b/test/spec/runners/sanity.ex
@@ -22,13 +22,16 @@ defmodule SanityTestRunner do
 
   @impl TestRunner
   def skip?(%SpecTestCase{fork: "capella", handler: handler, case: testcase})
-    when handler in @handlers, do: Enum.member?(@disabled_cases, testcase)
+      when handler in @handlers,
+      do: Enum.member?(@disabled_cases, testcase)
 
   def skip?(%SpecTestCase{fork: "deneb", handler: handler, case: testcase})
-    when handler in @handlers, do: Enum.member?(@disabled_cases, testcase)
+      when handler in @handlers,
+      do: Enum.member?(@disabled_cases, testcase)
 
   def skip?(%SpecTestCase{fork: "electra", handler: handler, case: testcase})
-    when handler in @handlers, do: Enum.member?(@disabled_cases, testcase)
+      when handler in @handlers,
+      do: Enum.member?(@disabled_cases, testcase)
 
   def skip?(_), do: true
 

--- a/test/spec/runners/sanity.ex
+++ b/test/spec/runners/sanity.ex
@@ -15,26 +15,12 @@ defmodule SanityTestRunner do
     "historical_accumulator"
   ]
 
-  @handlers [
-    "blocks",
-    "slots"
-  ]
-
-  @forks [
-    "capella",
-    "deneb",
-    "electra"
-  ]
-
   @impl TestRunner
-  def skip?(%SpecTestCase{fork: fork, handler: handler, case: testcase})
-      when handler in @handlers and fork in @forks do
-    if handler == "slots",
-      do: Enum.member?(@disabled_slot_cases, testcase),
-      else: false
+  def skip?(%SpecTestCase{handler: "slots", case: testcase}) do
+    Enum.member?(@disabled_slot_cases, testcase)
   end
 
-  def skip?(_), do: true
+  def skip?(_), do: false
 
   @impl TestRunner
   def run_test_case(%SpecTestCase{handler: "slots"} = testcase) do

--- a/test/spec/runners/sanity.ex
+++ b/test/spec/runners/sanity.ex
@@ -10,107 +10,25 @@ defmodule SanityTestRunner do
   alias LambdaEthereumConsensus.Utils.Diff
   alias Types.BeaconState
 
-  @disabled_block_cases [
-    # "activate_and_partial_withdrawal_max_effective_balance",
-    # "activate_and_partial_withdrawal_overdeposit",
-    # "attestation",
-    # "attester_slashing",
-    # "balance_driven_status_transitions",
-    # "bls_change",
-    # "deposit_and_bls_change",
-    # "deposit_in_block",
-    # "deposit_top_up",
-    # "duplicate_attestation_same_block",
-    # "invalid_is_execution_enabled_false",
-    # "empty_block_transition",
-    # "empty_block_transition_large_validator_set",
-    # "empty_block_transition_no_tx",
-    # "empty_block_transition_randomized_payload",
-    # "empty_epoch_transition",
-    # "empty_epoch_transition_large_validator_set",
-    # "empty_epoch_transition_not_finalizing",
-    # "eth1_data_votes_consensus",
-    # "eth1_data_votes_no_consensus",
-    # "exit_and_bls_change",
-    # "full_random_operations_0",
-    # "full_random_operations_1",
-    # "full_random_operations_2",
-    # "full_random_operations_3",
-    # "full_withdrawal_in_epoch_transition",
-    # "high_proposer_index",
-    # "historical_batch",
-    # "inactivity_scores_full_participation_leaking",
-    # "inactivity_scores_leaking",
-    # "invalid_all_zeroed_sig",
-    # "invalid_duplicate_attester_slashing_same_block",
-    # "invalid_duplicate_bls_changes_same_block",
-    # "invalid_duplicate_deposit_same_block",
-    # "invalid_duplicate_proposer_slashings_same_block",
-    # "invalid_duplicate_validator_exit_same_block",
-    # "invalid_incorrect_block_sig",
-    # "invalid_incorrect_proposer_index_sig_from_expected_proposer",
-    # "invalid_incorrect_proposer_index_sig_from_proposer_index",
-    # "invalid_incorrect_state_root",
-    # "invalid_only_increase_deposit_count",
-    # "invalid_parent_from_same_slot",
-    # "invalid_prev_slot_block_transition",
-    # "invalid_same_slot_block_transition",
-    # "invalid_similar_proposer_slashings_same_block",
-    # "invalid_two_bls_changes_of_different_addresses_same_validator_same_block",
-    # "invalid_withdrawal_fail_second_block_payload_isnt_compatible",
-    # "is_execution_enabled_false",
-    # "many_partial_withdrawals_in_epoch_transition",
-    # "multiple_attester_slashings_no_overlap",
-    # "multiple_attester_slashings_partial_overlap",
-    # "multiple_different_proposer_slashings_same_block",
-    # "multiple_different_validator_exits_same_block",
-    # "partial_withdrawal_in_epoch_transition",
-    # "proposer_after_inactive_index",
-    # "proposer_self_slashing",
-    # "proposer_slashing",
-    # "skipped_slots",
-    # "slash_and_exit_diff_index",
-    # "slash_and_exit_same_index"
-    # "sync_committee_committee__empty",
-    # "sync_committee_committee__full",
-    # "sync_committee_committee__half",
-    # "sync_committee_committee_genesis__empty",
-    # "sync_committee_committee_genesis__full",
-    # "sync_committee_committee_genesis__half",
-    # "top_up_and_partial_withdrawable_validator",
-    # "top_up_to_fully_withdrawn_validator",
-    # "voluntary_exit",
-    # "withdrawal_success_two_blocks"
+  # TODO: We need to make sure this is still needed to be here
+  @disabled_cases [
+    "historical_accumulator"
   ]
 
-  @disabled_slot_cases [
-    # "empty_epoch",
-    # "slots_1",
-    # "slots_2",
-    # "over_epoch_boundary",
-    # NOTE: too long to run in CI
-    # TODO: optimize
-    "historical_accumulator"
-
-    # "double_empty_epoch"
+  @handlers [
+    "blocks",
+    "slots"
   ]
 
   @impl TestRunner
-  def skip?(%SpecTestCase{fork: "capella", handler: "blocks", case: testcase}) do
-    Enum.member?(@disabled_block_cases, testcase)
-  end
+  def skip?(%SpecTestCase{fork: "capella", handler: handler, case: testcase})
+    when handler in @handlers, do: Enum.member?(@disabled_cases, testcase)
 
-  def skip?(%SpecTestCase{fork: "capella", handler: "slots", case: testcase}) do
-    Enum.member?(@disabled_slot_cases, testcase)
-  end
+  def skip?(%SpecTestCase{fork: "deneb", handler: handler, case: testcase})
+    when handler in @handlers, do: Enum.member?(@disabled_cases, testcase)
 
-  def skip?(%SpecTestCase{fork: "deneb", handler: "blocks", case: testcase}) do
-    Enum.member?(@disabled_block_cases, testcase)
-  end
-
-  def skip?(%SpecTestCase{fork: "deneb", handler: "slots", case: testcase}) do
-    Enum.member?(@disabled_slot_cases, testcase)
-  end
+  def skip?(%SpecTestCase{fork: "electra", handler: handler, case: testcase})
+    when handler in @handlers, do: Enum.member?(@disabled_cases, testcase)
 
   def skip?(_), do: true
 

--- a/test/spec/runners/sanity.ex
+++ b/test/spec/runners/sanity.ex
@@ -11,7 +11,7 @@ defmodule SanityTestRunner do
   alias Types.BeaconState
 
   # TODO: We need to make sure this is still needed to be here
-  @disabled_cases [
+  @disabled_slot_cases [
     "historical_accumulator"
   ]
 
@@ -20,18 +20,19 @@ defmodule SanityTestRunner do
     "slots"
   ]
 
+  @forks [
+    "capella",
+    "deneb",
+    "electra"
+  ]
+
   @impl TestRunner
-  def skip?(%SpecTestCase{fork: "capella", handler: handler, case: testcase})
-      when handler in @handlers,
-      do: Enum.member?(@disabled_cases, testcase)
-
-  def skip?(%SpecTestCase{fork: "deneb", handler: handler, case: testcase})
-      when handler in @handlers,
-      do: Enum.member?(@disabled_cases, testcase)
-
-  def skip?(%SpecTestCase{fork: "electra", handler: handler, case: testcase})
-      when handler in @handlers,
-      do: Enum.member?(@disabled_cases, testcase)
+  def skip?(%SpecTestCase{fork: fork, handler: handler, case: testcase})
+      when handler in @handlers and fork in @forks do
+    if handler == "slots",
+      do: Enum.member?(@disabled_slot_cases, testcase),
+      else: false
+  end
 
   def skip?(_), do: true
 

--- a/test/spec/runners/shuffling.ex
+++ b/test/spec/runners/shuffling.ex
@@ -10,12 +10,6 @@ defmodule ShufflingTestRunner do
   alias LambdaEthereumConsensus.StateTransition.Shuffling
 
   @impl TestRunner
-  def skip?(%SpecTestCase{fork: "capella"}), do: false
-  def skip?(%SpecTestCase{fork: "deneb"}), do: false
-  def skip?(%SpecTestCase{fork: "electra"}), do: false
-  def skip?(_), do: true
-
-  @impl TestRunner
   def run_test_case(%SpecTestCase{} = testcase) do
     case_dir = SpecTestCase.dir(testcase)
 

--- a/test/spec/runners/shuffling.ex
+++ b/test/spec/runners/shuffling.ex
@@ -9,7 +9,6 @@ defmodule ShufflingTestRunner do
   alias LambdaEthereumConsensus.StateTransition.Misc
   alias LambdaEthereumConsensus.StateTransition.Shuffling
 
-
   @impl TestRunner
   def skip?(%SpecTestCase{fork: "capella"}), do: false
   def skip?(%SpecTestCase{fork: "deneb"}), do: false

--- a/test/spec/runners/shuffling.ex
+++ b/test/spec/runners/shuffling.ex
@@ -9,15 +9,12 @@ defmodule ShufflingTestRunner do
   alias LambdaEthereumConsensus.StateTransition.Misc
   alias LambdaEthereumConsensus.StateTransition.Shuffling
 
-  # Remove handler from here once you implement the corresponding functions
-  @disabled_handlers [
-    # "core"
-  ]
 
   @impl TestRunner
-  def skip?(%SpecTestCase{} = testcase) do
-    Enum.member?(@disabled_handlers, testcase.handler)
-  end
+  def skip?(%SpecTestCase{fork: "capella"}), do: false
+  def skip?(%SpecTestCase{fork: "deneb"}), do: false
+  def skip?(%SpecTestCase{fork: "electra"}), do: false
+  def skip?(_), do: true
 
   @impl TestRunner
   def run_test_case(%SpecTestCase{} = testcase) do

--- a/test/spec/runners/ssz_generic.ex
+++ b/test/spec/runners/ssz_generic.ex
@@ -5,29 +5,11 @@ defmodule SszGenericTestRunner do
   use ExUnit.CaseTemplate
   use TestRunner
 
-  @disabled_handlers [
-    # "basic_vector",
-    # "bitlist",
-    # "bitvector"
-    # "boolean",
-    # "containers"
-    # "uints"
-  ]
-
-  @disabled_containers [
-    # "SingleFieldTestStruct",
-    # "SmallTestStruct",
-    # "FixedTestStruct",
-    # "VarTestStruct",
-    # "ComplexTestStruct"
-    # "BitsStruct"
-  ]
-
   @impl TestRunner
-  def skip?(%SpecTestCase{fork: fork, handler: handler, case: cse}) do
-    skip_container? = Enum.any?(@disabled_containers, &String.contains?(cse, &1))
-    fork != "phase0" or Enum.member?(@disabled_handlers, handler) or skip_container?
-  end
+  def skip?(%SpecTestCase{fork: "capella"}), do: false
+  def skip?(%SpecTestCase{fork: "deneb"}), do: false
+  def skip?(%SpecTestCase{fork: "electra"}), do: false
+  def skip?(_), do: true
 
   @impl TestRunner
   def run_test_case(%SpecTestCase{} = testcase) do

--- a/test/spec/runners/ssz_generic.ex
+++ b/test/spec/runners/ssz_generic.ex
@@ -6,10 +6,7 @@ defmodule SszGenericTestRunner do
   use TestRunner
 
   @impl TestRunner
-  def skip?(%SpecTestCase{fork: "capella"}), do: false
-  def skip?(%SpecTestCase{fork: "deneb"}), do: false
-  def skip?(%SpecTestCase{fork: "electra"}), do: false
-  def skip?(_), do: true
+  def skip?(%SpecTestCase{fork: "phase0"}), do: true
 
   @impl TestRunner
   def run_test_case(%SpecTestCase{} = testcase) do

--- a/test/spec/runners/ssz_generic.ex
+++ b/test/spec/runners/ssz_generic.ex
@@ -6,9 +6,6 @@ defmodule SszGenericTestRunner do
   use TestRunner
 
   @impl TestRunner
-  def skip?(%SpecTestCase{fork: "phase0"}), do: true
-
-  @impl TestRunner
   def run_test_case(%SpecTestCase{} = testcase) do
     case_dir = SpecTestCase.dir(testcase)
 

--- a/test/spec/runners/ssz_static.ex
+++ b/test/spec/runners/ssz_static.ex
@@ -17,47 +17,6 @@ defmodule SszStaticTestRunner do
   @only_ssz_ex [Types.Eth1Block, Types.SyncAggregatorSelectionData]
 
   @disabled [
-    # "DepositData",
-    # "DepositMessage",
-    # "Eth1Data",
-    # "ProposerSlashing",
-    # "SignedBeaconBlockHeader",
-    # "SignedVoluntaryExit",
-    # "Validator",
-    # "VoluntaryExit",
-    # "Attestation",
-    # "AttestationData",
-    # "BLSToExecutionChange",
-    # "BeaconBlockHeader",
-    # "Checkpoint",
-    # "Deposit",
-    # "SignedBLSToExecutionChange",
-    # "SigningData",
-    # "SyncCommittee",
-    # "SyncCommitteeMessage",
-    # "Withdrawal",
-    # "AttesterSlashing",
-    # "HistoricalSummary",
-    # "PendingAttestation",
-    # "Fork",
-    # "ForkData",
-    # "HistoricalBatch",
-    # "IndexedAttestation",
-    # "ExecutionPayload",
-    # "ExecutionPayloadHeader",
-    # "SignedBeaconBlock",
-    # "SyncAggregate",
-    # "AggregateAndProof",
-    # "BeaconBlock",
-    # "BeaconBlockBody",
-    # "BeaconState",
-    # "SignedAggregateAndProof",
-    # "Eth1Block",
-    # "SyncAggregatorSelectionData",
-    # "SignedContributionAndProof",
-    # "SyncCommitteeContribution",
-    # "ContributionAndProof",
-    # -- not defined yet
     "LightClientBootstrap",
     "LightClientOptimisticUpdate",
     "LightClientUpdate",
@@ -76,14 +35,10 @@ defmodule SszStaticTestRunner do
   }
 
   @impl TestRunner
-  def skip?(%SpecTestCase{fork: "capella", handler: handler}) do
-    Enum.member?(@disabled, handler)
-  end
-
-  def skip?(%SpecTestCase{fork: "deneb", handler: handler}) do
-    Enum.member?(@disabled, handler)
-  end
-
+  def skip?(%SpecTestCase{handler: handler}) when handler in @disabled, do: true
+  def skip?(%SpecTestCase{fork: "capella"}), do: false
+  def skip?(%SpecTestCase{fork: "deneb"}), do: false
+  def skip?(%SpecTestCase{fork: "electra"}), do: false
   def skip?(_), do: true
 
   @impl TestRunner

--- a/test/spec/runners/ssz_static.ex
+++ b/test/spec/runners/ssz_static.ex
@@ -36,10 +36,7 @@ defmodule SszStaticTestRunner do
 
   @impl TestRunner
   def skip?(%SpecTestCase{handler: handler}) when handler in @disabled, do: true
-  def skip?(%SpecTestCase{fork: "capella"}), do: false
-  def skip?(%SpecTestCase{fork: "deneb"}), do: false
-  def skip?(%SpecTestCase{fork: "electra"}), do: false
-  def skip?(_), do: true
+  def skip?(_), do: false
 
   @impl TestRunner
   def run_test_case(%SpecTestCase{} = testcase) do

--- a/test/spec/runners/sync.ex
+++ b/test/spec/runners/sync.ex
@@ -8,10 +8,6 @@ defmodule SyncTestRunner do
 
   alias LambdaEthereumConsensus.Execution.EngineApi
 
-  @disabled_cases [
-    # "from_syncing_to_invalid"
-  ]
-
   @impl TestRunner
   def setup() do
     # Start this supervisor, necessary for post state tasks.
@@ -20,10 +16,7 @@ defmodule SyncTestRunner do
   end
 
   @impl TestRunner
-  def skip?(%SpecTestCase{fork: "capella"} = testcase) do
-    Enum.member?(@disabled_cases, testcase.case)
-  end
-
+  def skip?(%SpecTestCase{fork: "capella"}), do: false
   def skip?(%SpecTestCase{fork: "deneb"}), do: false
   def skip?(%SpecTestCase{fork: "electra"}), do: false
   def skip?(_testcase), do: true

--- a/test/spec/runners/sync.ex
+++ b/test/spec/runners/sync.ex
@@ -16,12 +16,6 @@ defmodule SyncTestRunner do
   end
 
   @impl TestRunner
-  def skip?(%SpecTestCase{fork: "capella"}), do: false
-  def skip?(%SpecTestCase{fork: "deneb"}), do: false
-  def skip?(%SpecTestCase{fork: "electra"}), do: false
-  def skip?(_testcase), do: true
-
-  @impl TestRunner
   def run_test_case(%SpecTestCase{} = testcase) do
     original_engine_api_config = Application.fetch_env!(:lambda_ethereum_consensus, EngineApi)
 


### PR DESCRIPTION
**Motivation**

We were skipping 8k spec-test before this PR

**Description**

After some debugging and testing, most of the previously skipped test are not needed to be skipped at all. We are right now at 784 spect-test skipped which is mostly the same number as we are currently skipping in main.

This nonetheless could include some false positives and it's possible tat lots of this test share low-hanging fruit fixes apart from the electra implementation. I created a new issue for tracking that: #1429

Before this PR:
`11370 tests, 206 failures, 8092 skipped`

After this PR:
`11370 tests, 2003 failures, 784 skipped`


