### PR TITLE
Fix broken spec link for get_validator_from_deposit in Electra gap document

### DIFF
--- a/electra-gap.md
+++ b/electra-gap.md
@@ -100,7 +100,7 @@ The current status of the implementation is as follows:
 - [x] New `process_pending_deposits` ([Spec](docs/specs/electra/beacon-chain.md#new-process_pending_deposits), [PR](https://github.com/lambdaclass/lambda_ethereum_consensus/pull/1424))
 - [x] New `process_pending_consolidations` ([Spec](docs/specs/electra/beacon-chain.md#new-process_pending_consolidations), [PR](https://github.com/lambdaclass/lambda_ethereum_consensus/pull/1428))
 - [x] Modified `process_effective_balance_updates` ([Spec](docs/specs/electra/beacon-chain.md#modified-process_effective_balance_updates), [PR](https://github.com/lambdaclass/lambda_ethereum_consensus/pull/1428))
-- [x] Modified `get_validator_from_deposit` ([Spec](docs/specs/electra/beacon-chains.md#modified-get_validator_from_deposit), [PR](https://github.com/lambdaclass/lambda_ethereum_consensus/pull/1424))
+- [x] Modified `get_validator_from_deposit` ([Spec](docs/specs/electra/beacon-chain.md#modified-get_validator_from_deposit), [PR](https://github.com/lambdaclass/lambda_ethereum_consensus/pull/1424))
 
 #### Block Processing (12/12 - 100%)
 


### PR DESCRIPTION
Corrected the documentation link for the "Modified get_validator_from_deposit" function in electra-gap.md to point to the existing docs/specs/electra/beacon-chain.md file and the correct section. This resolves a broken link issue and ensures the reference is accurate for future readers and contributors. No other content was changed.