### PR TITLE
ci: add docker publish workflow

### DIFF
--- a/.github/workflows/docker_publish.yaml
+++ b/.github/workflows/docker_publish.yaml
@@ -1,0 +1,101 @@
+name: Publish Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: "Docker image tags, comma-separated (e.g., latest,v0.1.0)"
+        required: false
+        default: "latest"
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-image:
+    name: Build Docker image (${{ matrix.arch }})
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-22.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare tags
+        id: prep
+        run: |
+          TAGS=""
+          IFS=',' read -ra TAG_ARRAY <<< "${{ inputs.tags }}"
+          for t in "${TAG_ARRAY[@]}"; do
+            TAGS="${TAGS}${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${t}-${{ matrix.arch }},"
+          done
+          TAGS="${TAGS%,}"
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}
+          platforms: linux/${{ matrix.arch }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,scope=${{ matrix.arch }},mode=max
+
+  publish-manifest:
+    name: Create and push multi-arch manifest
+    runs-on: ubuntu-latest
+    needs: build-image
+
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifests
+        env:
+          SHORT_SHA: ${{ github.sha }}
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          IFS=',' read -ra TAG_ARRAY <<< "${{ inputs.tags }}"
+          FIRST_TAG="${TAG_ARRAY[0]}"
+
+          # Create manifest for first tag with SHA tag
+          docker buildx imagetools create \
+            -t "${IMAGE}:${FIRST_TAG}" \
+            -t "${IMAGE}:sha-${SHORT_SHA::7}" \
+            "${IMAGE}:${FIRST_TAG}-amd64" \
+            "${IMAGE}:${FIRST_TAG}-arm64"
+
+          # Create manifests for remaining tags
+          for t in "${TAG_ARRAY[@]:1}"; do
+            docker buildx imagetools create \
+              -t "${IMAGE}:${t}" \
+              "${IMAGE}:${t}-amd64" \
+              "${IMAGE}:${t}-arm64"
+          done


### PR DESCRIPTION
**Motivation**

We want to make Docker releases so users can easily run our client.

**Description**

This PR adds a manually-triggered (for now) workflow that publishes a Docker image to GHCR. The workflow was copied from https://github.com/lambdaclass/ethlambda/blob/75f0c2ee55ac81f5bd8b5db399e08bdde0c2501f/.github/workflows/docker_publish.yaml