### PR TITLE
fix: new ssz fixes for the static spec-test

### DIFF
--- a/native/ssz_nif/src/utils/mod.rs
+++ b/native/ssz_nif/src/utils/mod.rs
@@ -53,6 +53,14 @@ macro_rules! schema_match {
                 Epoch,
                 BlobSidecar<C>,
                 BlobIdentifier,
+                PendingDeposit,
+                PendingPartialWithdrawal,
+                PendingConsolidation,
+                DepositRequest,
+                WithdrawalRequest,
+                ConsolidationRequest,
+                ExecutionRequests<C>,
+                SingleAttestation,
             }
         )
     };


### PR DESCRIPTION
**Motivation**

After #1427 nearly 1500 test were failing due to ssz issues

**Description**

This PR makes a small changing adding the new containers to the schema_match macro that were missing them.

Before this PR: 
`11370 tests, 2003 failures, 784 skipped`

After this PR:
`11370 tests, 979 failures, 784 skipped`

Resolves part of #1429

