### PR TITLE
chore: update to the latest version of kurtosis

### DIFF
--- a/.github/config/assertoor/cl-stability-check.yml
+++ b/.github/config/assertoor/cl-stability-check.yml
@@ -34,7 +34,7 @@ tasks:
       name: check_consensus_block_proposals
       title: "Wait for block proposal from ${validatorPairName}"
       config:
-        minTransactionCount: 240
+        minTransactionCount: 80 # For some reason the tx fuzz is working different than the old spammer, we need to check it
       configVars:
         validatorNamePattern: "validatorPairName"
 

--- a/.github/config/assertoor/network-params.yml
+++ b/.github/config/assertoor/network-params.yml
@@ -21,8 +21,7 @@ participants:
 
 additional_services:
   - assertoor
-  - tx_spammer
-  - blob_spammer
+  - tx_fuzz
   - dora
 
 assertoor_params:
@@ -31,5 +30,5 @@ assertoor_params:
  tests:
    - https://raw.githubusercontent.com/lambdaclass/lambda_ethereum_consensus/refs/heads/main/.github/config/assertoor/cl-stability-check.yml
 
-tx_spammer_params:
-  tx_spammer_extra_args: ["--txcount=3", "--accounts=80"]
+tx_fuzz_params:
+  tx_fuzz_extra_args: ["--txcount=3", "--accounts=80"]

--- a/.github/config/assertoor/network-params.yml
+++ b/.github/config/assertoor/network-params.yml
@@ -28,7 +28,7 @@ assertoor_params:
  run_stability_check: false
  run_block_proposal_check: false
  tests:
-   - https://raw.githubusercontent.com/lambdaclass/lambda_ethereum_consensus/refs/heads/main/.github/config/assertoor/cl-stability-check.yml
+   - https://raw.githubusercontent.com/lambdaclass/lambda_ethereum_consensus/refs/heads/fix-kurtosis-and-assertoor/.github/config/assertoor/cl-stability-check.yml
 
 tx_fuzz_params:
   tx_fuzz_extra_args: ["--txcount=3", "--accounts=80"]

--- a/.github/config/assertoor/network-params.yml
+++ b/.github/config/assertoor/network-params.yml
@@ -1,16 +1,16 @@
 participants:
   - el_type: geth
-    el_image: ethereum/client-go:v1.14.12
+    el_image: ethereum/client-go:v1.15.6
     cl_type: lighthouse
-    cl_image: sigp/lighthouse:v5.3.0
+    cl_image: sigp/lighthouse:v7.0.0-beta.5
     validator_count: 32
   - el_type: geth
-    el_image: ethereum/client-go:v1.14.12
+    el_image: ethereum/client-go:v1.15.6
     cl_type: lighthouse
-    cl_image: sigp/lighthouse:v5.3.0
+    cl_image: sigp/lighthouse:v7.0.0-beta.5
     validator_count: 32
   - el_type: geth
-    el_image: ethereum/client-go:v1.14.12
+    el_image: ethereum/client-go:v1.15.6
     cl_type: lambda
     cl_image: lambda_ethereum_consensus:latest
     use_separate_vc: false

--- a/.github/config/assertoor/network-params.yml
+++ b/.github/config/assertoor/network-params.yml
@@ -28,7 +28,7 @@ assertoor_params:
  run_stability_check: false
  run_block_proposal_check: false
  tests:
-   - https://raw.githubusercontent.com/lambdaclass/lambda_ethereum_consensus/refs/heads/fix-kurtosis-and-assertoor/.github/config/assertoor/cl-stability-check.yml
+   - https://raw.githubusercontent.com/lambdaclass/lambda_ethereum_consensus/refs/heads/main/.github/config/assertoor/cl-stability-check.yml
 
 tx_fuzz_params:
   tx_fuzz_extra_args: ["--txcount=3", "--accounts=80"]

--- a/.github/workflows/assertoor.yml
+++ b/.github/workflows/assertoor.yml
@@ -29,7 +29,7 @@ jobs:
         uses: ethpandaops/kurtosis-assertoor-github-action@v1
         with:
           enclave_name: "elixir-consensus-assertoor"
-          kurtosis_version: "1.4.2"
+          kurtosis_version: "1.6.0"
           ethereum_package_url: 'github.com/lambdaclass/ethereum-package'
-          ethereum_package_branch: 'lecc-integration-and-assertoor'
+          ethereum_package_branch: 'lecc-integration-electra'
           ethereum_package_args: './.github/config/assertoor/network-params.yml'

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,10 @@ kurtosis.connect:
 kurtosis.connect.iex:
 	iex --sname client --remsh lambdaconsensus --cookie $(KURTOSIS_COOKIE)
 
+#💻 kurtosis.assertoor: @ Execute the assertoor network params in .github
+kurtosis.assertoor: kurtosis.clean kurtosis.setup.lambdaconsensus
+	kurtosis run --enclave $(KURTOSIS_ENCLAVE) $(KURTOSIS_DIR) --args-file .github/config/assertoor/network-params.yml
+
 #💻 nix: @ Start a nix environment.
 nix:
 	nix develop

--- a/lib/beacon_api/controllers/v1/config_controller.ex
+++ b/lib/beacon_api/controllers/v1/config_controller.ex
@@ -17,12 +17,6 @@ defmodule BeaconApi.V1.ConfigController do
   ]
   @chain_spec_hex_fields [
     "TERMINAL_BLOCK_HASH",
-    "GENESIS_FORK_VERSION",
-    "ALTAIR_FORK_VERSION",
-    "BELLATRIX_FORK_VERSION",
-    "CAPELLA_FORK_VERSION",
-    "DENEB_FORK_VERSION",
-    "ELECTRA_FORK_VERSION",
     "DEPOSIT_CONTRACT_ADDRESS",
     "MESSAGE_DOMAIN_INVALID_SNAPPY",
     "MESSAGE_DOMAIN_VALID_SNAPPY"
@@ -45,6 +39,7 @@ defmodule BeaconApi.V1.ConfigController do
     |> Map.new(fn
       {k, v} when is_integer(v) -> {k, Integer.to_string(v)}
       {k, v} when k in @chain_spec_hex_fields -> {k, Utils.hex_encode(v)}
+      {k, v} when is_binary(v) -> if String.ends_with?(k, "_FORK_VERSION"), do: {k, Utils.hex_encode(v)}, else: {k, v}
       {k, v} -> {k, v}
     end)
   end

--- a/lib/beacon_api/controllers/v1/config_controller.ex
+++ b/lib/beacon_api/controllers/v1/config_controller.ex
@@ -37,10 +37,17 @@ defmodule BeaconApi.V1.ConfigController do
     |> Map.drop(@chain_spec_removed_keys)
     |> rename_keys(@chain_spec_renamed_keys)
     |> Map.new(fn
-      {k, v} when is_integer(v) -> {k, Integer.to_string(v)}
-      {k, v} when k in @chain_spec_hex_fields -> {k, Utils.hex_encode(v)}
-      {k, v} when is_binary(v) -> if String.ends_with?(k, "_FORK_VERSION"), do: {k, Utils.hex_encode(v)}, else: {k, v}
-      {k, v} -> {k, v}
+      {k, v} when is_integer(v) ->
+        {k, Integer.to_string(v)}
+
+      {k, v} when k in @chain_spec_hex_fields ->
+        {k, Utils.hex_encode(v)}
+
+      {k, v} when is_binary(v) ->
+        if String.ends_with?(k, "_FORK_VERSION"), do: {k, Utils.hex_encode(v)}, else: {k, v}
+
+      {k, v} ->
+        {k, v}
     end)
   end
 

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -1,12 +1,12 @@
 participants:
   - el_type: geth
-    el_image: ethereum/client-go:v1.14.12
+    el_image: ethereum/client-go:v1.15.6
     cl_type: lighthouse
-    cl_image: sigp/lighthouse:v5.3.0
+    cl_image: sigp/lighthouse:v7.0.0-beta.5
     count: 2
     validator_count: 32
   - el_type: geth
-    el_image: ethereum/client-go:v1.14.12
+    el_image: ethereum/client-go:v1.15.6
     cl_type: lambda
     cl_image: lambda_ethereum_consensus:latest
     use_separate_vc: false

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -18,10 +18,8 @@ participants:
 # network_params:
 #   preset: minimal
 additional_services:
-  - tx_spammer
-  - blob_spammer
+  - tx_fuzz
   - dora
-  - beacon_metrics_gazer
   - prometheus_grafana
 # Uncomment the following lines to run the the network with the assertoor tests
 #   - assertoor
@@ -32,5 +30,5 @@ additional_services:
 #   tests:
 #     - https://raw.githubusercontent.com/lambdaclass/lambda_ethereum_consensus/refs/heads/main/.github/config/assertoor/cl-stability-check.yml
 
-# tx_spammer_params:
-#   tx_spammer_extra_args: ["--txcount=3", "--accounts=80"]
+# tx_fuzz_params:
+#   tx_fuzz_extra_args: ["--txcount=3", "--accounts=80"]


### PR DESCRIPTION
**Motivation**

PRs were failing in main due to assertoor (and specifically the update of `ethereum-package`)

**Description**

This PR updates kurtosis version as well as the clients one, it doesn't add the `electra_fork_epoch` param to still run in `deneb`.

The PR also add some minor changes, it fixed some hex values in the config matching the variables ending as `FORK_VERSION`, to avoid listing the new ones added in `ethereum-package` one by one and adds a convenient way to run assertoor locally.

