### PR TITLE
Fix byte generation in benchmark to avoid invalid byte values

### DIFF
--- a/bench/byte_reversal.exs
+++ b/bench/byte_reversal.exs
@@ -12,7 +12,7 @@ reverse_comprehension = fn bits ->
   for <<byte <- bits>>, do: <<byte>>, into: <<>>
 end
 
-bits = for i <- 1..512, do: <<i>>, into: <<>>
+bits = for i <- 1..512, do: <<rem(i, 256)>>, into: <<>>
 
 Benchee.run(
   %{


### PR DESCRIPTION
Replaced the original binary generation loop in bench/byte_reversal.exs to use rem(i, 256) for each byte value. This ensures that all generated bytes are within the valid range (0..255), preventing runtime errors that occur when trying to create a byte with a value greater than 255. The change allows the benchmark to run correctly for all intended input sizes.