### PR TITLE
fix: fixing the CI updating ubuntu and go

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   compile-native:
     name: Build native libraries
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
@@ -58,7 +58,7 @@ jobs:
 
   download-beacon-node-oapi:
     name: Download Beacon Node OAPI
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Cache Beacon Node OAPI
@@ -75,7 +75,7 @@ jobs:
   build:
     name: Build project
     needs: [compile-native, download-beacon-node-oapi]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Set up Elixir
@@ -135,7 +135,7 @@ jobs:
 
   docker-build:
     name: Build Docker image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Set up Docker Buildx
@@ -150,7 +150,7 @@ jobs:
   smoke:
     name: Start and stop the node
     needs: [compile-native, download-beacon-node-oapi]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Set up Elixir
@@ -200,7 +200,7 @@ jobs:
   test:
     name: Test
     needs: [compile-native, download-beacon-node-oapi]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Set up Elixir
@@ -245,7 +245,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Set up Elixir
@@ -273,7 +273,7 @@ jobs:
 
   download-spectests:
     name: Download spectests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Cache compressed spectests
@@ -295,7 +295,7 @@ jobs:
       matrix:
         fork: ["deneb"]
         config: ["minimal", "general", "mainnet"]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Elixir
@@ -357,7 +357,7 @@ jobs:
   spectests-success:
     name: All spec-tests passed
     needs: spectests-matrix
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: always()
     steps:
       - if: needs.spectests-matrix.result == 'success'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         # NOTE: this action comes with caching by default
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.24"
           cache-dependency-path: |
             native/libp2p_port/go.sum
       - name: Cache output artifacts

--- a/.github/workflows/ci_skipped.yml
+++ b/.github/workflows/ci_skipped.yml
@@ -14,36 +14,36 @@ on:
 jobs:
   compile-native:
     name: Build native libraries
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: false
     steps: [run: true]
 
   build:
     name: Build project
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: false
     steps: [run: true]
 
   smoke:
     name: Start and stop the node
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: false
     steps: [run: true]
 
   test:
     name: Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: false
     steps: [run: true]
 
   lint:
     name: Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: false
     steps: [run: true]
 
   spectests-success:
     name: All spec-tests passed
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: false
     steps: [run: true]

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 erlang 26.2
 elixir 1.16.2-otp-26
-golang 1.22.12
+golang 1.24.2
 rust 1.81.0
 protoc 30.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # libp2p port
-FROM golang:1.22 AS libp2p_builder
+FROM golang:1.24 AS libp2p_builder
 LABEL stage=builder
 
 # Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.24 AS libp2p_builder
 LABEL stage=builder
 
 # Install dependencies
-RUN apt-get update && apt-get install -y protobuf-compiler
+RUN apt-get update && apt-get install -y protobuf-compiler --fix-missing
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 
 RUN mkdir /libp2p_port

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.24 AS libp2p_builder
 LABEL stage=builder
 
 # Install dependencies
-RUN apt-get update && apt-get install -y protobuf-compiler --fix-missing
+RUN apt-get update && apt-get install -y --fix-missing protobuf-compiler
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 
 RUN mkdir /libp2p_port

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.24 AS libp2p_builder
 LABEL stage=builder
 
 # Install dependencies
-RUN apt-get update && apt-get install -y --fix-missing protobuf-compiler
+RUN apt-get update && apt-get install -y protobuf-compiler
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 
 RUN mkdir /libp2p_port

--- a/test/unit/validator/block_builder_test.exs
+++ b/test/unit/validator/block_builder_test.exs
@@ -85,7 +85,7 @@ defmodule Unit.Validator.BlockBuilderTest do
     commitment_root = SszEx.hash_tree_root!(commitment, TypeAliases.kzg_commitment())
 
     # Manually computed generalized index of the commitment in the body
-    index = 0b101100000
+    index = 0b1011000000
 
     valid? =
       Predicates.valid_merkle_branch?(commitment_root, proof, length(proof), index, body_root)

--- a/test/unit/validator/block_builder_test.exs
+++ b/test/unit/validator/block_builder_test.exs
@@ -80,7 +80,7 @@ defmodule Unit.Validator.BlockBuilderTest do
 
     [proof] = BlockBuilder.compute_inclusion_proofs(body)
 
-    assert length(proof) == 9
+    assert length(proof) == 10
 
     commitment_root = SszEx.hash_tree_root!(commitment, TypeAliases.kzg_commitment())
 


### PR DESCRIPTION
**Motivation**

Most of CI steps where failing unable to fetch the protobuf-compiler

**Description**

All go version has been updated to 1.24 and all Ubuntu 22.04 to 24.04 (LTS)
